### PR TITLE
fix: panic on file without trailing newline

### DIFF
--- a/src/snapshots/duvet__sourcemap__tests__lines_iter_cr_newline.snap
+++ b/src/snapshots/duvet__sourcemap__tests__lines_iter_cr_newline.snap
@@ -1,0 +1,17 @@
+---
+source: src/sourcemap.rs
+expression: "LinesIter::new(\"line 1\\r\\nline 2\\r\\n\").collect::<Vec<_>>()"
+
+---
+[
+    Str {
+        value: "line 1",
+        pos: 0,
+        line: 1,
+    },
+    Str {
+        value: "line 2",
+        pos: 8,
+        line: 2,
+    },
+]

--- a/src/snapshots/duvet__sourcemap__tests__lines_iter_with_trailing_newline.snap
+++ b/src/snapshots/duvet__sourcemap__tests__lines_iter_with_trailing_newline.snap
@@ -1,0 +1,17 @@
+---
+source: src/sourcemap.rs
+expression: "LinesIter::new(\"line 1\\nline 2\\n\").collect::<Vec<_>>()"
+
+---
+[
+    Str {
+        value: "line 1",
+        pos: 0,
+        line: 1,
+    },
+    Str {
+        value: "line 2",
+        pos: 7,
+        line: 2,
+    },
+]

--- a/src/snapshots/duvet__sourcemap__tests__lines_iter_without_trailing_newline.snap
+++ b/src/snapshots/duvet__sourcemap__tests__lines_iter_without_trailing_newline.snap
@@ -1,0 +1,17 @@
+---
+source: src/sourcemap.rs
+expression: "LinesIter::new(\"line 1\\nline 2\").collect::<Vec<_>>()"
+
+---
+[
+    Str {
+        value: "line 1",
+        pos: 0,
+        line: 1,
+    },
+    Str {
+        value: "line 2",
+        pos: 7,
+        line: 2,
+    },
+]

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -33,37 +33,34 @@ impl<'a> Iterator for LinesIter<'a> {
             return None;
         }
 
-        let (rel_offset, found_newline) = match content.find('\n') {
-            Some(offset) => (offset, true),
-            None => (content.len(), false),
+        let pos = self.offset;
+
+        let rel_offset = if let Some(next_newline) = content.find('\n') {
+            self.offset += next_newline + 1; // trim \n
+            next_newline
+        } else {
+            // consume the remaining characters
+            let len = content.len();
+            self.offset += len;
+            len
         };
 
         let value = Str {
             value: content[..rel_offset].trim_end_matches('\r'),
-            pos: self.offset,
+            pos,
             line: self.line,
         };
 
-        self.offset += rel_offset;
-        if found_newline {
-            self.offset += 1; // trim \n
-        }
         self.line += 1;
         Some(value)
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Str<'a> {
     pub value: &'a str,
     pub pos: usize,
     pub line: usize,
-}
-
-impl<'a> fmt::Debug for Str<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.value.fmt(f)
-    }
 }
 
 impl<'a> fmt::Display for Str<'a> {
@@ -125,50 +122,20 @@ impl<'a> Deref for Str<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use insta::assert_debug_snapshot;
 
     #[test]
     fn lines_iter_with_trailing_newline() {
-        let content = "line 1\nline 2\n";
-        let mut lines_iter = LinesIter::new(&content);
-        assert_eq!(
-            lines_iter.next(),
-            Some(Str {
-                value: "line 1",
-                pos: 0,
-                line: 1,
-            })
-        );
-        assert_eq!(
-            lines_iter.next(),
-            Some(Str {
-                value: "line 2",
-                pos: 7,
-                line: 2,
-            })
-        );
-        assert_eq!(lines_iter.next(), None);
+        assert_debug_snapshot!(LinesIter::new("line 1\nline 2\n").collect::<Vec<_>>());
     }
 
     #[test]
     fn lines_iter_without_trailing_newline() {
-        let content = "line 1\nline 2";
-        let mut lines_iter = LinesIter::new(&content);
-        assert_eq!(
-            lines_iter.next(),
-            Some(Str {
-                value: "line 1",
-                pos: 0,
-                line: 1,
-            })
-        );
-        assert_eq!(
-            lines_iter.next(),
-            Some(Str {
-                value: "line 2",
-                pos: 7,
-                line: 2,
-            })
-        );
-        assert_eq!(lines_iter.next(), None);
+        assert_debug_snapshot!(LinesIter::new("line 1\nline 2").collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn lines_iter_cr_newline() {
+        assert_debug_snapshot!(LinesIter::new("line 1\r\nline 2\r\n").collect::<Vec<_>>());
     }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixes the following panic that occurs when `LinesIter` attempts to read the last line in content that's missing a trailing newline:

```
thread '<unnamed>' panicked at 'byte index 5343 is out of bounds of `<file content omitted>`[...]', src/sourcemap.rs:30:24
   0: rust_begin_unwind
             at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/core/src/panicking.rs:107:14
   2: core::str::slice_error_fail
   3: <duvet::sourcemap::LinesIter as core::iter::traits::iterator::Iterator>::next
   4: duvet::pattern::Pattern::extract
   5: duvet::source::SourceFile::annotations
   6: rayon::iter::plumbing::Folder::consume_iter
   7: rayon::iter::plumbing::bridge_producer_consumer::helper
   8: std::panicking::try
   9: rayon_core::registry::in_worker
  10: rayon::iter::plumbing::bridge_producer_consumer::helper
  11: rayon_core::job::StackJob<L,F,R>::run_inline
  12: rayon_core::registry::in_worker
  13: rayon::iter::plumbing::bridge_producer_consumer::helper
  14: std::panicking::try
  15: rayon_core::registry::in_worker
  16: rayon::iter::plumbing::bridge_producer_consumer::helper
  17: std::panicking::try
  18: rayon_core::registry::in_worker
  19: rayon::iter::plumbing::bridge_producer_consumer::helper
  20: std::panicking::try
  21: rayon_core::registry::in_worker
  22: rayon::iter::plumbing::bridge_producer_consumer::helper
  23: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute
  24: rayon_core::registry::WorkerThread::wait_until_cold
  25: rayon_core::registry::ThreadBuilder::run
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
