### PR TITLE
fix: remove reduntant borrows

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -116,8 +116,8 @@ impl Annotation {
 
         let mut manifest_dir = self.manifest_dir.clone();
         loop {
-            if manifest_dir.join(&file).is_file() {
-                return Ok(manifest_dir.join(&file));
+            if manifest_dir.join(file).is_file() {
+                return Ok(manifest_dir.join(file));
             }
 
             if !manifest_dir.pop() {

--- a/src/report/lcov.rs
+++ b/src/report/lcov.rs
@@ -44,7 +44,7 @@ macro_rules! record {
 }
 
 pub fn report(report: &ReportResult, dir: &Path) -> Result<(), Error> {
-    std::fs::create_dir_all(&dir)?;
+    std::fs::create_dir_all(dir)?;
     let lcov_dir = dir.canonicalize()?;
     report
         .targets

--- a/src/source.rs
+++ b/src/source.rs
@@ -29,7 +29,7 @@ impl<'a> SourceFile<'a> {
                 Ok(annotations)
             }
             Self::Spec(file) => {
-                let text = std::fs::read_to_string(&file)?;
+                let text = std::fs::read_to_string(file)?;
                 let specs = toml::from_str::<Specs>(&text)?;
                 for anno in specs.specs {
                     annotations.insert(anno.into_annotation(file.clone(), &specs.target)?);


### PR DESCRIPTION
Clippy beta is now complaining about these.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
