### PR TITLE
chore: fix new clippy lints

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Before getting started, Duvet requires a [rust toolchain](https://www.rust-lang.
 
 ## Development
 
+You must have `git lfs` installed. You can check this by running
+```shell
+git lfs version
+```
+
 ### Building
 
 ```console

--- a/duvet/src/annotation.rs
+++ b/duvet/src/annotation.rs
@@ -187,20 +187,15 @@ impl Annotation {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum AnnotationType {
     Spec,
     Test,
+    #[default]
     Citation,
     Exception,
     Todo,
     Implication,
-}
-
-impl Default for AnnotationType {
-    fn default() -> Self {
-        Self::Citation
-    }
 }
 
 impl fmt::Display for AnnotationType {
@@ -244,9 +239,10 @@ impl FromStr for AnnotationType {
 }
 
 // The order is in terms of priority from least to greatest
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize)]
 #[cfg_attr(test, derive(bolero::TypeGenerator))]
 pub enum AnnotationLevel {
+    #[default]
     Auto,
     May,
     Should,
@@ -255,12 +251,6 @@ pub enum AnnotationLevel {
 
 impl AnnotationLevel {
     pub const LEVELS: [Self; 4] = [Self::Auto, Self::May, Self::Should, Self::Must];
-}
-
-impl Default for AnnotationLevel {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 impl fmt::Display for AnnotationLevel {

--- a/duvet/src/specification.rs
+++ b/duvet/src/specification.rs
@@ -62,17 +62,12 @@ impl Specification {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub enum Format {
+    #[default]
     Auto,
     Ietf,
     Markdown,
-}
-
-impl Default for Format {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 impl fmt::Display for Format {


### PR DESCRIPTION
There are new clippy lints, which are causing the CI to fail. This PR fixes them.

I was also thoroughly stumped on the tar failure, so added a note about git lfs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
