### PR TITLE
docs: include READMEs for individual crates

### DIFF
--- a/duvet-core/Cargo.toml
+++ b/duvet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duvet-core"
-version = "0.4.0"
+version = "0.4.1"
 description = "Internal crate used by duvet"
 authors = ["Cameron Bytheway <bythewc@amazon.com>"]
 edition = "2021"

--- a/duvet-core/README.md
+++ b/duvet-core/README.md
@@ -1,0 +1,10 @@
+# duvet-core
+
+This is an internal crate used by [duvet](https://github.com/awslabs/duvet). The API is not currently stable and should not be used directly.
+
+## License
+
+This project is licensed under the [Apache-2.0 License][license-url].
+
+[license-badge]: https://img.shields.io/badge/license-apache-blue.svg
+[license-url]: https://aws.amazon.com/apache-2-0/

--- a/duvet-macros/Cargo.toml
+++ b/duvet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duvet-macros"
-version = "0.4.0"
+version = "0.4.1"
 description = "Internal crate used by duvet"
 authors = ["Cameron Bytheway <bythewc@amazon.com>"]
 edition = "2021"

--- a/duvet-macros/README.md
+++ b/duvet-macros/README.md
@@ -1,0 +1,10 @@
+# duvet-macros
+
+This is an internal crate used by [duvet](https://github.com/awslabs/duvet). The API is not currently stable and should not be used directly.
+
+## License
+
+This project is licensed under the [Apache-2.0 License][license-url].
+
+[license-badge]: https://img.shields.io/badge/license-apache-blue.svg
+[license-url]: https://aws.amazon.com/apache-2-0/

--- a/duvet/Cargo.toml
+++ b/duvet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duvet"
-version = "0.4.0"
+version = "0.4.1"
 description = "A requirements traceability tool"
 authors = [
     "Cameron Bytheway <bythewc@amazon.com>",

--- a/duvet/README.md
+++ b/duvet/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
*Description of changes:*

After publishing `0.4.0` I realized each one of the crates needs its own readme, otherwise it's rendered blank: https://crates.io/crates/duvet/0.4.0.

This change puts READMEs in each of the crates and bumps to `0.4.1` so the crates version can include the correct readme.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
