### PR TITLE
feat: support ProVerif-style comments

### DIFF
--- a/duvet/src/comment/snapshots/duvet__comment__tokenizer__tests__proverif_style.snap
+++ b/duvet/src/comment/snapshots/duvet__comment__tokenizer__tests__proverif_style.snap
@@ -1,0 +1,20 @@
+---
+source: duvet/src/comment/tokenizer.rs
+assertion_line: 184
+expression: tokens
+---
+[
+    UnnamedMeta {
+        value: "https://example.com/spec.txt#section-1",
+        line: 2,
+    },
+    Meta {
+        key: "type",
+        value: "test",
+        line: 3,
+    },
+    Content {
+        value: "The requirement text goes here",
+        line: 4,
+    },
+]

--- a/duvet/src/comment/tokenizer.rs
+++ b/duvet/src/comment/tokenizer.rs
@@ -180,4 +180,19 @@ mod tests {
             content: "*#".into(),
         }
     );
+    // ProVerif/CryptoVerif use OCaml-style block comments: (* ... *)
+    snapshot_test!(
+        proverif_style,
+        r#"
+        (*
+         *= https://example.com/spec.txt#section-1
+         *= type=test
+         *# The requirement text goes here
+         *)
+        "#,
+        Pattern {
+            meta: "*=".into(),
+            content: "*#".into(),
+        }
+    );
 }

--- a/duvet/src/init.rs
+++ b/duvet/src/init.rs
@@ -109,6 +109,12 @@ struct Languages {
     /// Include rules for the JavaScript language
     #[clap(long = "lang-javascript")]
     javascript: bool,
+    /// Include rules for the ProVerif language
+    #[clap(long = "lang-proverif")]
+    proverif: bool,
+    /// Include rules for the CryptoVerif language
+    #[clap(long = "lang-cryptoverif")]
+    cryptoverif: bool,
     /// Include rules for the Python language
     #[clap(long = "lang-python")]
     python: bool,
@@ -146,9 +152,11 @@ impl Languages {
         }
 
         write!(c);
+        write!(cryptoverif);
         write!(go);
         write!(java);
         write!(javascript);
+        write!(proverif);
         write!(python);
         write!(typescript);
         write!(ruby);
@@ -225,9 +233,28 @@ mod lang {
             "*=", "*#"
         )
     );
+    // CryptoVerif uses OCaml-style block comments: (* ... *)
+    lang!(
+        cryptoverif,
+        "**/*.cv",
+        format_args!(
+            "comment-style = {{ meta = {:?}, content = {:?} }}",
+            "*=", "*#"
+        )
+    );
     lang!(go, "src/**/*.go");
     lang!(java, "src/**/*.java");
     lang!(javascript, "src/**/*.js");
+    // ProVerif uses OCaml-style block comments: (* ... *)
+    // Also includes CryptoVerif (.cv) files which use the same syntax
+    lang!(
+        proverif,
+        "**/*.pv",
+        format_args!(
+            "comment-style = {{ meta = {:?}, content = {:?} }}",
+            "*=", "*#"
+        )
+    );
     lang!(
         python,
         "src/**/*.py",


### PR DESCRIPTION
Closes #197 

*Description of changes:* This adds support for parsing `(* proverif / cryptoverif comments *)` in order to use Duvet in CI pipelines that trace program requirements into formal proofs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
