### PR TITLE
Increase MSRV and enable Markdown heading attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-10-07
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2025-05-20
 
 jobs:
   env:

--- a/duvet-core/Cargo.toml
+++ b/duvet-core/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Cameron Bytheway <bythewc@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/duvet"
+rust-version = "1.82"
 
 [features]
 default = ["diff", "http"]

--- a/duvet-macros/Cargo.toml
+++ b/duvet-macros/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Cameron Bytheway <bythewc@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/duvet"
+rust-version = "1.82"
 
 [lib]
 proc-macro = true

--- a/duvet/Cargo.toml
+++ b/duvet/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 repository = "https://github.com/awslabs/duvet"
 include = ["/src/**/*.rs", "/www/public"]
 default-run = "duvet"
+rust-version = "1.82"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/duvet/src/specification/ietf/snapshots.tar.gz
+++ b/duvet/src/specification/ietf/snapshots.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:479ca01f7406f6d7784de9cde820fe6e4de7d22491d9cd76039d1cb17d0e6826
-size 574638080
+oid sha256:2cdfabea8c45af7b7741717788e5dba44fcf10aacd2b6e25468009cb902d966f
+size 135902532

--- a/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__heading_attributes__tokens.snap
+++ b/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__heading_attributes__tokens.snap
@@ -1,0 +1,64 @@
+---
+source: duvet/src/specification/markdown/tests.rs
+expression: "super :: tokens(& contents).collect :: < Vec < _ >> ()"
+---
+[
+    Content {
+        value: "",
+        line: 1,
+    },
+    Section {
+        id: Some(
+            "custom-id",
+        ),
+        title: "Heading with ID",
+        level: 1,
+        line: 2,
+    },
+    Content {
+        value: "",
+        line: 3,
+    },
+    Content {
+        value: "Content under heading with custom ID.",
+        line: 4,
+    },
+    Content {
+        value: "",
+        line: 5,
+    },
+    Section {
+        id: Some(
+            "another-id",
+        ),
+        title: "Another heading",
+        level: 2,
+        line: 6,
+    },
+    Content {
+        value: "",
+        line: 7,
+    },
+    Content {
+        value: "More content here.",
+        line: 8,
+    },
+    Content {
+        value: "",
+        line: 9,
+    },
+    Section {
+        id: None,
+        title: "Regular heading",
+        level: 1,
+        line: 10,
+    },
+    Content {
+        value: "",
+        line: 11,
+    },
+    Content {
+        value: "This heading doesn't have a custom ID.",
+        line: 12,
+    },
+]

--- a/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__heading_attributes__tree.snap
+++ b/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__heading_attributes__tree.snap
@@ -1,0 +1,44 @@
+---
+source: duvet/src/specification/markdown/tests.rs
+expression: "super :: parse(& contents)"
+---
+Ok(
+    Specification {
+        title: Some(
+            "Heading with ID",
+        ),
+        sections: [
+            Section {
+                id: "custom-id",
+                title: "Heading with ID",
+                full_title: "Heading with ID",
+                lines: [
+                    Str(
+                        "Content under heading with custom ID.",
+                    ),
+                ],
+            },
+            Section {
+                id: "another-id",
+                title: "Another heading",
+                full_title: "Another heading",
+                lines: [
+                    Str(
+                        "More content here.",
+                    ),
+                ],
+            },
+            Section {
+                id: "regular-heading",
+                title: "Regular heading",
+                full_title: "Regular heading",
+                lines: [
+                    Str(
+                        "This heading doesn't have a custom ID.",
+                    ),
+                ],
+            },
+        ],
+        format: Markdown,
+    },
+)

--- a/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__multi_line_header_link_heading_attrs__tokens.snap
+++ b/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__multi_line_header_link_heading_attrs__tokens.snap
@@ -1,0 +1,30 @@
+---
+source: duvet/src/specification/markdown/tests.rs
+expression: "super :: tokens(& contents).collect :: < Vec < _ >> ()"
+---
+[
+    Content {
+        value: "",
+        line: 1,
+    },
+    Section {
+        id: Some(
+            "blah",
+        ),
+        title: "Foo **bar\nbaz** [I'm link](http://something)",
+        level: 1,
+        line: 2,
+    },
+    Content {
+        value: "",
+        line: 5,
+    },
+    Content {
+        value: "Content goes here. Another",
+        line: 6,
+    },
+    Content {
+        value: "sentence here.",
+        line: 7,
+    },
+]

--- a/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__multi_line_header_link_heading_attrs__tree.snap
+++ b/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__multi_line_header_link_heading_attrs__tree.snap
@@ -1,0 +1,27 @@
+---
+source: duvet/src/specification/markdown/tests.rs
+expression: "super :: parse(& contents)"
+---
+Ok(
+    Specification {
+        title: Some(
+            "Foo **bar baz** [I'm link](http://something)",
+        ),
+        sections: [
+            Section {
+                id: "blah",
+                title: "Foo **bar baz** [I'm link](http://something)",
+                full_title: "Foo **bar\nbaz** [I'm link](http://something)",
+                lines: [
+                    Str(
+                        "Content goes here. Another",
+                    ),
+                    Str(
+                        "sentence here.",
+                    ),
+                ],
+            },
+        ],
+        format: Markdown,
+    },
+)

--- a/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__multi_line_header_strong_heading_attrs__tokens.snap
+++ b/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__multi_line_header_strong_heading_attrs__tokens.snap
@@ -1,0 +1,30 @@
+---
+source: duvet/src/specification/markdown/tests.rs
+expression: "super :: tokens(& contents).collect :: < Vec < _ >> ()"
+---
+[
+    Content {
+        value: "",
+        line: 1,
+    },
+    Section {
+        id: Some(
+            "blah",
+        ),
+        title: "Foo **bar\nbaz**",
+        level: 1,
+        line: 2,
+    },
+    Content {
+        value: "",
+        line: 5,
+    },
+    Content {
+        value: "Content goes here. Another",
+        line: 6,
+    },
+    Content {
+        value: "sentence here.",
+        line: 7,
+    },
+]

--- a/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__multi_line_header_strong_heading_attrs__tree.snap
+++ b/duvet/src/specification/markdown/snapshots/duvet__specification__markdown__tests__multi_line_header_strong_heading_attrs__tree.snap
@@ -1,0 +1,27 @@
+---
+source: duvet/src/specification/markdown/tests.rs
+expression: "super :: parse(& contents)"
+---
+Ok(
+    Specification {
+        title: Some(
+            "Foo **bar baz**",
+        ),
+        sections: [
+            Section {
+                id: "blah",
+                title: "Foo **bar baz**",
+                full_title: "Foo **bar\nbaz**",
+                lines: [
+                    Str(
+                        "Content goes here. Another",
+                    ),
+                    Str(
+                        "sentence here.",
+                    ),
+                ],
+            },
+        ],
+        format: Markdown,
+    },
+)

--- a/duvet/src/specification/markdown/tests.rs
+++ b/duvet/src/specification/markdown/tests.rs
@@ -48,6 +48,30 @@ sentence here.
 );
 
 snapshot!(
+    multi_line_header_strong_heading_attrs,
+    r#"
+Foo **bar
+baz** {#blah}
+======
+
+Content goes here. Another
+sentence here.
+"#
+);
+
+snapshot!(
+    multi_line_header_link_heading_attrs,
+    r#"
+Foo **bar
+baz** [I'm link](http://something) {#blah}
+======
+
+Content goes here. Another
+sentence here.
+"#
+);
+
+snapshot!(
     multiple,
     r#"
 # This is a test
@@ -116,5 +140,22 @@ testing 123
 ## Duplicate header
 
 other test
+"#
+);
+
+snapshot!(
+    heading_attributes,
+    r#"
+# Heading with ID {#custom-id}
+
+Content under heading with custom ID.
+
+## Another heading {#another-id}
+
+More content here.
+
+# Regular heading
+
+This heading doesn't have a custom ID.
 "#
 );

--- a/integration/snapshots/report-invalid-quote_stderr.snap
+++ b/integration/snapshots/report-invalid-quote_stderr.snap
@@ -1,5 +1,6 @@
 ---
 source: xtask/src/tests.rs
+assertion_line: 284
 expression: stderr
 ---
 $ duvet report
@@ -15,9 +16,7 @@ EXIT: Some(1)
      Mapping sections
       Mapped 1 sections 
     Matching references
-
-  × 
-  │   × could not find text in section "section" of my-spec.md
+  ×   × could not find text in section "section" of my-spec.md
   │    ╭─[src/my-code.rs:2:5]
   │  1 │ //= my-spec.md#section
   │  2 │ //# Here is missing text

--- a/integration/snapshots/report-missing-section_stderr.snap
+++ b/integration/snapshots/report-missing-section_stderr.snap
@@ -1,5 +1,6 @@
 ---
 source: xtask/src/tests.rs
+assertion_line: 284
 expression: stderr
 ---
 $ duvet report
@@ -15,9 +16,7 @@ EXIT: Some(1)
      Mapping sections
       Mapped 1 sections 
     Matching references
-
-  × 
-  │   × missing section "foo" in my-spec.md
+  ×   × missing section "foo" in my-spec.md
   │    ╭─[src/my-code.rs:1:5]
   │  1 │ //= my-spec.md#foo
   │    ·     ───────┬──────

--- a/integration/snapshots/report-snapshot-missing_stderr.snap
+++ b/integration/snapshots/report-snapshot-missing_stderr.snap
@@ -1,5 +1,6 @@
 ---
 source: xtask/src/tests.rs
+assertion_line: 284
 expression: stderr
 ---
 $ duvet report --ci
@@ -21,6 +22,5 @@ EXIT: Some(1)
      Writing .duvet/reports/report.html
        Wrote .duvet/reports/report.html 
     Checking .duvet/snapshot.txt
-
   × .duvet/snapshot.txt
   ╰─▶ Could not read report snapshot. This is required to enforce CI checks.

--- a/integration/snapshots/report-snapshot-out-of-date_stderr.snap
+++ b/integration/snapshots/report-snapshot-out-of-date_stderr.snap
@@ -1,5 +1,6 @@
 ---
 source: xtask/src/tests.rs
+assertion_line: 284
 expression: stderr
 ---
 $ duvet report --ci
@@ -28,6 +29,5 @@ Differences detected in .duvet/snapshot.txt:
  SPECIFICATION: [Section](my-spec.md)
 +  SECTION: [Section](#section)
 +    TEXT[implementation]: here is a spec
-
   × .duvet/snapshot.txt
   ╰─▶ Report snapshot does not match with CI mode enabled.

--- a/integration/snapshots/s2n-tls_json.snap
+++ b/integration/snapshots/s2n-tls_json.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5d944d01bbe5f38b6dd827e9dea53d7328796fc4089adafa3ab526bf3140c8b
-size 3271982
+oid sha256:9cd60cf24f3177f84d866b8206a1703897a22646b0536a9c237d26b03818ccf4
+size 3272000

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 components = [ "rustc", "clippy", "rustfmt" ]


### PR DESCRIPTION
### Description of changes
1. Update MSRV to 1.82 due to upstream libraries moving upwards as well. We now also capture our MSRV in `Cargo.toml` files of each crate.
2. Update test snapshots with new RFCs. There are also some very minor whitespace changes in `duvet report` tests.
3. Enable Markdown heading attributes with `Options::ENABLE_HEADING_ATTRIBUTES` in pulldown_cmark so that we can specify heading attributes such as anchor IDs like this: `# My Heading {#my-custom-anchor}`. I'm hoping this will help LLMs trace requirement annotations in the code back to the requirements doc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
