### PR TITLE
chore: fix initial build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+fn main() {
+    Command::new("sh")
+        .arg("-c")
+        .arg("make www/public/script.js")
+        .output()
+        .expect("failed to execute process");
+}

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "duvet-report",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "duvet-report",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@material-ui/core": "4",
         "@material-ui/icons": "4",
@@ -4458,9 +4458,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.0.25",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
-      "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
+      "version": "17.0.52",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.52.tgz",
+      "integrity": "sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -21611,9 +21611,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.0.25",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
-      "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
+      "version": "17.0.52",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.52.tgz",
+      "integrity": "sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",


### PR DESCRIPTION
https://github.com/awslabs/duvet/pull/88 removed script.js and instead rebuilds it in CI. However this broke local development so I made a fix to generate `script.js` during the initial build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
