### PR TITLE
fix(duvet): remove BOM markers

### DIFF
--- a/duvet/src/specification/ietf/snapshots.tar.gz
+++ b/duvet/src/specification/ietf/snapshots.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fec55dd607d2bc099af6940745ba04fc5c31a917340c301084ad1b85fafa7844
-size 573480960
+oid sha256:139f84b4377e51be6089a905ae7f23a837fd56fac22c1759c2230d0e53aa54cd
+size 574074880

--- a/duvet/src/specification/ietf/tokenizer.rs
+++ b/duvet/src/specification/ietf/tokenizer.rs
@@ -128,7 +128,12 @@ macro_rules! expect_contents {
 
 /// Transforms file contents into lines
 fn lines(contents: &SourceFile) -> impl Iterator<Item = Token> + '_ {
-    contents.lines().enumerate().map(move |(line, value)| {
+    contents.lines().enumerate().map(move |(line, mut value)| {
+        // look for Byte Order Mark and filter it out
+        if line == 0 {
+            value = value.trim_start_matches("\u{feff}");
+        }
+
         // line numbers start at 1
         let line = line + 1;
         let value = contents.substr(value).unwrap();


### PR DESCRIPTION
*Description of changes:*

I noticed that some of the IETF documents include a [BOM marker](https://en.wikipedia.org/wiki/Byte_order_mark). I've updated the tokenizer to filter those out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
