### PR TITLE
build: update reqwest to 0.13

### DIFF
--- a/duvet-core/Cargo.toml
+++ b/duvet-core/Cargo.toml
@@ -25,7 +25,7 @@ globset = "0.4"
 http = { version = "1", optional = true }
 miette = { version = "7", features = ["fancy"] }
 once_cell = "1"
-reqwest = { version = "0.12", optional = true, features = ["native-tls"] }
+reqwest = { version = "0.13", optional = true }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 similar = { version = "2.6", features = ["inline"], optional = true }


### PR DESCRIPTION
The intention is to simplify building duvet on more targets.

Upgrading request to 0.13 switches in turn the TLS provider to rustls with aws-lc as the crypto provider. This drops the requirement to have openssl and pkg-config and installed at build-time.

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
