### PR TITLE
Remove aws-crypto-algorithms as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @camshaft @awslabs/aws-crypto-algorithms @awslabs/aws-crypto-tools
+* @camshaft @awslabs/aws-crypto-tools


### PR DESCRIPTION
*Description of changes:*

`aws-crypto-algorithms` is too broad a code owner group.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
