### PR TITLE
ci: fix cargo-deny task

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -1,28 +1,51 @@
 [advisories]
-vulnerability = "deny"
-unmaintained = "deny"
-notice = "deny"
 yanked = "deny"
-ignore = [
-    "RUSTSEC-2021-0139" # structopt is still using clap v2
-]
 
 [bans]
-multiple-versions = "deny"
+skip-tree = [
+    # all of these are going to be just test dependencies
+    { name = "insta" },
+]
 
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
 
 [licenses]
-unlicensed = "deny"
-allow-osi-fsf-free = "neither"
-copyleft = "deny"
-confidence-threshold = 0.90
+confidence-threshold = 0.9
+# ignore licenses for private crates
+private = { ignore = true }
 allow = [
     "Apache-2.0",
+    "BSD-2-Clause",
     "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
     "MIT",
+    "OpenSSL",
     "Unicode-DFS-2016",
     "Zlib",
+    "Unicode-3.0",
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+[[licenses.clarify]]
+name = "encoding_rs"
+version = "*"
+expression = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+license-files = [
+    { path = "COPYRIGHT", hash = 0x39f8ad31 }
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Evaluate definitions
         id: definitions
         run: |
-          export MSRV=$(cat rust-toolchain | awk '{$1=$1};1')
+          export MSRV=$(rustup show | awk 'NF' | awk 'END{print $2}')
           echo "msrv=$MSRV" >> "$GITHUB_OUTPUT"
           export RAW_VERSIONS="stable beta $RUST_NIGHTLY_TOOLCHAIN $MSRV"
           export VERSIONS=$(echo $RAW_VERSIONS | jq -scR 'rtrimstr("\n")|split(" ")|.')

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -30,6 +30,6 @@ jobs:
       - name: "Remove rust-toolchain"
         run: rm rust-toolchain
 
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check --config .github/config/cargo-deny.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ inherits = "dev"
 opt-level = 3
 incremental = false
 codegen-units = 1
+
+[profile.release-debug]
+inherits = "dev"
+opt-level = 3

--- a/duvet-macros/Cargo.toml
+++ b/duvet-macros/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "duvet-macros"
 version = "0.1.0"
+description = "Internal crate used by duvet"
+authors = ["Cameron Bytheway <bythewc@amazon.com>"]
 edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/awslabs/duvet"
 
 [lib]
 proc-macro = true

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-1.81.0
+[toolchain]
+channel = "1.81.0"
+components = [ "rustc", "clippy", "rustfmt" ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "xtask"
+version = "0.0.0"
 edition = "2021"
 publish = false
 

--- a/xtask/src/checks.rs
+++ b/xtask/src/checks.rs
@@ -14,7 +14,7 @@ pub struct Checks {
 impl Checks {
     pub fn run(&self, sh: &Shell) -> Result {
         crate::build::Build {
-            release: Some(Some(false)),
+            profile: "dev".into(),
         }
         .run(sh)?;
 

--- a/xtask/src/tests.rs
+++ b/xtask/src/tests.rs
@@ -20,14 +20,15 @@ pub struct Tests {
     #[clap(long)]
     /// Enables all of the default tests
     default_tests: Option<Option<bool>>,
-
-    #[clap(flatten)]
-    build: crate::build::Build,
 }
 
 impl Tests {
     pub fn run(&self, sh: &Shell) -> Result {
-        let bin = self.build.run(sh)?;
+        let bin = crate::build::Build {
+            // compile in dev mode with optimizations
+            profile: "release-debug".into(),
+        }
+        .run(sh)?;
 
         let default_tests = self.default_tests.is_enabled(true);
 


### PR DESCRIPTION
*Description of changes:*

This change both updates the `cargo-deny` workflow dependency and fixes the warnings associated with it.

Note the tests have started to fail for other reasons. This is addressed in #139.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
