### PR TITLE
chore: use duvet-owners in codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @camshaft @awslabs/aws-crypto-tools
+* @awslabs/duvet-owners


### PR DESCRIPTION
*Issue #, if available:* awslabs Generally allows for 1 approval for a merge, but this repo currently has two code owners, forcing 2 approvals.

To mitigate this, I have created a new GitHub team under awslabs composed of AWS stakeholders of Duvet. An approval from any member of this team will be sufficient for a PR to merge.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
