### PR TITLE
feat: add config file support

### DIFF
--- a/.duvet/.gitignore
+++ b/.duvet/.gitignore
@@ -1,0 +1,1 @@
+reports/

--- a/.duvet/config.toml
+++ b/.duvet/config.toml
@@ -1,0 +1,12 @@
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "duvet/**/*.rs"
+
+[report.html]
+enabled = true
+issue-link = "https://github.com/awslabs/duvet/issues"
+blob-link = "https://github.com/awslabs/duvet/blob/${{ GITHUB_SHA || 'main' }}"
+
+[report.json]
+enabled = true

--- a/config/v0.4.0.json
+++ b/config/v0.4.0.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://awslabs.github.io/duvet/config/v0.4.0.json",
+  "title": "Duvet Configuration",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "report": {
+      "$ref": "#/definitions/Report"
+    },
+    "requirement": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Requirement"
+      }
+    },
+    "source": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Source"
+      }
+    },
+    "specification": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Specification"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "CommentStyle": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "default": "//#",
+          "type": "string"
+        },
+        "meta": {
+          "default": "//=",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DefaultType": {
+      "type": "string",
+      "enum": [
+        "implementation",
+        "spec",
+        "test",
+        "exception",
+        "todo",
+        "implication"
+      ]
+    },
+    "HtmlReport": {
+      "type": "object",
+      "properties": {
+        "blob-link": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TemplatedString"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "issue-link": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TemplatedString"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path": {
+          "default": ".duvet/reports/report.html",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "JsonReport": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "path": {
+          "default": ".duvet/reports/report.json",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Report": {
+      "type": "object",
+      "properties": {
+        "html": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HtmlReport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "json": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JsonReport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Requirement": {
+      "type": "object",
+      "required": [
+        "pattern"
+      ],
+      "properties": {
+        "pattern": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Source": {
+      "type": "object",
+      "required": [
+        "pattern"
+      ],
+      "properties": {
+        "comment-style": {
+          "$ref": "#/definitions/CommentStyle"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/DefaultType"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Specification": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SpecificationFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SpecificationFormat": {
+      "type": "string",
+      "enum": [
+        "ietf",
+        "markdown"
+      ]
+    },
+    "TemplatedString": {
+      "type": "string"
+    }
+  }
+}

--- a/config/v0.4.json
+++ b/config/v0.4.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://awslabs.github.io/duvet/config/v0.4.json",
+  "title": "Duvet Configuration",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "report": {
+      "$ref": "#/definitions/Report"
+    },
+    "requirement": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Requirement"
+      }
+    },
+    "source": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Source"
+      }
+    },
+    "specification": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Specification"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "CommentStyle": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "default": "//#",
+          "type": "string"
+        },
+        "meta": {
+          "default": "//=",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DefaultType": {
+      "type": "string",
+      "enum": [
+        "implementation",
+        "spec",
+        "test",
+        "exception",
+        "todo",
+        "implication"
+      ]
+    },
+    "HtmlReport": {
+      "type": "object",
+      "properties": {
+        "blob-link": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TemplatedString"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "issue-link": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TemplatedString"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path": {
+          "default": ".duvet/reports/report.html",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "JsonReport": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "path": {
+          "default": ".duvet/reports/report.json",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Report": {
+      "type": "object",
+      "properties": {
+        "html": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HtmlReport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "json": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JsonReport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Requirement": {
+      "type": "object",
+      "required": [
+        "pattern"
+      ],
+      "properties": {
+        "pattern": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Source": {
+      "type": "object",
+      "required": [
+        "pattern"
+      ],
+      "properties": {
+        "comment-style": {
+          "$ref": "#/definitions/CommentStyle"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/DefaultType"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Specification": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SpecificationFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SpecificationFormat": {
+      "type": "string",
+      "enum": [
+        "ietf",
+        "markdown"
+      ]
+    },
+    "TemplatedString": {
+      "type": "string"
+    }
+  }
+}

--- a/duvet-core/src/artifact.rs
+++ b/duvet-core/src/artifact.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 /// Synchronizes a value to the file system
 ///
-/// When the `CI` environment variable is set, this method ensures the value matches
+/// When the `CI` environment variable is set, this method asserts the value matches
 /// what is on disk.
 pub fn sync(path: impl AsRef<Path>, value: impl AsRef<str>) {
     let path = path.as_ref();

--- a/duvet-core/src/artifact.rs
+++ b/duvet-core/src/artifact.rs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+/// Synchronizes a value to the file system
+///
+/// When the `CI` environment variable is set, this method ensures the value matches
+/// what is on disk.
+pub fn sync(path: impl AsRef<Path>, value: impl AsRef<str>) {
+    let path = path.as_ref();
+    let value = value.as_ref();
+    if std::env::var("CI").is_err() {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, value).unwrap();
+        return;
+    }
+
+    let actual = std::fs::read_to_string(path).unwrap();
+    assert_eq!(actual, value);
+}

--- a/duvet-core/src/lib.rs
+++ b/duvet-core/src/lib.rs
@@ -16,6 +16,8 @@ macro_rules! ensure {
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
+#[cfg(any(test, feature = "testing"))]
+pub mod artifact;
 mod cache;
 pub mod contents;
 pub mod diagnostic;

--- a/duvet/Cargo.toml
+++ b/duvet/Cargo.toml
@@ -33,7 +33,9 @@ v_jsonescape = "0.7"
 
 [dev-dependencies]
 bolero = "0.12"
+duvet-core = { version = "0.1", path = "../duvet-core", features = ["testing"] }
 insta = { version = "1", features = ["filters", "json"] }
+schemars = "0.8"
 serde_json = "1"
 strip-ansi-escapes = "0.2"
 tempfile = "3"

--- a/duvet/src/annotation.rs
+++ b/duvet/src/annotation.rs
@@ -29,7 +29,7 @@ pub type AnnotationReferenceMap =
 
 pub async fn specifications(
     annotations: AnnotationSet,
-    spec_path: Option<Path>,
+    spec_path: Path,
 ) -> Result<SpecificationMap> {
     let mut targets = TargetSet::new();
     for anno in annotations.iter() {

--- a/duvet/src/comment/snapshots/duvet__comment__tests__missing_new_line.snap
+++ b/duvet/src/comment/snapshots/duvet__comment__tests__missing_new_line.snap
@@ -1,6 +1,6 @@
 ---
 source: duvet/src/comment/tests.rs
-expression: "parse(\"//=,//#\",\nr#\"\n    //= https://example.com/spec.txt\n    //# Here is my citation\"#)"
+expression: "parse(\"//@=,//@#\",\nr#\"\n    //@= https://example.com/spec.txt\n    //@# Here is my citation\"#)"
 ---
 (
     {
@@ -8,7 +8,7 @@ expression: "parse(\"//=,//#\",\nr#\"\n    //= https://example.com/spec.txt\n   
             source: "file.rs",
             anno_line: 2,
             original_target: "https://example.com/spec.txt",
-            original_text: "https://example.com/spec.txt\n    //# Here is my citation",
+            original_text: "https://example.com/spec.txt\n    //@# Here is my citation",
             original_quote: "Here is my citation",
             anno: Citation,
             target: "https://example.com/spec.txt",

--- a/duvet/src/comment/snapshots/duvet__comment__tests__type_citation.snap
+++ b/duvet/src/comment/snapshots/duvet__comment__tests__type_citation.snap
@@ -1,6 +1,6 @@
 ---
 source: duvet/src/comment/tests.rs
-expression: "parse(\"//=,//#\",\nr#\"\n    //= https://example.com/spec.txt\n    //# Here is my citation\n    \"#)"
+expression: "parse(\"//@=,//@#\",\nr#\"\n    //@= https://example.com/spec.txt\n    //@# Here is my citation\n    \"#)"
 ---
 (
     {
@@ -8,7 +8,7 @@ expression: "parse(\"//=,//#\",\nr#\"\n    //= https://example.com/spec.txt\n   
             source: "file.rs",
             anno_line: 2,
             original_target: "https://example.com/spec.txt",
-            original_text: "https://example.com/spec.txt\n    //# Here is my citation",
+            original_text: "https://example.com/spec.txt\n    //@# Here is my citation",
             original_quote: "Here is my citation",
             anno: Citation,
             target: "https://example.com/spec.txt",

--- a/duvet/src/comment/snapshots/duvet__comment__tests__type_exception.snap
+++ b/duvet/src/comment/snapshots/duvet__comment__tests__type_exception.snap
@@ -1,6 +1,6 @@
 ---
 source: duvet/src/comment/tests.rs
-expression: "parse(\"//=,//#\",\nr#\"\n    //= https://example.com/spec.txt\n    //= type=exception\n    //= reason=This isn't possible currently\n    //# Here is my citation\n    \"#)"
+expression: "parse(\"//@=,//@#\",\nr#\"\n    //@= https://example.com/spec.txt\n    //@= type=exception\n    //@= reason=This isn't possible currently\n    //@# Here is my citation\n    \"#)"
 ---
 (
     {
@@ -8,7 +8,7 @@ expression: "parse(\"//=,//#\",\nr#\"\n    //= https://example.com/spec.txt\n   
             source: "file.rs",
             anno_line: 2,
             original_target: "https://example.com/spec.txt",
-            original_text: "https://example.com/spec.txt\n    //= type=exception\n    //= reason=This isn't possible currently\n    //# Here is my citation",
+            original_text: "https://example.com/spec.txt\n    //@= type=exception\n    //@= reason=This isn't possible currently\n    //@# Here is my citation",
             original_quote: "Here is my citation",
             anno: Exception,
             target: "https://example.com/spec.txt",

--- a/duvet/src/comment/snapshots/duvet__comment__tests__type_test.snap
+++ b/duvet/src/comment/snapshots/duvet__comment__tests__type_test.snap
@@ -1,6 +1,6 @@
 ---
 source: duvet/src/comment/tests.rs
-expression: "parse(\"//=,//#\",\nr#\"\n    //= https://example.com/spec.txt\n    //= type=test\n    //# Here is my citation\n    \"#)"
+expression: "parse(\"//@=,//@#\",\nr#\"\n    //@= https://example.com/spec.txt\n    //@= type=test\n    //@# Here is my citation\n    \"#)"
 ---
 (
     {
@@ -8,7 +8,7 @@ expression: "parse(\"//=,//#\",\nr#\"\n    //= https://example.com/spec.txt\n   
             source: "file.rs",
             anno_line: 2,
             original_target: "https://example.com/spec.txt",
-            original_text: "https://example.com/spec.txt\n    //= type=test\n    //# Here is my citation",
+            original_text: "https://example.com/spec.txt\n    //@= type=test\n    //@# Here is my citation",
             original_quote: "Here is my citation",
             anno: Test,
             target: "https://example.com/spec.txt",

--- a/duvet/src/comment/snapshots/duvet__comment__tests__type_todo.snap
+++ b/duvet/src/comment/snapshots/duvet__comment__tests__type_todo.snap
@@ -1,6 +1,6 @@
 ---
 source: duvet/src/comment/tests.rs
-expression: "parse(\"//=,//#\",\nr#\"\n    //= https://example.com/spec.txt\n    //= type=todo\n    //= feature=cool-things\n    //= tracking-issue=123\n    //# Here is my citation\n    \"#)"
+expression: "parse(\"//@=,//@#\",\nr#\"\n    //@= https://example.com/spec.txt\n    //@= type=todo\n    //@= feature=cool-things\n    //@= tracking-issue=123\n    //@# Here is my citation\n    \"#)"
 ---
 (
     {
@@ -8,7 +8,7 @@ expression: "parse(\"//=,//#\",\nr#\"\n    //= https://example.com/spec.txt\n   
             source: "file.rs",
             anno_line: 2,
             original_target: "https://example.com/spec.txt",
-            original_text: "https://example.com/spec.txt\n    //= type=todo\n    //= feature=cool-things\n    //= tracking-issue=123\n    //# Here is my citation",
+            original_text: "https://example.com/spec.txt\n    //@= type=todo\n    //@= feature=cool-things\n    //@= tracking-issue=123\n    //@# Here is my citation",
             original_quote: "Here is my citation",
             anno: Todo,
             target: "https://example.com/spec.txt",

--- a/duvet/src/comment/tests.rs
+++ b/duvet/src/comment/tests.rs
@@ -13,7 +13,8 @@ fn parse(pattern: &str, value: &str) -> (AnnotationSet, Vec<String>) {
 
 macro_rules! snapshot {
     ($name:ident, $value:expr) => {
-        snapshot!($name, "//=,//#", $value);
+        // use a different pattern so we don't register these tests as part of the duvet report
+        snapshot!($name, "//@=,//@#", $value);
     };
     ($name:ident, $pattern:expr, $value:expr) => {
         #[test]
@@ -38,58 +39,58 @@ macro_rules! snapshot {
 snapshot!(
     content_without_meta,
     r#"
-    //# This is some content without meta
+    //@# This is some content without meta
     "#
 );
 
 snapshot!(
     meta_without_content,
     r#"
-    //= type=todo
+    //@= type=todo
     "#
 );
 
 snapshot!(
     type_citation,
     r#"
-    //= https://example.com/spec.txt
-    //# Here is my citation
+    //@= https://example.com/spec.txt
+    //@# Here is my citation
     "#
 );
 
 snapshot!(
     type_test,
     r#"
-    //= https://example.com/spec.txt
-    //= type=test
-    //# Here is my citation
+    //@= https://example.com/spec.txt
+    //@= type=test
+    //@# Here is my citation
     "#
 );
 
 snapshot!(
     type_todo,
     r#"
-    //= https://example.com/spec.txt
-    //= type=todo
-    //= feature=cool-things
-    //= tracking-issue=123
-    //# Here is my citation
+    //@= https://example.com/spec.txt
+    //@= type=todo
+    //@= feature=cool-things
+    //@= tracking-issue=123
+    //@# Here is my citation
     "#
 );
 
 snapshot!(
     type_exception,
     r#"
-    //= https://example.com/spec.txt
-    //= type=exception
-    //= reason=This isn't possible currently
-    //# Here is my citation
+    //@= https://example.com/spec.txt
+    //@= type=exception
+    //@= reason=This isn't possible currently
+    //@# Here is my citation
     "#
 );
 
 snapshot!(
     missing_new_line,
     r#"
-    //= https://example.com/spec.txt
-    //# Here is my citation"#
+    //@= https://example.com/spec.txt
+    //@# Here is my citation"#
 );

--- a/duvet/src/comment/tokenizer.rs
+++ b/duvet/src/comment/tokenizer.rs
@@ -126,8 +126,8 @@ mod tests {
                 $name,
                 $input,
                 Pattern {
-                    meta: "//=".into(),
-                    content: "//#".into(),
+                    meta: "//@=".into(),
+                    content: "//@#".into(),
                 }
             );
         };
@@ -146,25 +146,25 @@ mod tests {
     snapshot_test!(
         basic,
         r#"
-        //= thing goes here
-        //= meta=foo
-        //= meta2 = bar
-        //# content goes
-        //# here
+        //@= thing goes here
+        //@= meta=foo
+        //@= meta2 = bar
+        //@# content goes
+        //@# here
         "#
     );
     snapshot_test!(
         only_unnamed,
         r#"
-        //= this is meta
-        //= this is other meta
+        //@= this is meta
+        //@= this is other meta
         "#
     );
     snapshot_test!(
         duplicate_meta,
         r#"
-        //= meta=1
-        //= meta=2
+        //@= meta=1
+        //@= meta=2
         "#
     );
     snapshot_test!(

--- a/duvet/src/config.rs
+++ b/duvet/src/config.rs
@@ -1,0 +1,128 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{extract::Extraction, Result};
+use duvet_core::{path::Path, vfs};
+use std::sync::Arc;
+
+pub mod schema;
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub sources: Vec<Source>,
+    pub requirements: Vec<Requirement>,
+    pub specifications: Vec<Specification>,
+    pub report: Report,
+    pub requirements_path: Path,
+    pub download_path: Path,
+}
+
+impl Config {
+    pub async fn load_specifications(&self) -> Result<usize> {
+        let download_path = &self.download_path;
+        let requirements_path = &self.requirements_path;
+
+        for spec in &self.specifications {
+            Extraction {
+                download_path,
+                base_path: Some(download_path),
+                target: spec.target.clone(),
+                out: requirements_path,
+                extension: "toml",
+                // don't log to reduce noise
+                log: false,
+            }
+            .exec()
+            .await?;
+        }
+
+        Ok(self.specifications.len())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Source {
+    pub pattern: String,
+    pub root: Path,
+    pub comment_style: crate::comment::Pattern,
+    pub default_type: crate::annotation::AnnotationType,
+}
+
+#[derive(Clone, Debug)]
+pub struct Requirement {
+    pub pattern: String,
+    pub root: Path,
+}
+
+#[derive(Clone, Debug)]
+pub struct Report {
+    pub html: HtmlReport,
+    pub json: JsonReport,
+}
+
+#[derive(Clone, Debug)]
+pub struct HtmlReport {
+    pub enabled: bool,
+    pub path: Path,
+    pub blob_link: Option<Arc<str>>,
+    pub issue_link: Option<Arc<str>>,
+}
+
+impl HtmlReport {
+    pub fn path(&self) -> Option<&Path> {
+        Some(&self.path).filter(|_| self.enabled)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct JsonReport {
+    pub enabled: bool,
+    pub path: Path,
+}
+
+impl JsonReport {
+    pub fn path(&self) -> Option<&Path> {
+        Some(&self.path).filter(|_| self.enabled)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Specification {
+    pub target: Arc<crate::target::Target>,
+}
+
+pub async fn load(path: Path, root: Path) -> Result<Arc<Config>> {
+    let file = vfs::read_string(path.clone()).await?;
+    let schema: Arc<schema::Schema> = file.as_toml().await?;
+
+    let mut sources = vec![];
+    let mut requirements = vec![];
+    let mut specifications = vec![];
+
+    schema.load_sources(&mut sources, &root)?;
+    schema.load_requirements(&mut requirements, &root)?;
+    schema.load_specifications(&mut specifications, &root)?;
+
+    let requirements_path = schema.requirements_path(&path, &root);
+    let download_path = schema.download_path(&path, &root);
+    let report = schema.report(&path, &root);
+
+    Ok(Arc::new(Config {
+        sources,
+        requirements,
+        specifications,
+        requirements_path,
+        download_path,
+        report,
+    }))
+}
+
+pub async fn default_path_and_root() -> Option<(Path, Path)> {
+    let root = duvet_core::env::current_dir().ok()?;
+    let path = root.join(".duvet").join("config.toml");
+
+    // check to see if it exists
+    let _ = vfs::read_metadata(&path).await.ok()?;
+
+    Some((path, root))
+}

--- a/duvet/src/config/schema.rs
+++ b/duvet/src/config/schema.rs
@@ -1,0 +1,149 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{str::FromStr, sync::Arc};
+
+use crate::{config, Result};
+use duvet_core::{error, path::Path};
+use serde::{de, Deserialize};
+
+pub mod v0_4_0;
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "$schema", deny_unknown_fields)]
+pub enum Schema {
+    #[serde(
+        rename = "https://awslabs.github.io/duvet/config/v0.4.0.json",
+        alias = "https://awslabs.github.io/duvet/config/v0.4.0.json#",
+        alias = "https://awslabs.github.io/duvet/config/v0.4.json",
+        alias = "https://awslabs.github.io/duvet/config/v0.4.json#"
+    )]
+    V1_0_0(v0_4_0::Schema),
+}
+
+impl Schema {
+    pub fn load_sources(&self, sources: &mut Vec<config::Source>, root: &Path) -> Result {
+        match self {
+            Schema::V1_0_0(schema) => schema.load_sources(sources, root),
+        }
+    }
+
+    pub fn load_requirements(
+        &self,
+        requirements: &mut Vec<config::Requirement>,
+        root: &Path,
+    ) -> Result {
+        match self {
+            Schema::V1_0_0(schema) => schema.load_requirements(requirements, root),
+        }
+    }
+
+    pub fn load_specifications(
+        &self,
+        specifications: &mut Vec<config::Specification>,
+        root: &Path,
+    ) -> Result {
+        match self {
+            Schema::V1_0_0(schema) => schema.load_specifications(specifications, root),
+        }
+    }
+
+    pub fn download_path(&self, config: &Path, root: &Path) -> Path {
+        match self {
+            Schema::V1_0_0(schema) => schema.download_path(config, root),
+        }
+    }
+
+    pub fn requirements_path(&self, config: &Path, root: &Path) -> Path {
+        match self {
+            Schema::V1_0_0(schema) => schema.requirements_path(config, root),
+        }
+    }
+
+    pub fn report(&self, config: &Path, root: &Path) -> config::Report {
+        match self {
+            Schema::V1_0_0(schema) => schema.report(config, root),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct TemplatedString(Arc<str>);
+
+impl FromStr for TemplatedString {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let mut out = String::new();
+
+        for (idx, part) in s.split("${{").enumerate() {
+            if idx == 0 {
+                out.push_str(part);
+                continue;
+            }
+
+            let close = "}}";
+            let (expr, rest) = part
+                .split_once(close)
+                .ok_or_else(|| error!("expected {close:?}"))?;
+
+            let mut value = None;
+
+            for choice in expr.split("||") {
+                let choice = choice.trim();
+                if let Some(choice) = choice.strip_prefix('\'') {
+                    let choice = choice.trim_end_matches('\'');
+                    value = Some(choice.to_string());
+                    break;
+                } else if let Ok(v) = std::env::var(choice) {
+                    value = Some(v);
+                    break;
+                }
+            }
+
+            let Some(value) = value else {
+                return Err(error!("failed to evaluate expression: {expr:?}"));
+            };
+
+            out.push_str(&value);
+            out.push_str(rest);
+        }
+
+        Ok(Self(out.into()))
+    }
+}
+
+impl From<&TemplatedString> for Arc<str> {
+    fn from(value: &TemplatedString) -> Self {
+        value.0.clone()
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TemplatedString {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use core::fmt;
+
+        struct Visitor;
+
+        impl de::Visitor<'_> for Visitor {
+            type Value = TemplatedString;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("string")
+            }
+
+            fn visit_str<E>(self, tmpl: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                tmpl.parse().map_err(de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(Visitor)
+    }
+}

--- a/duvet/src/config/schema/v0_4_0.rs
+++ b/duvet/src/config/schema/v0_4_0.rs
@@ -1,0 +1,356 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    annotation::AnnotationType,
+    config,
+    target::{Target, TargetPath},
+};
+use duvet_core::{diagnostic::IntoDiagnostic, path::Path, Result};
+use serde::Deserialize;
+use std::sync::Arc;
+
+use super::TemplatedString;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct Schema {
+    #[serde(default, rename = "source")]
+    pub sources: Arc<[Source]>,
+
+    #[serde(default, rename = "requirement")]
+    pub requirements: Arc<[Requirement]>,
+
+    #[serde(default)]
+    pub report: Arc<Report>,
+
+    #[serde(default, rename = "specification")]
+    pub specifications: Arc<[Specification]>,
+
+    #[serde(rename = "$schema")]
+    _schema: Option<Arc<str>>,
+}
+
+impl Schema {
+    pub fn load_sources(&self, sources: &mut Vec<config::Source>, root: &Path) -> Result {
+        for source in self.sources.iter() {
+            sources.push(config::Source {
+                // TODO add context to error
+                pattern: source.pattern.parse().into_diagnostic()?,
+                comment_style: (&source.comment_style).into(),
+                default_type: source.default_type.into(),
+                root: root.clone(),
+            });
+        }
+
+        Ok(())
+    }
+
+    pub fn load_requirements(
+        &self,
+        requirements: &mut Vec<config::Requirement>,
+        root: &Path,
+    ) -> Result {
+        // include several default paths
+        for pattern in [
+            ".duvet/requirements/**/*.toml",
+            ".duvet/todos/**/*.toml",
+            ".duvet/exceptions/**/*.toml",
+        ] {
+            requirements.push(config::Requirement {
+                pattern: pattern.parse().into_diagnostic()?,
+                root: root.clone(),
+            })
+        }
+
+        for requirement in self.requirements.iter() {
+            requirements.push(config::Requirement {
+                // TODO add context to error
+                pattern: requirement.pattern.parse().into_diagnostic()?,
+                root: root.clone(),
+            });
+        }
+
+        Ok(())
+    }
+
+    pub fn load_specifications(
+        &self,
+        specifications: &mut Vec<config::Specification>,
+        _root: &Path,
+    ) -> Result {
+        for spec in self.specifications.iter() {
+            let path = spec.source.parse::<TargetPath>()?;
+            let format = spec
+                .format
+                .map(From::from)
+                .unwrap_or_else(|| crate::specification::Format::Auto);
+
+            let target = Target { path, format }.into();
+            specifications.push(config::Specification { target });
+        }
+
+        Ok(())
+    }
+
+    pub fn download_path(&self, config: &Path, _root: &Path) -> Path {
+        config.parent().unwrap().join("specifications").into()
+    }
+
+    pub fn requirements_path(&self, config: &Path, _root: &Path) -> Path {
+        config.parent().unwrap().join("requirements").into()
+    }
+
+    pub fn report(&self, _config: &Path, _root: &Path) -> config::Report {
+        (&*self.report).into()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct Source {
+    pub pattern: String,
+    #[serde(default, rename = "comment-style")]
+    pub comment_style: CommentStyle,
+    #[serde(rename = "type", default)]
+    pub default_type: DefaultType,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub enum DefaultType {
+    #[default]
+    #[serde(rename = "implementation")]
+    Implementation,
+    #[serde(rename = "spec")]
+    Spec,
+    #[serde(rename = "test")]
+    Test,
+    #[serde(rename = "exception")]
+    Exception,
+    #[serde(rename = "todo")]
+    Todo,
+    #[serde(rename = "implication")]
+    Implication,
+}
+
+impl From<DefaultType> for AnnotationType {
+    fn from(value: DefaultType) -> Self {
+        match value {
+            DefaultType::Implementation => Self::Citation,
+            DefaultType::Spec => Self::Spec,
+            DefaultType::Test => Self::Test,
+            DefaultType::Todo => Self::Todo,
+            DefaultType::Exception => Self::Exception,
+            DefaultType::Implication => Self::Implication,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct CommentStyle {
+    #[serde(default = "default_meta")]
+    pub meta: Arc<str>,
+    #[serde(default = "default_content")]
+    pub content: Arc<str>,
+}
+
+fn default_meta() -> Arc<str> {
+    Arc::from("//=")
+}
+
+fn default_content() -> Arc<str> {
+    Arc::from("//#")
+}
+
+impl Default for CommentStyle {
+    fn default() -> Self {
+        Self {
+            meta: default_meta(),
+            content: default_content(),
+        }
+    }
+}
+
+impl From<&CommentStyle> for crate::comment::Pattern {
+    fn from(value: &CommentStyle) -> Self {
+        Self {
+            meta: value.meta.clone(),
+            content: value.content.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct Requirement {
+    pub pattern: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct Report {
+    #[serde(default)]
+    pub html: Option<HtmlReport>,
+    #[serde(default)]
+    pub json: Option<JsonReport>,
+}
+
+impl From<&Report> for config::Report {
+    fn from(value: &Report) -> Self {
+        Self {
+            html: value
+                .html
+                .as_ref()
+                .map(From::from)
+                .unwrap_or_else(|| (&HtmlReport::default()).into()),
+            json: value
+                .json
+                .as_ref()
+                .map(From::from)
+                .unwrap_or_else(|| (&JsonReport::default()).into()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct HtmlReport {
+    #[serde(default = "HtmlReport::default_enabled")]
+    pub enabled: bool,
+    #[serde(default = "HtmlReport::default_path")]
+    pub path: String,
+    #[serde(default, rename = "blob-link")]
+    pub blob_link: Option<TemplatedString>,
+    #[serde(default, rename = "issue-link")]
+    pub issue_link: Option<TemplatedString>,
+}
+
+impl Default for HtmlReport {
+    fn default() -> Self {
+        Self {
+            enabled: Self::default_enabled(),
+            path: Self::default_path(),
+            blob_link: None,
+            issue_link: None,
+        }
+    }
+}
+
+impl HtmlReport {
+    fn default_enabled() -> bool {
+        true
+    }
+
+    fn default_path() -> String {
+        ".duvet/reports/report.html".into()
+    }
+}
+
+impl From<&HtmlReport> for config::HtmlReport {
+    fn from(value: &HtmlReport) -> Self {
+        Self {
+            enabled: value.enabled,
+            path: value.path.as_str().into(),
+            issue_link: value.issue_link.as_ref().map(From::from),
+            blob_link: value.blob_link.as_ref().map(From::from),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct JsonReport {
+    #[serde(default = "JsonReport::default_enabled")]
+    pub enabled: bool,
+    #[serde(default = "JsonReport::default_path")]
+    pub path: String,
+}
+
+impl Default for JsonReport {
+    fn default() -> Self {
+        Self {
+            enabled: Self::default_enabled(),
+            path: Self::default_path(),
+        }
+    }
+}
+
+impl JsonReport {
+    fn default_enabled() -> bool {
+        false
+    }
+
+    fn default_path() -> String {
+        ".duvet/reports/report.json".into()
+    }
+}
+
+impl From<&JsonReport> for config::JsonReport {
+    fn from(value: &JsonReport) -> Self {
+        Self {
+            enabled: value.enabled,
+            path: value.path.as_str().into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct Specification {
+    #[serde(default)]
+    pub source: String,
+    pub format: Option<SpecificationFormat>,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub enum SpecificationFormat {
+    #[serde(rename = "ietf", alias = "IETF")]
+    Ietf,
+    #[serde(rename = "markdown", alias = "md")]
+    Markdown,
+}
+
+impl From<SpecificationFormat> for crate::specification::Format {
+    fn from(value: SpecificationFormat) -> Self {
+        match value {
+            SpecificationFormat::Ietf => Self::Ietf,
+            SpecificationFormat::Markdown => Self::Markdown,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_test() {
+        let mut schema = schemars::schema_for!(Schema);
+
+        let metadata = schema.schema.metadata();
+        metadata.title = Some("Duvet Configuration".into());
+        metadata.id = Some("https://awslabs.github.io/duvet/config/v0.4.0.json".into());
+        duvet_core::artifact::sync(
+            concat!(env!("CARGO_MANIFEST_DIR"), "/../config/v0.4.0.json"),
+            serde_json::to_string_pretty(&schema).unwrap(),
+        );
+
+        let metadata = schema.schema.metadata();
+        metadata.id = Some("https://awslabs.github.io/duvet/config/v0.4.json".into());
+        duvet_core::artifact::sync(
+            concat!(env!("CARGO_MANIFEST_DIR"), "/../config/v0.4.json"),
+            serde_json::to_string_pretty(&schema).unwrap(),
+        );
+    }
+}

--- a/duvet/src/lib.rs
+++ b/duvet/src/lib.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 mod annotation;
 mod comment;
+mod config;
 mod extract;
 mod project;
 mod reference;

--- a/duvet/src/report/lcov.rs
+++ b/duvet/src/report/lcov.rs
@@ -39,6 +39,7 @@ macro_rules! record {
 pub fn report(report: &ReportResult, dir: &Path) -> Result {
     std::fs::create_dir_all(dir)?;
     let lcov_dir = dir.canonicalize()?;
+    let download_path = &report.download_path;
     report
         .targets
         .iter()
@@ -46,7 +47,7 @@ pub fn report(report: &ReportResult, dir: &Path) -> Result {
         .try_for_each(|(id, (source, report))| {
             let path = lcov_dir.join(format!("compliance.{}.lcov", id));
             let mut output = BufWriter::new(std::fs::File::create(path)?);
-            report_source(source, report, &mut output)?;
+            report_source(source, report, download_path, &mut output)?;
             <Result>::Ok(())
         })?;
     Ok(())
@@ -56,6 +57,7 @@ pub fn report(report: &ReportResult, dir: &Path) -> Result {
 fn report_source<Output: Write>(
     source: &Target,
     report: &TargetReport,
+    download_path: &Path,
     output: &mut Output,
 ) -> Result {
     macro_rules! put {
@@ -65,7 +67,7 @@ fn report_source<Output: Write>(
     }
 
     put!("TN:Compliance");
-    let relative = source.path.local(None);
+    let relative = source.path.local(download_path);
     put!("SF:{}", relative.display());
 
     // record all sections

--- a/duvet/src/source.rs
+++ b/duvet/src/source.rs
@@ -1,22 +1,33 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{annotation::AnnotationSet, comment, Error};
+use crate::{
+    annotation::{AnnotationSet, AnnotationType},
+    comment, Error,
+};
 use duvet_core::path::Path;
 
 pub mod toml;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub enum SourceFile {
-    Text(comment::Pattern, Path),
+    Text {
+        pattern: comment::Pattern,
+        default_type: AnnotationType,
+        path: Path,
+    },
     Toml(Path),
 }
 
 impl SourceFile {
     pub async fn annotations(&self) -> (AnnotationSet, Vec<Error>) {
         match self {
-            Self::Text(pattern, file) => match duvet_core::vfs::read_string(file).await {
-                Ok(text) => comment::extract(&text, pattern, Default::default()),
+            Self::Text {
+                pattern,
+                default_type,
+                path,
+            } => match duvet_core::vfs::read_string(path).await {
+                Ok(text) => comment::extract(&text, pattern, *default_type),
                 Err(err) => (Default::default(), vec![err]),
             },
             Self::Toml(file) => toml::load(file).await,

--- a/duvet/src/text/find.rs
+++ b/duvet/src/text/find.rs
@@ -50,7 +50,7 @@ fn fast_find(needle: &str, haystack: &str) -> Option<Range<usize>> {
     })
 }
 
-/// TODO we should probaly deprecate this - it's better to enforce strict matching
+/// TODO we should probably deprecate this - it's better to enforce strict matching
 fn fuzzy_find(needle: &str, haystack: &str) -> Option<Range<usize>> {
     text_search(
         needle.as_bytes(),


### PR DESCRIPTION
*Description of changes:*

This change adds support for config files for configuring `duvet`, rather than CLI arguments. This should standardize how customers set up their repositories/reports and avoid having one-off scripts everywhere:

* https://github.com/aws/s2n-quic/blob/main/scripts/compliance
* https://github.com/aws/s2n-tls/blob/main/compliance/generate_report.sh
* https://github.com/hyperium/h3/blob/master/ci/compliance/report.sh
* https://github.com/aws/aws-encryption-sdk-dafny/blob/c3ba5e314e1118efb1fd663c85e3d56578622b91/Makefile#L12-L31

The config location is `.duvet/config.toml`. All of the artifacts and `toml` files are stored alongside in `.duvet/`. I've included [a config file](https://github.com/awslabs/duvet/blob/dd828403ed1b6973654ba93b371ba739a21005f1/.duvet/config.toml) for the duvet repo itself:

```toml
'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"

[[source]]
pattern = "duvet/**/*.rs"

[report.html]
enabled = true
issue-link = "https://github.com/awslabs/duvet/issues"
blob-link = "https://github.com/awslabs/duvet/blob/${{ GITHUB_SHA || 'main' }}"

[report.json]
enabled = true
```

With a config file, generating a report no longer requires any arguments:

```console
$ duvet report
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
