### PR TITLE
chore: Remove CODEOWNERS to not cause spam for teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# Each line is a file pattern followed by one or more owners.
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-*       @awslabs/aws-crypto-tools
-*       @awslabs/aws-crypto-algorithms


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I thought creating CODEOWNERS would allow me to enable GHA from forks.
But it does not. 
Its an awslabs policy that GHA does not run on PRs from forks.
As such, there is no way for @chenyuan99's PRs to trigger CI unless he pushes branches to this repo.
Which is what we will do.
But, there is no need to spam the algorithms or crypto team with PR requests while we develop this.
So I am removing the CODEOWNERs file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
