### PR TITLE
test(duvet): update ietf snapshots

### DIFF
--- a/duvet/src/specification/ietf/snapshots.tar.gz
+++ b/duvet/src/specification/ietf/snapshots.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c39aefea4476c89a2f71a1885eb9b1d1b0549e8d2a3715a7c667ef7ec786e540
-size 573450240
+oid sha256:fec55dd607d2bc099af6940745ba04fc5c31a917340c301084ad1b85fafa7844
+size 573480960


### PR DESCRIPTION
*Description of changes:*

A new IETF document - [RFC 9602](https://www.rfc-editor.org/rfc/rfc9602) - was published out of order with the currently set maximum of 9663, causing the snapshot to be unrecognized and the [CI to start failing](https://github.com/awslabs/duvet/actions/runs/11616487766/job/32349568930). I've updated the snapshots with the new value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
