### PR TITLE
specify path to the spec files

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -55,15 +55,23 @@ pub struct Extract {
     #[structopt(short, long, default_value = ".")]
     out: PathBuf,
 
+    /// Path to store the collection of spec files
+    ///
+    /// The collection of spec files are stored in a folder called `specs`. The
+    /// `specs` folder is stored in the current directory by default. Use this
+    /// argument to override the default location.
+    #[structopt(long = "spec-path")]
+    pub spec_path: Option<String>,
+
     target: TargetPath,
 }
 
 impl Extract {
     pub fn exec(&self) -> Result<(), Error> {
-        let contents = self.target.load(None)?;
+        let contents = self.target.load(self.spec_path.as_deref())?;
         let spec = self.format.parse(&contents)?;
         let sections = extract_sections(&spec);
-        let local_path = self.target.local(None);
+        let local_path = self.target.local(self.spec_path.as_deref());
 
         if self.out.extension().is_some() {
             // assume a path with an extension is a single file

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -60,10 +60,10 @@ pub struct Extract {
 
 impl Extract {
     pub fn exec(&self) -> Result<(), Error> {
-        let contents = self.target.load()?;
+        let contents = self.target.load(None)?;
         let spec = self.format.parse(&contents)?;
         let sections = extract_sections(&spec);
-        let local_path = self.target.local();
+        let local_path = self.target.local(None);
 
         if self.out.extension().is_some() {
             // assume a path with an extension is a single file

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn main() {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, StructOpt)]
 enum Arguments {
     Extract(extract::Extract),

--- a/src/project.rs
+++ b/src/project.rs
@@ -58,11 +58,11 @@ pub struct Project {
 
     /// Path to store the collection of spec files
     ///
-    /// The spec files are stored in a folder called `specs`. This folder is
-    /// stored at the root of the project by default. Use this argument to
-    /// specify a different location.
-    #[structopt(long = "spec-download-path", default_value = ".")]
-    pub spec_download_path: String,
+    /// The collection of spec files are stored in a folder called `specs`. The
+    /// `specs` folder is stored in the current directory by default. Use this
+    /// argument to override the default location.
+    #[structopt(long = "spec-path")]
+    pub spec_path: Option<String>,
 }
 
 impl Project {

--- a/src/project.rs
+++ b/src/project.rs
@@ -55,6 +55,14 @@ pub struct Project {
     /// Glob patterns for spec files
     #[structopt(long = "spec-pattern")]
     spec_patterns: Vec<String>,
+
+    /// Path to store the collection of spec files
+    ///
+    /// The spec files are stored in a folder called `specs`. This folder is
+    /// stored at the root of the project by default. Use this argument to
+    /// specify a different location.
+    #[structopt(long = "spec-download-path", default_value = ".")]
+    pub spec_download_path: String,
 }
 
 impl Project {

--- a/src/report/lcov.rs
+++ b/src/report/lcov.rs
@@ -61,10 +61,7 @@ pub fn report(report: &ReportResult, dir: &Path) -> Result<(), Error> {
 }
 
 #[allow(clippy::cognitive_complexity)]
-pub fn report_source<Output: Write>(
-    report: &TargetReport,
-    output: &mut Output,
-) -> Result<(), Error> {
+fn report_source<Output: Write>(report: &TargetReport, output: &mut Output) -> Result<(), Error> {
     macro_rules! put {
         ($($arg:expr),* $(,)?) => {
             writeln!(output $(, $arg)*)?;
@@ -73,7 +70,7 @@ pub fn report_source<Output: Write>(
 
     put!("TN:Compliance");
     let relative =
-        pathdiff::diff_paths(report.target.path.local(), std::env::current_dir()?).unwrap();
+        pathdiff::diff_paths(report.target.path.local(None), std::env::current_dir()?).unwrap();
     put!("SF:{}", relative.display());
 
     // record all sections

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -115,7 +115,10 @@ impl Report {
         let contents: HashMap<_, _> = targets
             .par_iter()
             .map(|target| {
-                let contents = target.path.load().unwrap();
+                let contents = target
+                    .path
+                    .load(Some(&self.project.spec_download_path))
+                    .unwrap();
                 (target, contents)
             })
             .collect();

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -115,10 +115,7 @@ impl Report {
         let contents: HashMap<_, _> = targets
             .par_iter()
             .map(|target| {
-                let contents = target
-                    .path
-                    .load(Some(&self.project.spec_download_path))
-                    .unwrap();
+                let contents = target.path.load(self.project.spec_path.as_deref()).unwrap();
                 (target, contents)
             })
             .collect();

--- a/src/target.rs
+++ b/src/target.rs
@@ -72,7 +72,7 @@ impl TargetPath {
         Ok(Self::Path(path))
     }
 
-    pub fn load(&self, spec_download_path: Option<&String>) -> Result<String, Error> {
+    pub fn load(&self, spec_download_path: Option<&str>) -> Result<String, Error> {
         let mut contents = match self {
             Self::Url(url) => {
                 let path = self.local(spec_download_path);
@@ -103,13 +103,14 @@ impl TargetPath {
         Ok(contents)
     }
 
-    pub fn local(&self, spec_download_path: Option<&String>) -> PathBuf {
+    pub fn local(&self, spec_download_path: Option<&str>) -> PathBuf {
         match self {
             Self::Url(url) => {
-                let mut path = std::env::current_dir().unwrap();
-                if let Some(path_to_spec) = spec_download_path {
-                    path.push(path_to_spec);
-                }
+                let mut path = if let Some(path_to_spec) = spec_download_path {
+                    PathBuf::from_str(path_to_spec).unwrap()
+                } else {
+                    std::env::current_dir().unwrap()
+                };
                 path.push("specs");
                 path.push(url.host_str().expect("url should have host"));
                 path.extend(url.path_segments().expect("url should have path"));

--- a/src/target.rs
+++ b/src/target.rs
@@ -72,10 +72,10 @@ impl TargetPath {
         Ok(Self::Path(path))
     }
 
-    pub fn load(&self) -> Result<String, Error> {
+    pub fn load(&self, spec_download_path: Option<&String>) -> Result<String, Error> {
         let mut contents = match self {
             Self::Url(url) => {
-                let path = self.local();
+                let path = self.local(spec_download_path);
                 if !path.exists() {
                     std::fs::create_dir_all(path.parent().unwrap())?;
 
@@ -103,10 +103,13 @@ impl TargetPath {
         Ok(contents)
     }
 
-    pub fn local(&self) -> PathBuf {
+    pub fn local(&self, spec_download_path: Option<&String>) -> PathBuf {
         match self {
             Self::Url(url) => {
                 let mut path = std::env::current_dir().unwrap();
+                if let Some(path_to_spec) = spec_download_path {
+                    path.push(path_to_spec);
+                }
                 path.push("specs");
                 path.push(url.host_str().expect("url should have host"));
                 path.extend(url.path_segments().expect("url should have path"));


### PR DESCRIPTION
https://github.com/aws/s2n-tls/issues/4219

*Description of changes:*
Duvet was originally designed so that the spec files would be stored at project root. Since, ends up cluttering the codebase, some projects such as [s2n-tls](https://github.com/aws/s2n-tls/tree/main/compliance) instead store all spec related material in a separate directory. This results in unexpected behavior where the `report` command is unable to find the spec files and attempts to re-download them each time.

This PR expose a new argument `--spec-download-path` which can be used to specify the location where to download the spec files. Specifically for s2n-tls you could add `--spec-download-path 'compliance'` to the [generate script](https://github.com/aws/s2n-tls/blob/main/compliance/generate_report.sh). 

### Callout
I only exposed the spec-download-path for the `report` sub-command and not `extract` since it possible to run extract from any directory. We can always add this param if we want later on.

### Testing
I tested this locally to confirm that this works with the directory structure in s2n-tls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
