### PR TITLE
refactor: move reference map query to module

### DIFF
--- a/duvet/src/comment/parser.rs
+++ b/duvet/src/comment/parser.rs
@@ -111,7 +111,7 @@ impl Meta {
         let mut original_quote = original_text.clone();
 
         let mut quote = String::new();
-        for (idx, part) in contents.into_iter().enumerate() {
+        for (idx, part) in contents.iter().enumerate() {
             if idx == 0 {
                 original_quote = part.range();
             } else {
@@ -135,7 +135,7 @@ impl Meta {
             original_text,
             original_target,
             original_quote,
-            target: target.to_string(),
+            target,
             quote,
             manifest_dir: duvet_core::env::current_dir()?,
             comment: self.reason.map(|v| v.to_string()).unwrap_or_default(),

--- a/duvet/src/project.rs
+++ b/duvet/src/project.rs
@@ -67,7 +67,7 @@ pub struct Project {
 }
 
 impl Project {
-    pub fn sources(&self) -> Result<HashSet<SourceFile>> {
+    pub async fn sources(&self) -> Result<HashSet<SourceFile>> {
         let mut sources = HashSet::new();
 
         for pattern in &self.source_patterns {

--- a/duvet/src/report/html.rs
+++ b/duvet/src/report/html.rs
@@ -3,10 +3,10 @@
 
 use super::ReportResult;
 use crate::Result;
+use duvet_core::path::Path;
 use std::{
     fs::File,
     io::{BufWriter, Write},
-    path::Path,
 };
 
 #[rustfmt::skip] // it gets really confused with macros that generate macros

--- a/duvet/src/report/json.rs
+++ b/duvet/src/report/json.rs
@@ -7,12 +7,11 @@ use crate::{
     specification::Line,
     Error, Result,
 };
-use duvet_core::file::Slice;
+use duvet_core::{file::Slice, path::Path};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fs::File,
     io::{BufWriter, Cursor, Write},
-    path::Path,
 };
 
 macro_rules! writer {
@@ -268,7 +267,7 @@ pub fn report_source<Output: Write>(report: &TargetReport, output: &mut Output) 
     let mut requirements = BTreeSet::new();
     for reference in &report.references {
         if reference.annotation.anno == AnnotationType::Spec {
-            requirements.insert(reference.annotation_id);
+            requirements.insert(reference.annotation.id);
         }
         references
             .entry(reference.line())
@@ -402,9 +401,9 @@ fn report_references<Output: Write>(
                         arr,
                         arr!(|arr| {
                             for r in current_refs {
-                                item!(arr, w!(r.annotation_id));
+                                item!(arr, w!(r.annotation.id));
                                 if r.annotation.anno == AnnotationType::Spec {
-                                    requirements.insert(r.annotation_id);
+                                    requirements.insert(r.annotation.id);
                                 }
                                 status.on_anno(r);
                             }

--- a/duvet/src/report/lcov.rs
+++ b/duvet/src/report/lcov.rs
@@ -3,11 +3,10 @@
 
 use super::{ReportResult, TargetReport};
 use crate::{annotation::AnnotationType, Result};
-use duvet_core::env;
+use duvet_core::{env, path::Path};
 use std::{
     collections::HashSet,
     io::{BufWriter, Write},
-    path::Path,
 };
 
 const IMPL_BLOCK: &str = "0,0";

--- a/duvet/src/report/status.rs
+++ b/duvet/src/report/status.rs
@@ -34,7 +34,7 @@ impl StatusMap {
                     coverage.entry(offset).or_default().push(r);
                 }
             } else {
-                specs.entry(r.annotation_id).or_default().push(r);
+                specs.entry(r.annotation.id).or_default().push(r);
             }
         }
 
@@ -49,7 +49,7 @@ impl StatusMap {
                     for (offset, refs) in coverage.range(r.start()..r.end()) {
                         for r in refs {
                             spec.insert(*offset, r);
-                            spec.related.insert(r.annotation_id);
+                            spec.related.insert(r.annotation.id);
                         }
                     }
                 }


### PR DESCRIPTION
*Description of changes:*

This change moves the reference map query to a separate module. Along with this change, it also adds progress reporting to give an idea of what the program is doing and how long:

```console
$ duvet report
    Scanning sources
     Scanned 957 sources 19ms
   Extracing annotations
   Extracted 2425 annotations 200ms
     Loading specifications
      Loaded 43 specifications 29ms
   Compiling references
    Compiled references in 418 sections 1.29s
     Writing target/compliance/report.html
       Wrote target/compliance/report.html 15ms
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
