### PR TITLE
chore: dependency updates

### DIFF
--- a/duvet-core/Cargo.toml
+++ b/duvet-core/Cargo.toml
@@ -17,10 +17,10 @@ testing = ["tracing-subscriber"]
 [dependencies]
 blake3 = "1"
 bytes = "1"
-console = "0.15"
+console = "0.16"
 duvet-macros = { version = "0.4", path = "../duvet-macros" }
 futures = { version = "0.3", default-features = false }
-fxhash = "0.2"
+rustc-hash = "1.1"
 globset = "0.4"
 http = { version = "1", optional = true }
 miette = { version = "7", features = ["fancy"] }
@@ -31,7 +31,7 @@ serde_json = "1"
 similar = { version = "2.6", features = ["inline"], optional = true }
 tokio = { version = "1", features = ["fs", "sync"] }
 tokio-util = "0.7"
-toml_edit = { version = "0.22", features = ["parse", "serde"] }
+toml_edit = { version = "0.23", features = ["parse", "serde"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",

--- a/duvet-core/src/cache.rs
+++ b/duvet-core/src/cache.rs
@@ -3,7 +3,7 @@
 
 use crate::query::Query;
 use core::marker::PhantomData;
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use std::{
     any::{Any, TypeId},
     cell::RefCell,

--- a/duvet/Cargo.toml
+++ b/duvet/Cargo.toml
@@ -21,10 +21,10 @@ glob = "0.3"
 lazy_static = "1"
 mimalloc = { version = "0.1", default-features = false }
 once_cell = "1"
-pulldown-cmark = { version = "0.12", default-features = false }
+pulldown-cmark = { version = "0.13", default-features = false }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
-serde_spanned = "0.6"
+serde_spanned = "1.0"
 slug = { version = "0.1" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4", features = ["derive"] }
 insta = { version = "1", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "0.8"
+toml = "0.9"
 xshell = "0.2"
 
 [lints.rust.unexpected_cfgs]


### PR DESCRIPTION
Various dependency updates, and removal of `fxhash` which is unmaintained.

Current state of dependencies
```
ubuntu@ip-172-31-49-198:~/workspace/duvet$ cargo update --verbose
    Updating crates.io index
     Locking 0 packages to latest compatible versions
   Unchanged darling v0.14.4 (available: v0.21.3)
   Unchanged schemars v0.8.22 (available: v1.0.5)
   Unchanged syn v1.0.109 (available: v2.0.108)
   Unchanged toml_datetime v0.6.3 (available: v0.6.11)
   Unchanged toml_edit v0.20.2 (available: v0.20.7)
```
- `darling` and `syn` are part of the proc macro stuff, which is pretty gnarly. Upgrading that will take more effort/some familiar with the macros.
- schemars: getting the tests to pass is pretty easy, but it ends up changing the json schema. It's unclear to me whether it was actually a breaking change.
- everything else is semver compatible with the latest version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
