### PR TITLE
feat: handle duplicate markdown section names

### DIFF
--- a/src/extract/snapshots/duvet__extract__tests__esdk_encrypt.snap
+++ b/src/extract/snapshots/duvet__extract__tests__esdk_encrypt.snap
@@ -104,6 +104,25 @@ expression: results
         },
     ),
     (
+        "encryption-context",
+        Feature {
+            level: Must,
+            quote: [
+                "If the input encryption context contains any entries with a key beginning with this prefix,",
+                "the encryption operation MUST fail.",
+            ],
+        },
+    ),
+    (
+        "algorithm-suite",
+        Feature {
+            level: Should,
+            quote: [
+                "The [algorithm suite](../framework/algorithm-suites.md) that SHOULD be used for encryption.",
+            ],
+        },
+    ),
+    (
         "frame-length",
         Feature {
             level: Must,
@@ -188,7 +207,7 @@ expression: results
         },
     ),
     (
-        "encryption-context",
+        "encryption-context-1",
         Feature {
             level: May,
             quote: [
@@ -197,7 +216,7 @@ expression: results
         },
     ),
     (
-        "algorithm-suite",
+        "algorithm-suite-1",
         Feature {
             level: May,
             quote: [

--- a/src/specification/markdown/snapshots/duvet__specification__markdown__tests__duplicate_sections__tokens.snap
+++ b/src/specification/markdown/snapshots/duvet__specification__markdown__tests__duplicate_sections__tokens.snap
@@ -1,0 +1,76 @@
+---
+source: src/specification/markdown/tests.rs
+expression: "super::tokens(r#\"\n# Duplicate header\n\ntesting 123\n\n## Duplicate header\n\nother test\n\"#)"
+---
+[
+    Line(
+        Str {
+            value: "",
+            pos: 0,
+            line: 1,
+        },
+    ),
+    Header {
+        line: Str {
+            value: "# Duplicate header",
+            pos: 1,
+            line: 2,
+        },
+        name: Str {
+            value: "Duplicate header",
+            pos: 3,
+            line: 2,
+        },
+        fragment: None,
+        level: 1,
+    },
+    Line(
+        Str {
+            value: "",
+            pos: 20,
+            line: 3,
+        },
+    ),
+    Line(
+        Str {
+            value: "testing 123",
+            pos: 21,
+            line: 4,
+        },
+    ),
+    Line(
+        Str {
+            value: "",
+            pos: 33,
+            line: 5,
+        },
+    ),
+    Header {
+        line: Str {
+            value: "## Duplicate header",
+            pos: 34,
+            line: 6,
+        },
+        name: Str {
+            value: "Duplicate header",
+            pos: 37,
+            line: 6,
+        },
+        fragment: None,
+        level: 2,
+    },
+    Line(
+        Str {
+            value: "",
+            pos: 54,
+            line: 7,
+        },
+    ),
+    Line(
+        Str {
+            value: "other test",
+            pos: 55,
+            line: 8,
+        },
+    ),
+]

--- a/src/specification/markdown/snapshots/duvet__specification__markdown__tests__duplicate_sections__tree.snap
+++ b/src/specification/markdown/snapshots/duvet__specification__markdown__tests__duplicate_sections__tree.snap
@@ -1,0 +1,57 @@
+---
+source: src/specification/markdown/tests.rs
+expression: "super::parse(r#\"\n# Duplicate header\n\ntesting 123\n\n## Duplicate header\n\nother test\n\"#)"
+---
+Ok(
+    Specification {
+        title: Some(
+            "Duplicate header",
+        ),
+        sections: [
+            Section {
+                id: "duplicate-header",
+                title: "Duplicate header",
+                full_title: Str {
+                    value: "# Duplicate header",
+                    pos: 1,
+                    line: 2,
+                },
+                lines: [
+                    Str(
+                        Str {
+                            value: "testing 123",
+                            pos: 21,
+                            line: 4,
+                        },
+                    ),
+                    Str(
+                        Str {
+                            value: "",
+                            pos: 33,
+                            line: 5,
+                        },
+                    ),
+                ],
+            },
+            Section {
+                id: "duplicate-header-1",
+                title: "Duplicate header",
+                full_title: Str {
+                    value: "## Duplicate header",
+                    pos: 34,
+                    line: 6,
+                },
+                lines: [
+                    Str(
+                        Str {
+                            value: "other test",
+                            pos: 55,
+                            line: 8,
+                        },
+                    ),
+                ],
+            },
+        ],
+        format: Markdown,
+    },
+)

--- a/src/specification/markdown/tests.rs
+++ b/src/specification/markdown/tests.rs
@@ -103,3 +103,16 @@ Testing 123
 More content
 "#
 );
+
+snapshot!(
+    duplicate_sections,
+    r#"
+# Duplicate header
+
+testing 123
+
+## Duplicate header
+
+other test
+"#
+);


### PR DESCRIPTION
*Issue #, if available:*

fixes #93 

*Description of changes:*

As mentioned in the issue, markdown section titles don't have to be unique, but still need a unique identifier. This change adopts the same mechanism as GitHub and adds a counter after the title if it already exists in the document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
