### PR TITLE
fix: make target downloads non-blocking

### DIFF
--- a/duvet-core/Cargo.toml
+++ b/duvet-core/Cargo.toml
@@ -23,7 +23,7 @@ globset = "0.4"
 http = { version = "1", optional = true }
 miette = { version = "7", features = ["fancy"] }
 once_cell = "1"
-reqwest = { version = "0.12", optional = true }
+reqwest = { version = "0.12", optional = true, features = ["native-tls"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 tokio = { version = "1", features = ["fs", "sync"] }

--- a/duvet/Cargo.toml
+++ b/duvet/Cargo.toml
@@ -24,7 +24,6 @@ pathdiff = "0.2"
 pulldown-cmark = { version = "0.12", default-features = false }
 rayon = "1"
 regex = "1"
-reqwest = { version = "0.12", features = ["blocking", "native-tls"] }
 serde = { version = "1", features = ["derive"] }
 slug = { version = "0.1" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/duvet/src/extract.rs
+++ b/duvet/src/extract.rs
@@ -68,9 +68,8 @@ pub struct Extract {
 
 impl Extract {
     pub async fn exec(&self) -> Result<(), Error> {
-        let contents = self.target.load(self.spec_path.as_deref())?;
-        let local_path = self.target.local(self.spec_path.as_deref());
-        let contents = duvet_core::file::SourceFile::new(&*local_path, contents).unwrap();
+        let contents = self.target.load(self.spec_path.as_deref()).await?;
+        let local_path = contents.path();
 
         let spec = self.format.parse(&contents)?;
         let sections = extract_sections(&spec);
@@ -87,7 +86,7 @@ impl Extract {
                     // The specification may be stored alongside the extracted TOML.
                     let mut out = match local_path.strip_prefix(&self.out) {
                         Ok(path) => self.out.join(path),
-                        Err(_e) => self.out.join(&local_path),
+                        Err(_e) => self.out.join(local_path),
                     };
 
                     out.set_extension("");

--- a/duvet/src/report/mod.rs
+++ b/duvet/src/report/mod.rs
@@ -106,16 +106,13 @@ impl Report {
 
         let targets = annotations.targets()?;
 
-        let contents: HashMap<_, _> = targets
-            .par_iter()
-            .map(|target| {
-                let spec_path = self.project.spec_path.as_deref();
-                let path = target.path.local(spec_path);
-                let contents = target.path.load(spec_path).unwrap();
-                let contents = duvet_core::file::SourceFile::new(path, contents).unwrap();
-                (target, contents)
-            })
-            .collect();
+        let mut contents = HashMap::new();
+        for target in targets.iter() {
+            let spec_path = self.project.spec_path.as_deref();
+            let file = target.path.load(spec_path).await?;
+
+            contents.insert(target, file);
+        }
 
         let specifications: HashMap<_, _> = contents
             .par_iter()


### PR DESCRIPTION
*Description of changes:*

Using blocking reqwest calls inside of a tokio runtime causes issues. This change modifies the `load` function to be async instead.

Note that the dependencies task is broken. It's being fixed in #138.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
