### PR TITLE
Fix keyword patterns

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -32,7 +32,7 @@ lazy_static! {
             .iter()
             .cloned()
             .map(|(pat, l)| {
-                let r = Regex::new(&format!("{}(\")?", pat))?;
+                let r = Regex::new(&format!("\\b{}\\b\"?", pat))?;
                 Ok((r, l))
             })
             .collect::<Result<_, Error>>()


### PR DESCRIPTION
*Issue #, if available:*
fix #70 

*Description of changes:*
* add word bound assertions around keywords so that false matches like "IS_REQUIRED" won't happen
* remove the capturing group in `(\")?`, it isn't necessary

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
