### PR TITLE
chore: udeps nightly update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2025-05-20
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2025-11-09
 
 jobs:
   env:


### PR DESCRIPTION
### Changes

Bump the nightly rust tool chain version to address the udeps failures, e.g. [scheduled run against main](https://github.com/awslabs/duvet/actions/runs/19509787680).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
