### PR TITLE
Move Duvet GitHub Action from s2n-quic to Duvet repo

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -1,0 +1,68 @@
+# duvet-action
+
+This action builds and installs [Duvet](https://github.com/aws/s2n-quic/tree/main/common/duvet), generates a compliance report via a provided script, and publishes the result to an S3 bucket.
+
+# Usage
+
+### `report-script: ''`
+
+Path to a script that generates a Duvet report. See `duvet report --help` for more information about generating reports. The action expects the report to be generated to `report-path`.
+
+The script will be passed `github.sha` in the first argument, which can be used with the `--blob-link` Duvet argument.
+
+### `report-path: '''`
+
+Path to the output report generated in `report-script`. Defaults to `report.html` in the same directory that `report-script` is in.
+
+### `aws-access-key-id: ''`
+
+Deprecated.  This was previously used to authenticate with long lived IAM credentials. See [Configuring OpenID Connect](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers)
+
+### `aws-secret-access-key: ''`
+
+Deprecated.  This was previously used to authenticate with long lived IAM credentials. See [Configuring OpenID Connect](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers)
+
+### `role-to-assume: ''`
+
+For Open ID Connect, the role attached to the IdP, in the form of an ARN. Intended for use with [AWS](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+
+### `role-session-name: ''`
+
+For Open ID Connect, an arbitrary session name. Intended for use with [AWS](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+
+### `aws-s3-bucket-name: ''`
+
+The name of the destination S3 bucket which the report will be uploaded to.
+
+### `cdn: ''`
+
+An optional CDN which will prefix the published S3 URL in the `compliance / report` Github check.
+
+### `s2n-quic-dir: ''`
+
+Path to the directory where s2n-quic is cloned. Used for repositories other than s2n-quic, which first clone s2n-quic to call this action.
+
+
+## Example usage:
+
+```yml
+jobs:
+  duvet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/s2n-quic
+          path: ./s2n-quic
+          submodules: true
+      - uses: ./s2n-quic/.github/actions/duvet
+        with:
+          s2n-quic-dir: ./s2n-quic
+          report-script: compliance/generate_report.sh
+          role-to-assume: arn:aws:iam::123456789:role/GitHubOIDCRole
+          role-session-name: GithubActionSession
+          aws-s3-bucket-name: s2n-tls-ci-artifacts
+          aws-s3-region: us-west-2
+          cdn: https://d3fqnyekunr9xg.cloudfront.net
+```

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,0 +1,95 @@
+name: 'Duvet'
+description: 'Uses Duvet to generate a compliance report and uploads it to S3'
+inputs:
+  duvet-version:
+    description: 'Version string for Duvet'
+    default: latest
+    required: false
+  report-script:
+    description: 'Path to script that generates a Duvet report'
+    required: true
+  report-path:
+    description: 'Path to generated Duvet report output'
+    required: false
+  role-to-assume:
+    description: 'Role to assume for OpenID Connect'
+    required: true
+  role-session-name:
+    description: 'Role session name for OpenID Connect'
+    required: true
+  aws-s3-bucket-name:
+    description: 'Destination S3 bucket name for duvet reports'
+    required: true
+  aws-s3-region:
+    description: 'S3 bucket region'
+    required: true
+  cdn:
+    description: 'Prefix the S3 URL with a CDN'
+    required: false
+  s2n-quic-dir:
+    description: 'Path to the directory where s2n-quic is cloned'
+    default: ${{ github.workspace }}
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Install rust toolchain
+      id: toolchain
+      shell: bash
+      run: |
+        rustup toolchain install stable
+        rustup override set stable
+
+    - uses: camshaft/rust-cache@v1
+
+    - uses: camshaft/install@v1
+      with:
+        crate: duvet
+        version: ${{ inputs.duvet-version }}
+
+    - name: Generate Duvet report
+      shell: bash
+      run: ${{ inputs.report-script }} ${{ github.sha }}
+
+    - uses: aws-actions/configure-aws-credentials@v4.0.2
+      if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+      with:
+        role-to-assume: ${{ inputs.role-to-assume}}
+        role-session-name: ${{ inputs.role-session-name}}
+        aws-region: ${{ inputs.aws-s3-region }}
+
+    - name: Upload to S3
+      if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+      id: s3
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.report-path }}" ]; then
+          REPORT_PATH="${{ inputs.report-path }}"
+        else
+          REPORT_PATH=$(dirname "${{ inputs.report-script }}")/report.html
+        fi
+
+        TARGET_SHA="${{ github.sha }}/compliance.html"
+        aws s3 cp "$REPORT_PATH" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_SHA" --acl private --follow-symlinks
+
+        # Only upload to latest if the event is push to main
+        if [ "${{ github.event_name }}" == "push" ]; then
+          TARGET_LATEST="latest/compliance.html"
+          aws s3 cp "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_SHA" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_LATEST"
+        fi
+
+        if [ -n "${{ inputs.cdn }}" ]; then
+          PREFIX="${{ inputs.cdn }}"
+        else
+          PREFIX="https://${{ inputs.aws-s3-bucket-name }}.s3.amazonaws.com"
+        fi
+        URL="$PREFIX/$TARGET_SHA"
+
+        echo "::set-output name=URL::$URL"
+
+    - uses: ouzi-dev/commit-status-updater@v1.1.2
+      if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+      with:
+        name: "compliance / report"
+        status: "success"
+        url: ${{ steps.s3.outputs.URL }}


### PR DESCRIPTION
Issue #, if available:
[#178](https://github.com/awslabs/duvet/issues/178)

Description of changes:
Moves the Duvet GitHub Action into the Duvet repo. This removes unnecessary dependencies (e.g., s2n-tls depending on s2n-quic just to use the action) and makes it easier for any repo to use Duvet without cloning s2n-quic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.