### PR TITLE
refactor: move reference query to separate module

### DIFF
--- a/duvet/Cargo.toml
+++ b/duvet/Cargo.toml
@@ -14,13 +14,11 @@ include = [
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 duvet-core = { version = "0.1", path = "../duvet-core" }
-fnv = { version = "1", default-features = false }
 futures = { version = "0.3" }
 glob = "0.3"
 lazy_static = "1"
 mimalloc = { version = "0.1", default-features = false }
 once_cell = "1"
-pathdiff = "0.2"
 pulldown-cmark = { version = "0.12", default-features = false }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
@@ -36,4 +34,5 @@ v_jsonescape = "0.7"
 [dev-dependencies]
 insta = { version = "1", features = ["filters", "json"] }
 serde_json = "1"
+strip-ansi-escapes = "0.2"
 tempfile = "3"

--- a/duvet/src/lib.rs
+++ b/duvet/src/lib.rs
@@ -8,6 +8,7 @@ mod annotation;
 mod comment;
 mod extract;
 mod project;
+mod reference;
 mod report;
 mod source;
 mod specification;
@@ -43,11 +44,4 @@ impl Arguments {
 pub async fn run() -> Result {
     arguments().await.exec().await?;
     Ok(())
-}
-
-pub(crate) fn fnv<H: core::hash::Hash + ?Sized>(value: &H) -> u64 {
-    use core::hash::Hasher;
-    let mut hasher = fnv::FnvHasher::default();
-    value.hash(&mut hasher);
-    hasher.finish()
 }

--- a/duvet/src/reference.rs
+++ b/duvet/src/reference.rs
@@ -84,7 +84,7 @@ pub async fn build_references(
     let mut references = vec![];
 
     let Some(section_id) = section_id else {
-        // TODO return an warning that referring to a spec without a section doesn't make sense
+        // TODO return a warning that referring to a spec without a section doesn't make sense
         return (references.into(), errors.into());
     };
 

--- a/duvet/src/reference.rs
+++ b/duvet/src/reference.rs
@@ -1,0 +1,145 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    annotation::{AnnotationReferenceMap, AnnotationWithId},
+    specification::Specification,
+    target::{SpecificationMap, Target},
+    Result,
+};
+use duvet_core::{
+    diagnostic::{Error, IntoDiagnostic},
+    error,
+    file::Slice,
+};
+use std::sync::Arc;
+
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+pub struct Reference {
+    pub target: Arc<Target>,
+    pub annotation: AnnotationWithId,
+    pub text: Slice,
+}
+
+impl Reference {
+    pub fn line(&self) -> usize {
+        self.text.line()
+    }
+
+    pub fn start(&self) -> usize {
+        self.text.range().start
+    }
+
+    pub fn end(&self) -> usize {
+        self.text.range().end
+    }
+}
+
+pub async fn query(
+    reference_map: AnnotationReferenceMap,
+    specs: SpecificationMap,
+) -> Result<Arc<[Reference]>> {
+    let mut errors = vec![];
+
+    let mut tasks = tokio::task::JoinSet::new();
+
+    for ((target, section_id), annotations) in reference_map.iter() {
+        let spec = specs.get(target).expect("missing spec");
+        let task = build_references(
+            target.clone(),
+            spec.clone(),
+            section_id.clone(),
+            annotations.clone(),
+        );
+        tasks.spawn(task);
+    }
+
+    let mut references = vec![];
+    while let Some(res) = tasks.join_next().await {
+        match res.into_diagnostic() {
+            Ok((task_references, task_errors)) => {
+                references.extend(task_references.iter().cloned());
+                errors.extend(task_errors.iter().cloned());
+            }
+            Err(err) => {
+                errors.push(err);
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        Err(errors.into())
+    } else {
+        Ok(references.into())
+    }
+}
+
+pub async fn build_references(
+    target: Arc<Target>,
+    spec: Arc<Specification>,
+    section_id: Option<Arc<str>>,
+    annotations: Arc<[AnnotationWithId]>,
+) -> (Arc<[Reference]>, Arc<[Error]>) {
+    let mut errors = vec![];
+    let mut references = vec![];
+
+    let Some(section_id) = section_id else {
+        // TODO return an warning that referring to a spec without a section doesn't make sense
+        return (references.into(), errors.into());
+    };
+
+    let Some(section) = spec.section(&section_id) else {
+        for annotation in annotations.iter() {
+            let mut error = error!("missing section {section_id:?} in {}", target.path);
+            error = error.with_source_slice(annotation.original_target.clone(), "referenced here");
+            // TODO try to make a suggestion if there's something that's close
+            errors.push(error);
+        }
+        return (references.into(), errors.into());
+    };
+
+    let contents = section.view();
+
+    for annotation in annotations.iter() {
+        if annotation.quote.is_empty() {
+            // empty quotes don't count towards coverage but are still
+            // references
+            let text = section.full_title.clone();
+            references.push(Reference {
+                target: target.clone(),
+                text,
+                annotation: annotation.clone(),
+            });
+            continue;
+        }
+
+        if let Some(range) = annotation.quote_range(&contents) {
+            for text in contents.ranges(range) {
+                references.push(Reference {
+                    target: target.clone(),
+                    text,
+                    annotation: annotation.clone(),
+                });
+            }
+        } else {
+            let mut error = error!(
+                "could not find text in section {section_id:?} of {}",
+                target.path
+            );
+            if let Some(original_text) = section.original_text() {
+                error = error.with_source_slice(annotation.original_quote.clone(), "text here");
+
+                // TODO print out the section text in the `help` with line numbers
+                let _ = original_text;
+            } else {
+                error =
+                    error.with_source_slice(annotation.original_quote.clone(), "section is empty");
+            }
+            errors.push(error);
+        }
+    }
+
+    // TODO upgrade levels whenever they overlap
+
+    (references.into(), errors.into())
+}

--- a/duvet/src/report.rs
+++ b/duvet/src/report.rs
@@ -2,19 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    annotation::{self, Annotation, AnnotationLevel, AnnotationSet, AnnotationWithId},
+    annotation::{self, AnnotationSet},
     project::Project,
+    reference::{self, Reference},
     specification::Specification,
     target::Target,
     Result,
 };
 use clap::Parser;
-use core::fmt;
-use duvet_core::{error, path::Path, progress};
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-};
+use duvet_core::{path::Path, progress};
+use std::{collections::BTreeMap, sync::Arc};
 
 mod ci;
 mod html;
@@ -55,57 +52,6 @@ pub struct Report {
     issue_link: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
-struct Reference {
-    line: usize,
-    start: usize,
-    end: usize,
-    annotation: AnnotationWithId,
-    level: AnnotationLevel,
-}
-
-impl Reference {
-    pub fn start(&self) -> usize {
-        self.start
-    }
-
-    pub fn end(&self) -> usize {
-        self.end
-    }
-
-    pub fn line(&self) -> usize {
-        self.line
-    }
-}
-
-#[derive(Debug)]
-enum ReportError<'a> {
-    QuoteMismatch { annotation: &'a Annotation },
-    MissingSection { annotation: &'a Annotation },
-}
-
-impl fmt::Display for ReportError<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::QuoteMismatch { annotation } => write!(
-                f,
-                "{}#{} - quote not found in {:?}",
-                annotation.source.display(),
-                annotation.anno_line,
-                annotation.target,
-            ),
-            Self::MissingSection { annotation } => write!(
-                f,
-                "{}#{} - section {:?} not found in {:?}",
-                annotation.source.display(),
-                annotation.anno_line,
-                annotation.target_section().as_deref().unwrap_or("-"),
-                annotation.target_path(),
-            ),
-        }
-    }
-}
-
 impl Report {
     pub async fn exec(&self) -> Result {
         let progress = progress!("Scanning sources");
@@ -125,129 +71,44 @@ impl Report {
         let progress = progress!("Compiling references");
         let reference_map = annotation::reference_map(annotations.clone()).await?;
 
-        let results: Vec<_> = reference_map
-            .iter()
-            .flat_map(|((target, section_id), annotations)| {
-                let spec = specifications.get(target).expect("spec already checked");
-
-                let mut results = vec![];
-
-                if let Some(section_id) = section_id {
-                    if let Some(section) = spec.section(section_id) {
-                        let contents = section.view();
-
-                        for annotation in annotations.iter() {
-                            if annotation.quote.is_empty() {
-                                // empty quotes don't count towards coverage but are still
-                                // references
-                                let text = section.full_title.clone();
-                                results.push(Ok((
-                                    target,
-                                    Reference {
-                                        line: text.line(),
-                                        start: text.range().start,
-                                        end: text.range().end,
-                                        annotation: annotation.clone(),
-                                        level: annotation.level,
-                                    },
-                                )));
-                                continue;
-                            }
-
-                            if let Some(range) = annotation.quote_range(&contents) {
-                                for text in contents.ranges(range) {
-                                    results.push(Ok((
-                                        target,
-                                        Reference {
-                                            line: text.line(),
-                                            start: text.range().start,
-                                            end: text.range().end,
-                                            annotation: annotation.clone(),
-                                            level: annotation.level,
-                                        },
-                                    )));
-                                }
-                            } else {
-                                results
-                                    .push(Err((target, ReportError::QuoteMismatch { annotation })));
-                            }
-                        }
-                    } else {
-                        for annotation in annotations.iter() {
-                            results.push(Err((target, ReportError::MissingSection { annotation })));
-                        }
-                    }
-                } else {
-                    // TODO
-                    eprintln!("TOTAL REFERENCE {:?}", annotations);
-                }
-
-                // TODO upgrade levels whenever they overlap
-
-                results
-            })
-            .collect();
-
         let mut report = ReportResult {
             targets: Default::default(),
             annotations,
             blob_link: self.blob_link.as_deref(),
             issue_link: self.issue_link.as_deref(),
         };
-        let mut errors = BTreeSet::new();
 
-        for result in results {
-            let (target, result) = match result {
-                Ok((target, entry)) => (target, Ok(entry)),
-                Err((target, err)) => (target, Err(err)),
-            };
-            let target = target.clone();
+        let references = reference::query(reference_map.clone(), specifications.clone()).await?;
 
-            let entry = report.targets.entry(target.clone()).or_insert_with(|| {
-                let specification = specifications
-                    .get(&target)
-                    .expect("content should exist")
-                    .clone();
-                TargetReport {
-                    target,
-                    references: BTreeSet::new(),
-                    specification,
-                    require_citations: self.require_citations(),
-                    require_tests: self.require_tests(),
-                    statuses: Default::default(),
-                }
-            });
-
-            match result {
-                Ok(reference) => {
-                    entry.references.insert(reference);
-                }
-                Err(err) => {
-                    errors.insert(err.to_string());
-                }
-            }
+        for reference in references.iter() {
+            report
+                .targets
+                .entry(reference.target.clone())
+                .or_insert_with(|| {
+                    let specification = specifications.get(&reference.target).unwrap().clone();
+                    TargetReport {
+                        references: vec![],
+                        specification,
+                        require_citations: self.require_citations(),
+                        require_tests: self.require_tests(),
+                        statuses: Default::default(),
+                    }
+                })
+                .references
+                .push(reference.clone());
         }
+
+        report.targets.iter_mut().for_each(|(_, target)| {
+            target.references.sort();
+            target.statuses.populate(&target.references)
+        });
 
         progress!(
             progress,
-            "Compiled references in {} sections",
+            "Compiled {} references across {} sections",
+            references.len(),
             reference_map.len()
         );
-
-        if !errors.is_empty() {
-            for error in &errors {
-                eprintln!("{}", error);
-            }
-
-            return Err(error!(
-                "source errors were found. no reports were generated"
-            ));
-        }
-
-        report
-            .targets
-            .iter_mut()
-            .for_each(|(_, target)| target.statuses.populate(&target.references));
 
         type ReportFn = fn(&ReportResult, &Path) -> crate::Result<()>;
 
@@ -307,8 +168,7 @@ pub struct ReportResult<'a> {
 
 #[derive(Debug)]
 pub struct TargetReport {
-    target: Arc<Target>,
-    references: BTreeSet<Reference>,
+    references: Vec<Reference>,
     specification: Arc<Specification>,
     require_citations: bool,
     require_tests: bool,

--- a/duvet/src/report/stats.rs
+++ b/duvet/src/report/stats.rs
@@ -14,7 +14,7 @@ pub struct Statistics {
 impl Statistics {
     #[allow(dead_code)]
     pub(super) fn record(&mut self, reference: &Reference) {
-        match reference.level {
+        match reference.annotation.level {
             AnnotationLevel::Auto => {
                 // don't record auto references
             }

--- a/duvet/src/report/status.rs
+++ b/duvet/src/report/status.rs
@@ -23,7 +23,7 @@ impl Deref for StatusMap {
 }
 
 impl StatusMap {
-    pub(super) fn populate(&mut self, references: &BTreeSet<Reference>) {
+    pub(super) fn populate(&mut self, references: &[Reference]) {
         let mut specs: BTreeMap<AnnotationId, Vec<&Reference>> = BTreeMap::new();
         let mut coverage: BTreeMap<usize, Vec<&Reference>> = BTreeMap::new();
 

--- a/duvet/src/snapshots/duvet__tests__inner_whitespace.snap
+++ b/duvet/src/snapshots/duvet__tests__inner_whitespace.snap
@@ -1,6 +1,6 @@
 ---
 source: duvet/src/tests.rs
-expression: "out[\"specifications\"][&spec]"
+expression: "out[\"specifications\"][\"my-spec.md\"]"
 ---
 {
   "format": "markdown",

--- a/duvet/src/snapshots/duvet__tests__invalid_quote.snap
+++ b/duvet/src/snapshots/duvet__tests__invalid_quote.snap
@@ -1,0 +1,12 @@
+---
+source: duvet/src/tests.rs
+expression: error
+---
+  × could not find text in section "section" of my-spec.md
+   ╭─[src/my-code.rs:3:5]
+ 2 │ //= my-spec.md#section
+ 3 │ //# Here is missing text
+   ·     ──────────┬─────────
+   ·               ╰── text here
+ 4 │         
+   ╰────

--- a/duvet/src/snapshots/duvet__tests__invalid_section.snap
+++ b/duvet/src/snapshots/duvet__tests__invalid_section.snap
@@ -1,0 +1,12 @@
+---
+source: duvet/src/tests.rs
+expression: error
+---
+  × missing section "foo" in my-spec.md
+   ╭─[src/my-code.rs:2:5]
+ 1 │ 
+ 2 │ //= my-spec.md#foo
+   ·     ───────┬──────
+   ·            ╰── referenced here
+ 3 │ //# This quote MUST NOT work
+   ╰────

--- a/duvet/src/snapshots/duvet__tests__markdown_report.snap
+++ b/duvet/src/snapshots/duvet__tests__markdown_report.snap
@@ -1,6 +1,6 @@
 ---
 source: duvet/src/tests.rs
-expression: "out[\"specifications\"][&spec]"
+expression: "out[\"specifications\"][\"my-spec.md\"]"
 ---
 {
   "format": "markdown",

--- a/duvet/src/specification.rs
+++ b/duvet/src/specification.rs
@@ -159,6 +159,30 @@ impl Section {
             Line::Break => None,
         }))
     }
+
+    pub fn original_text(&self) -> Option<Slice> {
+        let mut start = usize::MAX;
+        let mut end = 0;
+        let mut has_content = false;
+
+        for line in self.lines.iter() {
+            match line {
+                Line::Str(v) => {
+                    let r = v.range();
+                    start = start.min(r.start);
+                    end = end.max(r.end);
+                    has_content = true;
+                }
+                Line::Break => {}
+            }
+        }
+
+        if !has_content {
+            return None;
+        }
+
+        Some(self.full_title.file().substr_range(start..end).unwrap())
+    }
 }
 
 impl Ord for Section {

--- a/duvet/src/tests.rs
+++ b/duvet/src/tests.rs
@@ -3,13 +3,21 @@
 
 use crate::{Arguments, Result};
 use clap::Parser;
-use duvet_core::diagnostic::IntoDiagnostic;
+use duvet_core::diagnostic::{Context as _, IntoDiagnostic as _};
 use insta::assert_json_snapshot;
 use std::{
     ffi::OsString,
+    io::Read,
     path::{Path, PathBuf},
 };
 use tempfile::TempDir;
+
+macro_rules! assert_error_snapshot {
+    ($error:expr) => {
+        let error = strip_ansi_escapes::strip_str($error.snapshot().to_string());
+        insta::assert_snapshot!(error);
+    };
+}
 
 struct Env {
     dir: TempDir,
@@ -19,28 +27,39 @@ struct Env {
 impl Env {
     fn new() -> Result<Self> {
         let dir = tempfile::tempdir()?;
+        duvet_core::env::set_current_dir(dir.path().into());
         Ok(Self { dir })
     }
 
     fn put(&self, path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<String> {
-        let path = self.path(path);
-        if let Some(parent) = path.parent() {
+        let path = path.as_ref();
+        let full_path = self.path(path);
+        if let Some(parent) = full_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(&path, contents)?;
-        Ok(path.display().to_string())
+        std::fs::write(&full_path, contents)?;
+        let path = full_path.display().to_string();
+        Ok(path)
     }
 
     fn get(&self, path: impl AsRef<Path>) -> Result<String> {
-        let path = self.path(path);
-        Ok(std::fs::read_to_string(path)?)
+        let mut out = String::new();
+        self.get_file(path)?.read_to_string(&mut out)?;
+        Ok(out)
     }
 
     fn get_json(&self, path: impl AsRef<Path>) -> Result<serde_json::Value> {
-        let path = self.path(path);
-        let file = std::fs::File::open(path)?;
+        let file = self.get_file(path)?;
         let value = serde_json::from_reader(file)?;
         Ok(value)
+    }
+
+    fn get_file(&self, path: impl AsRef<Path>) -> Result<std::fs::File> {
+        let path = self.path(path);
+        let file = std::fs::File::open(&path)
+            .into_diagnostic()
+            .wrap_err_with(|| path.display().to_string())?;
+        Ok(file)
     }
 
     fn path(&self, path: impl AsRef<Path>) -> PathBuf {
@@ -68,7 +87,7 @@ impl Env {
 async fn markdown_report() -> Result {
     let env = Env::new()?;
 
-    let spec = env.put(
+    env.put(
         "my-spec.md",
         r#"
 # My spec
@@ -85,14 +104,12 @@ This quote MUST work
 
     let code = env.put(
         "src/my-code.rs",
-        format!(
-            r#"
-//= {spec}#testing
+        r#"
+//= my-spec.md#testing
 //# This quote MUST work
 //# * with
 //# * bullets
         "#,
-        ),
     )?;
 
     let target = env.path("target/report.json");
@@ -108,7 +125,7 @@ This quote MUST work
 
     let out = env.get_json(&target)?;
 
-    assert_json_snapshot!(out["specifications"][&spec]);
+    assert_json_snapshot!(out["specifications"]["my-spec.md"]);
 
     Ok(())
 }
@@ -117,7 +134,7 @@ This quote MUST work
 async fn inner_whitespace() -> Result {
     let env = Env::new()?;
 
-    let spec = env.put(
+    env.put(
         "my-spec.md",
         r#"
 # Testing
@@ -128,12 +145,10 @@ This      SHOULD         ignore        whitespace.
 
     let code = env.put(
         "src/my-code.rs",
-        format!(
-            r#"
-//= {spec}#testing
+        r#"
+//= my-spec.md#testing
 //# This SHOULD             ignore         whitespace.
-            "#
-        ),
+        "#,
     )?;
 
     let out = env.path("target/report.json");
@@ -149,7 +164,85 @@ This      SHOULD         ignore        whitespace.
 
     let out = env.get_json(&out)?;
 
-    assert_json_snapshot!(out["specifications"][&spec]);
+    assert_json_snapshot!(out["specifications"]["my-spec.md"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_section() -> Result {
+    let env = Env::new()?;
+
+    env.put(
+        "my-spec.md",
+        r#"
+# Section
+
+here is a spec
+        "#,
+    )?;
+
+    let code = env.put(
+        "src/my-code.rs",
+        r#"
+//= my-spec.md#foo
+//# This quote MUST NOT work
+        "#,
+    )?;
+
+    let target = env.path("target/report.json");
+
+    let err = env
+        .exec([
+            "report",
+            "--source-pattern",
+            &code,
+            "--json",
+            &target.display().to_string(),
+        ])
+        .await
+        .unwrap_err();
+
+    assert_error_snapshot!(err);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_quote() -> Result {
+    let env = Env::new()?;
+
+    env.put(
+        "my-spec.md",
+        r#"
+# Section
+
+here is a spec
+        "#,
+    )?;
+
+    let code = env.put(
+        "src/my-code.rs",
+        r#"
+//= my-spec.md#section
+//# Here is missing text
+        "#,
+    )?;
+
+    let target = env.path("target/report.json");
+
+    let err = env
+        .exec([
+            "report",
+            "--source-pattern",
+            &code,
+            "--json",
+            &target.display().to_string(),
+        ])
+        .await
+        .unwrap_err();
+
+    assert_error_snapshot!(err);
 
     Ok(())
 }

--- a/integration/snapshots/aws-cryptographic-material-providers-library.snap
+++ b/integration/snapshots/aws-cryptographic-material-providers-library.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28dc553c3ee62fe6a1eeef326b346a8a35ef7a40958d370c3a957c6fac174567
+oid sha256:201bdde1f3cdf9fda8fda3a0591036a294ef3b97dcfeeb1f8bbbea8a392e7097
 size 1902704

--- a/integration/snapshots/h3.snap
+++ b/integration/snapshots/h3.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad8e8048f7907ce0b5fe5447ef67a1e37cae42700d48406d11d4dd74cf96a8c5
+oid sha256:a3beb0b76629e441a936b0f6b56e79e9189ed8ead9fa597ba87b905cab886bd9
 size 690627

--- a/integration/snapshots/s2n-quic.snap
+++ b/integration/snapshots/s2n-quic.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:813d070256700492f7608ee31aa11b5416f9beec63145b62faa9c3d0d2d9353d
+oid sha256:21eeaa29e6aa471e9ce00c1f3e5b967fc146eac957ed8f6f6796b823c0c11700
 size 6286465

--- a/integration/snapshots/s2n-tls.snap
+++ b/integration/snapshots/s2n-tls.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e8b194a98dbaeaf7dc9121558166848fb8b1c8a828cb8251eef98d8a6365cf5
+oid sha256:9a84733f2483a22a58445970b4dcf483409b94a48efb5cd234fc62624c8e0fa8
 size 3272196


### PR DESCRIPTION
*Description of changes:*

This change moves all of the reference linking queries to a separate module from the report module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
