### PR TITLE
feat: add `duvet merge` subcommand for combining v2 JSON reports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 integration/snapshots/*_json.snap filter=lfs diff=lfs merge=lfs -text
 integration/snapshots/*_json_v2.snap filter=lfs diff=lfs merge=lfs -text
+integration/snapshots/*_merged.snap filter=lfs diff=lfs merge=lfs -text
+integration/snapshots/*_duvet_report_v2.snap filter=lfs diff=lfs merge=lfs -text
 **/snapshots.tar.gz filter=lfs diff=lfs merge=lfs

--- a/duvet/src/lib.rs
+++ b/duvet/src/lib.rs
@@ -10,6 +10,7 @@ mod config;
 mod extract;
 pub(crate) mod ids;
 mod init;
+mod merge;
 mod project;
 mod reference;
 mod report;
@@ -29,6 +30,8 @@ pub enum Arguments {
     Extract(extract::Extract),
     /// Generates reports for the project
     Report(report::Report),
+    /// Merges multiple v2 JSON reports into one
+    Merge(merge::Merge),
 }
 
 #[duvet_core::query(cache)]
@@ -42,6 +45,7 @@ impl Arguments {
             Self::Init(args) => args.exec().await,
             Self::Extract(args) => args.exec().await,
             Self::Report(args) => args.exec().await,
+            Self::Merge(args) => args.exec().await,
         }
     }
 }

--- a/duvet/src/merge.rs
+++ b/duvet/src/merge.rs
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `duvet merge` subcommand: combine multiple v2 JSON reports into one.
+//!
+//! Each input must be a v2 JSON report produced by `duvet report --json-v2`
+//! (or by a previous merge). The merge is purely deterministic — entity IDs
+//! are content hashes, so the same input pair produces the same output
+//! regardless of input order.
+
+use crate::{
+    report::{json_v2, json_v2_merge},
+    Result,
+};
+use clap::Parser;
+use duvet_core::path::Path;
+
+#[derive(Debug, Parser)]
+pub struct Merge {
+    /// One or more v2 JSON reports to merge. Repeat the flag per input.
+    #[clap(long, required = true)]
+    input: Vec<Path>,
+
+    /// Output path for the merged v2 JSON report.
+    #[clap(long)]
+    output: Path,
+}
+
+impl Merge {
+    pub async fn exec(&self) -> Result {
+        let mut reports = Vec::with_capacity(self.input.len());
+        for path in &self.input {
+            let report = json_v2::read_report_v2(path.as_ref())?;
+            reports.push(report);
+        }
+
+        let merged = json_v2_merge::merge_reports(reports)?;
+        json_v2::write_report_v2(&merged, self.output.as_ref())?;
+
+        Ok(())
+    }
+}

--- a/duvet/src/report.rs
+++ b/duvet/src/report.rs
@@ -17,6 +17,7 @@ mod ci;
 mod html;
 mod json;
 pub(crate) mod json_v2;
+pub(crate) mod json_v2_merge;
 mod lcov;
 mod snapshot;
 mod stats;

--- a/duvet/src/report/json_v2.rs
+++ b/duvet/src/report/json_v2.rs
@@ -852,7 +852,6 @@ pub fn write_report_v2_to_writer<W: std::io::Write>(report: &ReportV2, writer: W
     Ok(())
 }
 
-#[allow(dead_code)]
 pub fn read_report_v2(path: &std::path::Path) -> crate::Result<ReportV2> {
     use std::{fs::File, io::BufReader};
 
@@ -863,7 +862,6 @@ pub fn read_report_v2(path: &std::path::Path) -> crate::Result<ReportV2> {
         .map_err(|e| duvet_core::error!("failed to read report from '{}': {}", path.display(), e))
 }
 
-#[allow(dead_code)]
 pub fn read_report_v2_from_reader<R: std::io::Read>(reader: R) -> crate::Result<ReportV2> {
     let report: ReportV2 = serde_json::from_reader(reader)
         .map_err(|e| duvet_core::error!("failed to parse JSON: {}", e))?;

--- a/duvet/src/report/json_v2_merge.rs
+++ b/duvet/src/report/json_v2_merge.rs
@@ -66,6 +66,39 @@ pub fn merge_reports(reports: Vec<ReportV2>) -> crate::Result<ReportV2> {
         ));
     }
 
+    // Linked sources without a `repository` collapse to a `lnk-` ID hashed
+    // from `file_name` alone. Within a single report that's fine — paths
+    // are unique by construction. The hazard is across reports: if two
+    // unrelated projects each have a no-repo linked source for the same
+    // path (e.g. `src/lib.rs`), they share a `lnk-` ID and merging them
+    // would silently consolidate annotations from disjoint codebases.
+    //
+    // We can't tell same-project from cross-project at merge time, so we
+    // refuse the merge whenever the same no-repo `lnk-` ID appears in two
+    // or more inputs. Single-input occurrences are safe and remain allowed.
+    {
+        let mut no_repo_seen: BTreeMap<&str, usize> = BTreeMap::new();
+        for (i, report) in reports.iter().enumerate() {
+            for (lnk_id, src) in &report.sources.linked {
+                if src.repository.is_some() {
+                    continue;
+                }
+                if let Some(&prior) = no_repo_seen.get(lnk_id.as_str()) {
+                    return Err(duvet_core::error!(
+                        "linked source '{}' (file '{}') without a repository appears in inputs #{} and #{}; \
+                         merging would silently consolidate it across reports — \
+                         add a blob-link to disambiguate (see [[source]] blob-link in your duvet config)",
+                        lnk_id,
+                        src.file_name,
+                        prior,
+                        i,
+                    ));
+                }
+                no_repo_seen.insert(lnk_id, i);
+            }
+        }
+    }
+
     // Use the first input as the accumulator and fold the rest in. Because
     // every per-bucket merge operation is a BTreeMap union over content-
     // hashed IDs, the choice of seed doesn't affect the final result —
@@ -470,8 +503,8 @@ fn finalize_coverage(requirements: &mut BTreeMap<String, RequirementAnnotation>)
 mod tests {
     use super::*;
     use crate::report::json_v2::{
-        AnnotationLevel, AnnotationType, ByteRange, InlineSource, SourceLocation, SourceRanges,
-        SourceRef,
+        AnnotationLevel, AnnotationType, ByteRange, InlineSource, LinkedSource, SourceLocation,
+        SourceRanges, SourceRef,
     };
 
     fn empty() -> ReportV2 {
@@ -912,6 +945,114 @@ mod tests {
         assert!(format!("{err}").contains("invariant"));
     }
 
+    #[test]
+    fn merge_errors_when_no_repo_linked_source_overlaps_inputs() {
+        // Two inputs both carry a no-repo linked source under the same
+        // lnk-id — the canonical cross-project consolidation hazard.
+        let mut a = empty();
+        a.sources.linked.insert(
+            "lnk-x".to_string(),
+            LinkedSource {
+                file_name: "src/lib.rs".to_string(),
+                repository: None,
+            },
+        );
+        let mut b = empty();
+        b.sources.linked.insert(
+            "lnk-x".to_string(),
+            LinkedSource {
+                file_name: "src/lib.rs".to_string(),
+                repository: None,
+            },
+        );
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("inputs #0 and #1"), "msg = {msg}");
+        assert!(msg.contains("lnk-x"), "msg = {msg}");
+        assert!(msg.contains("src/lib.rs"), "msg = {msg}");
+        assert!(msg.contains("blob-link"), "msg = {msg}");
+    }
+
+    #[test]
+    fn merge_errors_when_no_repo_linked_source_overlaps_third_input() {
+        // The collision is across non-adjacent inputs (#0 and #2). The
+        // pre-validation pass needs to catch it independent of fold order.
+        let mut a = empty();
+        a.sources.linked.insert(
+            "lnk-x".to_string(),
+            LinkedSource {
+                file_name: "src/lib.rs".to_string(),
+                repository: None,
+            },
+        );
+        let b = empty();
+        let mut c = empty();
+        c.sources.linked.insert(
+            "lnk-x".to_string(),
+            LinkedSource {
+                file_name: "src/lib.rs".to_string(),
+                repository: None,
+            },
+        );
+        let err = merge_reports(vec![a, b, c]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("inputs #0 and #2"), "msg = {msg}");
+    }
+
+    #[test]
+    fn merge_allows_disjoint_no_repo_linked_sources_three_way() {
+        // 3-way happy path: each input has its own no-repo linked source
+        // under a distinct lnk-id, so there's no cross-input collision.
+        let mut a = empty();
+        a.sources.linked.insert(
+            "lnk-x".to_string(),
+            LinkedSource {
+                file_name: "package-a/src/lib.rs".to_string(),
+                repository: None,
+            },
+        );
+        let mut b = empty();
+        b.sources.linked.insert(
+            "lnk-y".to_string(),
+            LinkedSource {
+                file_name: "package-b/src/lib.rs".to_string(),
+                repository: None,
+            },
+        );
+        let mut c = empty();
+        c.sources.linked.insert(
+            "lnk-z".to_string(),
+            LinkedSource {
+                file_name: "package-c/src/lib.rs".to_string(),
+                repository: None,
+            },
+        );
+
+        let merged = merge_reports(vec![a, b, c]).unwrap();
+        assert_eq!(merged.sources.linked.len(), 3);
+        assert!(merged.sources.linked.contains_key("lnk-x"));
+        assert!(merged.sources.linked.contains_key("lnk-y"));
+        assert!(merged.sources.linked.contains_key("lnk-z"));
+    }
+
+    #[test]
+    fn merge_allows_no_repo_linked_source_in_single_input() {
+        // A no-repo linked source that appears in only one input is fine —
+        // there's no cross-input collision possible.
+        let mut a = empty();
+        a.sources.linked.insert(
+            "lnk-x".to_string(),
+            LinkedSource {
+                file_name: "src/lib.rs".to_string(),
+                repository: None,
+            },
+        );
+        let b = empty();
+        let merged = merge_reports(vec![a, b]).unwrap();
+        assert_eq!(merged.sources.linked.len(), 1);
+        assert_eq!(merged.sources.linked["lnk-x"].repository, None);
+    }
+
     // ── Property tests ──
 
     fn fixture_a() -> ReportV2 {
@@ -1024,8 +1165,13 @@ mod tests {
 
     #[test]
     fn merge_real_snapshot_self_idempotent() {
+        // Use the per-source blob-link fixture: every linked source has a
+        // repository, so the no-repo cross-input collision check accepts a
+        // self-merge. The markdown fixture would (correctly) be rejected,
+        // since self-merge of a no-repo lnk-id is indistinguishable from a
+        // cross-project consolidation.
         const SNAPSHOT: &str =
-            include_str!("../../../integration/snapshots/report-markdown_json_v2.snap");
+            include_str!("../../../integration/snapshots/report-source-blob-link_json_v2.snap");
         let json = SNAPSHOT
             .split_once("---\n")
             .and_then(|(_, rest)| rest.split_once("---\n"))

--- a/duvet/src/report/json_v2_merge.rs
+++ b/duvet/src/report/json_v2_merge.rs
@@ -34,9 +34,13 @@
 //!
 //! 3. **Soft drift** — outside the hash and tolerated. Cite metadata
 //!    (`comment`, `feature`, `tracking_issue`, `tags`) often differs across
-//!    branches/checkouts and isn't load-bearing for traceability; we keep
-//!    the value from the first input that defined the ID and warn so the
-//!    drift is observable.
+//!    branches/checkouts and isn't load-bearing for traceability. When two
+//!    inputs disagree we reconcile deterministically: lexicographically
+//!    smaller wins for the `Option<String>` fields, and `tags` is the
+//!    sorted union of both sets. The deterministic tie-break keeps the
+//!    binary merge commutative and associative, so an N-way fold is
+//!    order-independent. Drift is logged as a warning so it stays
+//!    observable.
 //!
 //! Coverage on requirements is a fourth, special case: it's a *set* keyed
 //! by cite ID, so we merge by union and post-process with sort+dedup so the
@@ -389,14 +393,15 @@ fn merge_requirement(
 ///
 /// The "soft" cite metadata (`comment`, `feature`, `tracking_issue`,
 /// `tags`) is not load-bearing for traceability and routinely drifts
-/// across branches; we keep the first value seen and warn — see
-/// [`warn_on_soft_drift`].
+/// across branches. On disagreement we reconcile deterministically: the
+/// lexicographically smaller value wins for `Option<String>` fields, and
+/// `tags` becomes the sorted union of both sets. See [`merge_soft_drift`].
 fn merge_cite(
     out: &mut BTreeMap<String, CiteAnnotation>,
     id: String,
     anno: CiteAnnotation,
 ) -> crate::Result {
-    match out.get(&id) {
+    match out.get_mut(&id) {
         Some(existing) => {
             if existing.anno_type != anno.anno_type {
                 return Err(duvet_core::error!(
@@ -427,7 +432,7 @@ fn merge_cite(
                 ));
             }
 
-            warn_on_soft_drift(&id, existing, &anno);
+            merge_soft_drift(&id, existing, anno);
         }
         None => {
             out.insert(id, anno);
@@ -436,7 +441,15 @@ fn merge_cite(
     Ok(())
 }
 
-fn warn_on_soft_drift(id: &str, existing: &CiteAnnotation, incoming: &CiteAnnotation) {
+/// Reconcile the soft cite metadata fields (`comment`, `feature`,
+/// `tracking_issue`, `tags`) deterministically so the binary merge is
+/// commutative and associative. For `Option<String>` fields, `Some` beats
+/// `None`, and when both sides are `Some` the lexicographically smaller
+/// value wins. `tags` becomes the sorted union of both sets.
+///
+/// Any field that actually differed before reconciliation is reported on
+/// stderr so the drift remains observable.
+fn merge_soft_drift(id: &str, existing: &mut CiteAnnotation, incoming: CiteAnnotation) {
     let mut drifted = Vec::new();
     if existing.comment != incoming.comment {
         drifted.push("comment");
@@ -450,12 +463,35 @@ fn warn_on_soft_drift(id: &str, existing: &CiteAnnotation, incoming: &CiteAnnota
     if existing.tags != incoming.tags {
         drifted.push("tags");
     }
+
+    existing.comment = pick_lex_min(existing.comment.take(), incoming.comment);
+    existing.feature = pick_lex_min(existing.feature.take(), incoming.feature);
+    existing.tracking_issue = pick_lex_min(existing.tracking_issue.take(), incoming.tracking_issue);
+
+    // Sorted union: extend then sort+dedup. The sort gives a canonical
+    // order independent of which side contributed which tag; dedup keeps
+    // the result idempotent under self-merge.
+    existing.tags.extend(incoming.tags);
+    existing.tags.sort();
+    existing.tags.dedup();
+
     if !drifted.is_empty() {
         eprintln!(
-            "warning: cite annotation '{}' has metadata drift across inputs ({}); keeping value from first input",
+            "warning: cite annotation '{}' has metadata drift across inputs ({}); reconciling deterministically (lex-min for strings, sorted union for tags)",
             id,
             drifted.join(", ")
         );
+    }
+}
+
+/// Combine two `Option<String>` values from the two sides of a binary
+/// merge into a single deterministic value. `Some` beats `None`; when both
+/// sides are `Some`, the lexicographically smaller string wins.
+fn pick_lex_min(a: Option<String>, b: Option<String>) -> Option<String> {
+    match (a, b) {
+        (None, None) => None,
+        (Some(x), None) | (None, Some(x)) => Some(x),
+        (Some(x), Some(y)) => Some(if x <= y { x } else { y }),
     }
 }
 
@@ -838,7 +874,9 @@ mod tests {
     }
 
     #[test]
-    fn merge_warns_on_cite_comment_drift_keeps_first() {
+    fn merge_cite_comment_drift_picks_lexicographically_smaller() {
+        // The drift winner is whichever string sorts first, regardless of
+        // input order — that's what makes the merge commutative.
         let mut c1 = cite(1, AnnotationType::Citation, vec![]);
         c1.comment = Some("first".to_string());
         let mut c2 = cite(1, AnnotationType::Citation, vec![]);
@@ -849,11 +887,57 @@ mod tests {
         let mut b = empty();
         b.annotations.cite.insert("cite-1".to_string(), c2);
 
-        let merged = merge_reports(vec![a, b]).unwrap();
+        let forward = merge_reports(vec![a.clone(), b.clone()]).unwrap();
+        let reverse = merge_reports(vec![b, a]).unwrap();
+        // "first" < "second", so it wins regardless of fold order.
         assert_eq!(
-            merged.annotations.cite["cite-1"].comment.as_deref(),
+            forward.annotations.cite["cite-1"].comment.as_deref(),
             Some("first")
         );
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn merge_cite_some_beats_none_in_either_direction() {
+        // `Some` should always win over `None` so a sparsely-populated
+        // input doesn't erase metadata recorded by another.
+        let mut c1 = cite(1, AnnotationType::Citation, vec![]);
+        c1.feature = Some("f".to_string());
+        let c2 = cite(1, AnnotationType::Citation, vec![]); // feature: None
+
+        let mut a = empty();
+        a.annotations.cite.insert("cite-1".to_string(), c1);
+        let mut b = empty();
+        b.annotations.cite.insert("cite-1".to_string(), c2);
+
+        let forward = merge_reports(vec![a.clone(), b.clone()]).unwrap();
+        let reverse = merge_reports(vec![b, a]).unwrap();
+        assert_eq!(
+            forward.annotations.cite["cite-1"].feature.as_deref(),
+            Some("f")
+        );
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn merge_cite_tags_are_sorted_union() {
+        let mut c1 = cite(1, AnnotationType::Citation, vec![]);
+        c1.tags = vec!["b".to_string(), "a".to_string()];
+        let mut c2 = cite(1, AnnotationType::Citation, vec![]);
+        c2.tags = vec!["c".to_string(), "a".to_string()];
+
+        let mut a = empty();
+        a.annotations.cite.insert("cite-1".to_string(), c1);
+        let mut b = empty();
+        b.annotations.cite.insert("cite-1".to_string(), c2);
+
+        let forward = merge_reports(vec![a.clone(), b.clone()]).unwrap();
+        let reverse = merge_reports(vec![b, a]).unwrap();
+        assert_eq!(
+            forward.annotations.cite["cite-1"].tags,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+        assert_eq!(forward, reverse);
     }
 
     #[test]
@@ -1153,6 +1237,63 @@ mod tests {
         let json = serde_json::to_string(&merged).unwrap();
         let back: ReportV2 = serde_json::from_str(&json).unwrap();
         assert_eq!(back, merged);
+    }
+
+    /// Three reports that share a single cite ID but disagree on every
+    /// soft-drift field. Used to exercise the commutative reconciliation.
+    fn drift_fixture(comment: &str, feature: &str, tracking: &str, tag: &str) -> ReportV2 {
+        let mut r = empty();
+        let mut c = cite(1, AnnotationType::Citation, vec![]);
+        c.comment = Some(comment.to_string());
+        c.feature = Some(feature.to_string());
+        c.tracking_issue = Some(tracking.to_string());
+        c.tags = vec![tag.to_string()];
+        r.annotations.cite.insert("cite-shared".to_string(), c);
+        r
+    }
+
+    #[test]
+    fn property_commutativity_with_soft_drift() {
+        let a = drift_fixture("alpha", "f-a", "T-1", "x");
+        let b = drift_fixture("bravo", "f-b", "T-2", "y");
+        let forward = merge_reports(vec![a.clone(), b.clone()]).unwrap();
+        let reverse = merge_reports(vec![b, a]).unwrap();
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn property_n_way_order_independence_with_soft_drift() {
+        // Three inputs, all sharing one cite ID with disagreeing soft-drift
+        // values. All 6 permutations of the 3-way fold must produce the
+        // same merged report.
+        let a = drift_fixture("alpha", "f-a", "T-1", "x");
+        let b = drift_fixture("bravo", "f-b", "T-2", "y");
+        let c = drift_fixture("charlie", "f-c", "T-3", "z");
+
+        let perms = [
+            vec![a.clone(), b.clone(), c.clone()],
+            vec![a.clone(), c.clone(), b.clone()],
+            vec![b.clone(), a.clone(), c.clone()],
+            vec![b.clone(), c.clone(), a.clone()],
+            vec![c.clone(), a.clone(), b.clone()],
+            vec![c.clone(), b.clone(), a.clone()],
+        ];
+        let baseline = merge_reports(perms[0].clone()).unwrap();
+        for perm in &perms[1..] {
+            let merged = merge_reports(perm.clone()).unwrap();
+            assert_eq!(merged, baseline);
+        }
+
+        // Sanity-check the reconciled values: lex-min for Option strings,
+        // sorted union for tags.
+        let merged_cite = &baseline.annotations.cite["cite-shared"];
+        assert_eq!(merged_cite.comment.as_deref(), Some("alpha"));
+        assert_eq!(merged_cite.feature.as_deref(), Some("f-a"));
+        assert_eq!(merged_cite.tracking_issue.as_deref(), Some("T-1"));
+        assert_eq!(
+            merged_cite.tags,
+            vec!["x".to_string(), "y".to_string(), "z".to_string()]
+        );
     }
 
     // ── Light snapshot-based smoke test ──

--- a/duvet/src/report/json_v2_merge.rs
+++ b/duvet/src/report/json_v2_merge.rs
@@ -166,7 +166,7 @@ fn merge_repositories(
                 // no safe way to pick between the two.
                 if existing.blob_link != repo.blob_link {
                     return Err(duvet_core::error!(
-                        "internal invariant violation: repository '{}' has different blob_link across inputs ('{}' vs '{}'); likely hash collision or producer bug",
+                        "internal invariant violation: repository '{}' has different blob_link across inputs ('{}' vs '{}'); likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
                         id,
                         existing.blob_link,
                         repo.blob_link
@@ -193,7 +193,7 @@ fn merge_sources(out: &mut SourcesV2, incoming: SourcesV2) -> crate::Result {
             Some(existing) => {
                 if existing.contents != src.contents {
                     return Err(duvet_core::error!(
-                        "internal invariant violation: inline source '{}' has different contents across inputs; likely hash collision or producer bug",
+                        "internal invariant violation: inline source '{}' has different contents across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
                         id
                     ));
                 }
@@ -220,7 +220,7 @@ fn merge_sources(out: &mut SourcesV2, incoming: SourcesV2) -> crate::Result {
             Some(existing) => {
                 if existing != &src {
                     return Err(duvet_core::error!(
-                        "internal invariant violation: linked source '{}' differs across inputs; likely hash collision or producer bug",
+                        "internal invariant violation: linked source '{}' differs across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
                         id
                     ));
                 }
@@ -284,7 +284,7 @@ fn merge_specification(
             }
             if existing.source != anno.source {
                 return Err(duvet_core::error!(
-                    "internal invariant violation: specification '{}' has different source across inputs; likely hash collision or producer bug",
+                    "internal invariant violation: specification '{}' has different source across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
                     id
                 ));
             }
@@ -322,7 +322,7 @@ fn merge_section(
             }
             if existing.source != anno.source {
                 return Err(duvet_core::error!(
-                    "internal invariant violation: section '{}' has different source across inputs; likely hash collision or producer bug",
+                    "internal invariant violation: section '{}' has different source across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
                     id
                 ));
             }
@@ -357,13 +357,13 @@ fn merge_requirement(
             }
             if existing.source != anno.source {
                 return Err(duvet_core::error!(
-                    "internal invariant violation: requirement '{}' has different source across inputs; likely hash collision or producer bug",
+                    "internal invariant violation: requirement '{}' has different source across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
                     id
                 ));
             }
             if existing.origin != anno.origin {
                 return Err(duvet_core::error!(
-                    "internal invariant violation: requirement '{}' has different origin across inputs; likely hash collision or producer bug",
+                    "internal invariant violation: requirement '{}' has different origin across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
                     id
                 ));
             }
@@ -422,7 +422,7 @@ fn merge_cite(
             }
             if existing.source != anno.source {
                 return Err(duvet_core::error!(
-                    "internal invariant violation: cite '{}' has different source across inputs; likely hash collision or producer bug",
+                    "internal invariant violation: cite '{}' has different source across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
                     id
                 ));
             }

--- a/duvet/src/report/json_v2_merge.rs
+++ b/duvet/src/report/json_v2_merge.rs
@@ -107,17 +107,17 @@ pub fn merge_reports(reports: Vec<ReportV2>) -> crate::Result<ReportV2> {
     // every per-bucket merge operation is a BTreeMap union over content-
     // hashed IDs, the choice of seed doesn't affect the final result —
     // the merge is order-independent (see `property_commutativity_*`).
-    let mut iter = reports.into_iter();
-    let mut out = iter.next().expect("non-empty");
+    let mut iter = reports.into_iter().enumerate();
+    let (_, mut out) = iter.next().expect("non-empty");
     if out.version != "2.0" {
         return Err(duvet_core::error!(
-            "unsupported report version '{}', expected '2.0'",
+            "input #0: unsupported report version '{}', expected '2.0'",
             out.version
         ));
     }
 
-    for next in iter {
-        merge_one(&mut out, next)?;
+    for (idx, next) in iter {
+        merge_one(&mut out, next, idx)?;
     }
 
     // After all inputs have been folded in, normalize coverage range lists
@@ -127,10 +127,11 @@ pub fn merge_reports(reports: Vec<ReportV2>) -> crate::Result<ReportV2> {
     Ok(out)
 }
 
-fn merge_one(out: &mut ReportV2, incoming: ReportV2) -> crate::Result {
+fn merge_one(out: &mut ReportV2, incoming: ReportV2, idx: usize) -> crate::Result {
     if incoming.version != "2.0" {
         return Err(duvet_core::error!(
-            "unsupported report version '{}', expected '2.0'",
+            "input #{}: unsupported report version '{}', expected '2.0'",
+            idx,
             incoming.version
         ));
     }
@@ -138,9 +139,9 @@ fn merge_one(out: &mut ReportV2, incoming: ReportV2) -> crate::Result {
     // Each top-level bucket is independent: ordering between them doesn't
     // matter, and within a bucket the merge is keyed by deterministic ID.
     merge_issue_links(&mut out.issue_links, incoming.issue_links);
-    merge_repositories(&mut out.repositories, incoming.repositories)?;
-    merge_sources(&mut out.sources, incoming.sources)?;
-    merge_annotations(&mut out.annotations, incoming.annotations)?;
+    merge_repositories(&mut out.repositories, incoming.repositories, idx)?;
+    merge_sources(&mut out.sources, incoming.sources, idx)?;
+    merge_annotations(&mut out.annotations, incoming.annotations, idx)?;
 
     Ok(())
 }
@@ -158,6 +159,7 @@ fn merge_issue_links(out: &mut Vec<String>, incoming: Vec<String>) {
 fn merge_repositories(
     out: &mut BTreeMap<String, Repository>,
     incoming: BTreeMap<String, Repository>,
+    idx: usize,
 ) -> crate::Result {
     for (id, repo) in incoming {
         match out.get(&id) {
@@ -168,10 +170,11 @@ fn merge_repositories(
                 // no safe way to pick between the two.
                 if existing.blob_link != repo.blob_link {
                     return Err(duvet_core::error!(
-                        "internal invariant violation: repository '{}' has different blob_link across inputs ('{}' vs '{}'); likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
+                        "internal invariant violation: input #{} has repository '{}' with blob_link '{}' conflicting with previously seen '{}'; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
+                        idx,
                         id,
+                        repo.blob_link,
                         existing.blob_link,
-                        repo.blob_link
                     ));
                 }
             }
@@ -183,7 +186,7 @@ fn merge_repositories(
     Ok(())
 }
 
-fn merge_sources(out: &mut SourcesV2, incoming: SourcesV2) -> crate::Result {
+fn merge_sources(out: &mut SourcesV2, incoming: SourcesV2, idx: usize) -> crate::Result {
     // Inline sources: `src-` IDs hash the contents only, so contents
     // equality is implied by ID equality. `file_name` is *not* hashed —
     // two reports can legitimately disagree on the path they observed for
@@ -195,16 +198,18 @@ fn merge_sources(out: &mut SourcesV2, incoming: SourcesV2) -> crate::Result {
             Some(existing) => {
                 if existing.contents != src.contents {
                     return Err(duvet_core::error!(
-                        "internal invariant violation: inline source '{}' has different contents across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
-                        id
+                        "internal invariant violation: input #{} has inline source '{}' with contents conflicting with previously seen contents; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
+                        idx,
+                        id,
                     ));
                 }
                 if existing.file_name != src.file_name {
                     return Err(duvet_core::error!(
-                        "inline source '{}' has conflicting file_name across inputs: '{}' vs '{}'",
+                        "input #{} has inline source '{}' with file_name '{}' conflicting with previously seen '{}'",
+                        idx,
                         id,
+                        src.file_name,
                         existing.file_name,
-                        src.file_name
                     ));
                 }
             }
@@ -222,8 +227,9 @@ fn merge_sources(out: &mut SourcesV2, incoming: SourcesV2) -> crate::Result {
             Some(existing) => {
                 if existing != &src {
                     return Err(duvet_core::error!(
-                        "internal invariant violation: linked source '{}' differs across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
-                        id
+                        "internal invariant violation: input #{} has linked source '{}' that differs from previously seen entry under the same id; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
+                        idx,
+                        id,
                     ));
                 }
             }
@@ -235,28 +241,32 @@ fn merge_sources(out: &mut SourcesV2, incoming: SourcesV2) -> crate::Result {
 
     // Unknown URL-keyed source buckets are passed through verbatim under
     // strict equality — see `merge_extensions`.
-    merge_extensions("sources", &mut out.extensions, incoming.extensions)?;
+    merge_extensions("sources", &mut out.extensions, incoming.extensions, idx)?;
 
     Ok(())
 }
 
-fn merge_annotations(out: &mut AnnotationsV2, incoming: AnnotationsV2) -> crate::Result {
+fn merge_annotations(
+    out: &mut AnnotationsV2,
+    incoming: AnnotationsV2,
+    idx: usize,
+) -> crate::Result {
     // Each annotation kind has its own conflict policy; see the per-kind
     // helpers below for the precise rules.
     for (id, anno) in incoming.specification {
-        merge_specification(&mut out.specification, id, anno)?;
+        merge_specification(&mut out.specification, id, anno, idx)?;
     }
     for (id, anno) in incoming.section {
-        merge_section(&mut out.section, id, anno)?;
+        merge_section(&mut out.section, id, anno, idx)?;
     }
     for (id, anno) in incoming.requirement {
-        merge_requirement(&mut out.requirement, id, anno)?;
+        merge_requirement(&mut out.requirement, id, anno, idx)?;
     }
     for (id, anno) in incoming.cite {
-        merge_cite(&mut out.cite, id, anno)?;
+        merge_cite(&mut out.cite, id, anno, idx)?;
     }
 
-    merge_extensions("annotations", &mut out.extensions, incoming.extensions)?;
+    merge_extensions("annotations", &mut out.extensions, incoming.extensions, idx)?;
 
     Ok(())
 }
@@ -269,25 +279,26 @@ fn merge_specification(
     out: &mut BTreeMap<String, SpecificationAnnotation>,
     id: String,
     anno: SpecificationAnnotation,
+    idx: usize,
 ) -> crate::Result {
     match out.get(&id) {
         Some(existing) => {
             if existing.title != anno.title {
                 return Err(duvet_core::error!(
-                    "specification annotation '{}' has conflicting title across inputs: {:?} vs {:?}",
-                    id, existing.title, anno.title
+                    "input #{} has specification annotation '{}' with title {:?} conflicting with previously seen {:?}",
+                    idx, id, anno.title, existing.title
                 ));
             }
             if existing.format != anno.format {
                 return Err(duvet_core::error!(
-                    "specification annotation '{}' has conflicting format across inputs: '{}' vs '{}'",
-                    id, existing.format, anno.format
+                    "input #{} has specification annotation '{}' with format '{}' conflicting with previously seen '{}'",
+                    idx, id, anno.format, existing.format
                 ));
             }
             if existing.source != anno.source {
                 return Err(duvet_core::error!(
-                    "internal invariant violation: specification '{}' has different source across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
-                    id
+                    "internal invariant violation: input #{} has specification '{}' with source differing from previously seen; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
+                    idx, id
                 ));
             }
         }
@@ -305,27 +316,29 @@ fn merge_section(
     out: &mut BTreeMap<String, SectionAnnotation>,
     id: String,
     anno: SectionAnnotation,
+    idx: usize,
 ) -> crate::Result {
     match out.get(&id) {
         Some(existing) => {
             if existing.short_name != anno.short_name {
                 return Err(duvet_core::error!(
-                    "section annotation '{}' has conflicting short_name across inputs: '{}' vs '{}'",
-                    id, existing.short_name, anno.short_name
+                    "input #{} has section annotation '{}' with short_name '{}' conflicting with previously seen '{}'",
+                    idx, id, anno.short_name, existing.short_name
                 ));
             }
             if existing.long_name != anno.long_name {
                 return Err(duvet_core::error!(
-                    "section annotation '{}' has conflicting long_name across inputs: {:?} vs {:?}",
+                    "input #{} has section annotation '{}' with long_name {:?} conflicting with previously seen {:?}",
+                    idx,
                     id,
+                    anno.long_name,
                     existing.long_name,
-                    anno.long_name
                 ));
             }
             if existing.source != anno.source {
                 return Err(duvet_core::error!(
-                    "internal invariant violation: section '{}' has different source across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
-                    id
+                    "internal invariant violation: input #{} has section '{}' with source differing from previously seen; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
+                    idx, id
                 ));
             }
         }
@@ -346,27 +359,29 @@ fn merge_requirement(
     out: &mut BTreeMap<String, RequirementAnnotation>,
     id: String,
     anno: RequirementAnnotation,
+    idx: usize,
 ) -> crate::Result {
     match out.get_mut(&id) {
         Some(existing) => {
             if existing.level != anno.level {
                 return Err(duvet_core::error!(
-                    "requirement annotation '{}' has conflicting level across inputs: {:?} vs {:?}",
+                    "input #{} has requirement annotation '{}' with level {:?} conflicting with previously seen {:?}",
+                    idx,
                     id,
+                    anno.level,
                     existing.level,
-                    anno.level
                 ));
             }
             if existing.source != anno.source {
                 return Err(duvet_core::error!(
-                    "internal invariant violation: requirement '{}' has different source across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
-                    id
+                    "internal invariant violation: input #{} has requirement '{}' with source differing from previously seen; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
+                    idx, id
                 ));
             }
             if existing.origin != anno.origin {
                 return Err(duvet_core::error!(
-                    "internal invariant violation: requirement '{}' has different origin across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
-                    id
+                    "internal invariant violation: input #{} has requirement '{}' with origin differing from previously seen; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
+                    idx, id
                 ));
             }
 
@@ -398,39 +413,42 @@ fn merge_cite(
     out: &mut BTreeMap<String, CiteAnnotation>,
     id: String,
     anno: CiteAnnotation,
+    idx: usize,
 ) -> crate::Result {
     match out.get_mut(&id) {
         Some(existing) => {
             if existing.anno_type != anno.anno_type {
                 return Err(duvet_core::error!(
-                    "cite annotation '{}' has conflicting type across inputs: {:?} vs {:?}",
+                    "input #{} has cite annotation '{}' with type {:?} conflicting with previously seen {:?}",
+                    idx,
                     id,
+                    anno.anno_type,
                     existing.anno_type,
-                    anno.anno_type
                 ));
             }
             if existing.level != anno.level {
                 return Err(duvet_core::error!(
-                    "cite annotation '{}' has conflicting level across inputs: {:?} vs {:?}",
+                    "input #{} has cite annotation '{}' with level {:?} conflicting with previously seen {:?}",
+                    idx,
                     id,
+                    anno.level,
                     existing.level,
-                    anno.level
                 ));
             }
             if existing.target != anno.target {
                 return Err(duvet_core::error!(
-                    "cite annotation '{}' has conflicting target across inputs",
-                    id
+                    "input #{} has cite annotation '{}' with target conflicting with previously seen",
+                    idx, id
                 ));
             }
             if existing.source != anno.source {
                 return Err(duvet_core::error!(
-                    "internal invariant violation: cite '{}' has different source across inputs; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
-                    id
+                    "internal invariant violation: input #{} has cite '{}' with source differing from previously seen; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
+                    idx, id
                 ));
             }
 
-            merge_soft_drift(&id, existing, anno);
+            merge_soft_drift(&id, existing, anno, idx);
         }
         None => {
             out.insert(id, anno);
@@ -447,7 +465,7 @@ fn merge_cite(
 ///
 /// Any field that actually differed before reconciliation is reported on
 /// stderr so the drift remains observable.
-fn merge_soft_drift(id: &str, existing: &mut CiteAnnotation, incoming: CiteAnnotation) {
+fn merge_soft_drift(id: &str, existing: &mut CiteAnnotation, incoming: CiteAnnotation, idx: usize) {
     let mut drifted = Vec::new();
     if existing.comment != incoming.comment {
         drifted.push("comment");
@@ -475,7 +493,8 @@ fn merge_soft_drift(id: &str, existing: &mut CiteAnnotation, incoming: CiteAnnot
 
     if !drifted.is_empty() {
         eprintln!(
-            "warning: cite annotation '{}' has metadata drift across inputs ({}); reconciling deterministically (lex-min for strings, sorted union for tags)",
+            "warning: input #{} has cite annotation '{}' with metadata drift from previously seen ({}); reconciling deterministically (lex-min for strings, sorted union for tags)",
+            idx,
             id,
             drifted.join(", ")
         );
@@ -501,14 +520,16 @@ fn merge_extensions(
     bucket: &str,
     out: &mut BTreeMap<String, serde_json::Value>,
     incoming: BTreeMap<String, serde_json::Value>,
+    idx: usize,
 ) -> crate::Result {
     for (key, value) in incoming {
         match out.get(&key) {
             Some(existing) if existing != &value => {
                 return Err(duvet_core::error!(
-                    "conflicting extension '{}' under {} across inputs",
+                    "input #{} has extension '{}' under {} conflicting with previously seen value",
+                    idx,
                     key,
-                    bucket
+                    bucket,
                 ));
             }
             Some(_) => {}
@@ -713,6 +734,46 @@ mod tests {
             merged.issue_links,
             vec!["x".to_string(), "y".to_string(), "z".to_string()]
         );
+    }
+
+    #[test]
+    fn merge_error_names_offending_input_index_for_non_adjacent_conflict() {
+        // 3-way fold where #0 and #2 conflict on a spec title, with #1
+        // contributing nothing on `spc-1`. The error should name the
+        // incoming input (#2), not just print "A vs B" without a pointer.
+        let mut a = empty();
+        a.annotations.specification.insert(
+            "spc-1".to_string(),
+            SpecificationAnnotation {
+                source: SourceRef {
+                    src: "src-x".to_string(),
+                    start: 0,
+                    end: 1,
+                },
+                title: Some("A".to_string()),
+                format: "markdown".to_string(),
+            },
+        );
+        let b = empty();
+        let mut c = empty();
+        c.annotations.specification.insert(
+            "spc-1".to_string(),
+            SpecificationAnnotation {
+                source: SourceRef {
+                    src: "src-x".to_string(),
+                    start: 0,
+                    end: 1,
+                },
+                title: Some("C".to_string()),
+                format: "markdown".to_string(),
+            },
+        );
+
+        let err = merge_reports(vec![a, b, c]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("input #2"), "msg = {msg}");
+        assert!(msg.contains("spc-1"), "msg = {msg}");
+        assert!(msg.contains("title"), "msg = {msg}");
     }
 
     #[test]

--- a/duvet/src/report/json_v2_merge.rs
+++ b/duvet/src/report/json_v2_merge.rs
@@ -145,16 +145,14 @@ fn merge_one(out: &mut ReportV2, incoming: ReportV2) -> crate::Result {
     Ok(())
 }
 
-/// `issue_links` is an order-preserving deduped concatenation. We can't use
-/// a `BTreeMap` here because the schema is a free-form `Vec<String>` with
-/// no ID, but we still want a stable, idempotent result: appending a link
-/// already present is a no-op.
+/// `issue_links` is a sorted, deduped union. The schema is a free-form
+/// `Vec<String>` with no ID, so we can't use a `BTreeMap`; sort+dedup gives
+/// a canonical order that is independent of fold order, which is what keeps
+/// the binary merge commutative (and therefore the N-way fold associative).
 fn merge_issue_links(out: &mut Vec<String>, incoming: Vec<String>) {
-    for link in incoming {
-        if !out.contains(&link) {
-            out.push(link);
-        }
-    }
+    out.extend(incoming);
+    out.sort();
+    out.dedup();
 }
 
 fn merge_repositories(
@@ -1250,6 +1248,22 @@ mod tests {
         c.tags = vec![tag.to_string()];
         r.annotations.cite.insert("cite-shared".to_string(), c);
         r
+    }
+
+    #[test]
+    fn property_commutativity_of_issue_links() {
+        // `issue_links` has no entity ID, so the only thing keeping the merge
+        // commutative is canonical ordering of the unioned list. With
+        // overlapping-but-not-equal inputs, an order-preserving append
+        // would produce different results for `[a, b]` vs `[b, a]`.
+        let mut a = empty();
+        a.issue_links = vec!["x".to_string(), "y".to_string()];
+        let mut b = empty();
+        b.issue_links = vec!["y".to_string(), "z".to_string()];
+
+        let forward = merge_reports(vec![a.clone(), b.clone()]).unwrap();
+        let reverse = merge_reports(vec![b, a]).unwrap();
+        assert_eq!(forward, reverse);
     }
 
     #[test]

--- a/duvet/src/report/json_v2_merge.rs
+++ b/duvet/src/report/json_v2_merge.rs
@@ -1,0 +1,1039 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Multi-report merge for v2 JSON reports.
+//!
+//! # Strategy
+//!
+//! v2 entity IDs are deterministic FNV-1a 64-bit hashes of structurally
+//! significant fields (see `crate::ids` for the per-entity hash schema).
+//! Equal IDs across inputs therefore imply that the *hashed* fields are
+//! equal — modulo the ~1-in-2^32 birthday-bound collision probability the
+//! `ids.rs` module documents.
+//!
+//! Given that, merging N reports collapses to a per-bucket [`BTreeMap`]
+//! union keyed by ID. For each ID seen in more than one input we then need
+//! to reconcile *un-hashed* fields: those are not implied by ID equality,
+//! so two inputs can disagree.
+//!
+//! # Field classification
+//!
+//! Each entity field falls into one of three categories:
+//!
+//! 1. **Hash-input** — included in the FNV-1a key. ID equality implies field
+//!    equality, so any mismatch is a hash collision (or a producer bug). We
+//!    treat these as hard errors — silently dropping one side could merge
+//!    structurally distinct entities. See `ids.rs`: "a merge tool should
+//!    detect and handle collisions".
+//!
+//! 2. **Structural conflict** — outside the hash, but we still require
+//!    agreement (e.g. spec `title`, requirement `level`, cite `anno_type`).
+//!    A mismatch indicates the producers disagree on the entity's meaning;
+//!    refusing to merge protects downstream consumers from silently averaged
+//!    semantics.
+//!
+//! 3. **Soft drift** — outside the hash and tolerated. Cite metadata
+//!    (`comment`, `feature`, `tracking_issue`, `tags`) often differs across
+//!    branches/checkouts and isn't load-bearing for traceability; we keep
+//!    the value from the first input that defined the ID and warn so the
+//!    drift is observable.
+//!
+//! Coverage on requirements is a fourth, special case: it's a *set* keyed
+//! by cite ID, so we merge by union and post-process with sort+dedup so the
+//! merged report is canonical regardless of input order.
+
+use crate::report::json_v2::{
+    AnnotationsV2, CiteAnnotation, ReportV2, Repository, RequirementAnnotation, SectionAnnotation,
+    SourcesV2, SpecificationAnnotation,
+};
+use std::collections::BTreeMap;
+
+/// Merge `reports` into a single `ReportV2`.
+///
+/// Returns an error when:
+/// * `reports` is empty.
+/// * Any input report has `version != "2.0"`.
+/// * Two inputs disagree on a structurally meaningful field for the same
+///   entity ID (e.g. spec annotation title, requirement level, cite
+///   `anno_type`/`level`/`target`, or extension key value).
+/// * A hash-input invariant fails — i.e. two inputs share an ID but differ
+///   on a field that goes into that ID's hash. This is either a hash
+///   collision or a producer bug; either way we refuse to silently merge.
+pub fn merge_reports(reports: Vec<ReportV2>) -> crate::Result<ReportV2> {
+    if reports.is_empty() {
+        return Err(duvet_core::error!(
+            "merge requires at least one input report"
+        ));
+    }
+
+    // Use the first input as the accumulator and fold the rest in. Because
+    // every per-bucket merge operation is a BTreeMap union over content-
+    // hashed IDs, the choice of seed doesn't affect the final result —
+    // the merge is order-independent (see `property_commutativity_*`).
+    let mut iter = reports.into_iter();
+    let mut out = iter.next().expect("non-empty");
+    if out.version != "2.0" {
+        return Err(duvet_core::error!(
+            "unsupported report version '{}', expected '2.0'",
+            out.version
+        ));
+    }
+
+    for next in iter {
+        merge_one(&mut out, next)?;
+    }
+
+    // After all inputs have been folded in, normalize coverage range lists
+    // so the output is stable regardless of input order or duplicates.
+    finalize_coverage(&mut out.annotations.requirement);
+
+    Ok(out)
+}
+
+fn merge_one(out: &mut ReportV2, incoming: ReportV2) -> crate::Result {
+    if incoming.version != "2.0" {
+        return Err(duvet_core::error!(
+            "unsupported report version '{}', expected '2.0'",
+            incoming.version
+        ));
+    }
+
+    // Each top-level bucket is independent: ordering between them doesn't
+    // matter, and within a bucket the merge is keyed by deterministic ID.
+    merge_issue_links(&mut out.issue_links, incoming.issue_links);
+    merge_repositories(&mut out.repositories, incoming.repositories)?;
+    merge_sources(&mut out.sources, incoming.sources)?;
+    merge_annotations(&mut out.annotations, incoming.annotations)?;
+
+    Ok(())
+}
+
+/// `issue_links` is an order-preserving deduped concatenation. We can't use
+/// a `BTreeMap` here because the schema is a free-form `Vec<String>` with
+/// no ID, but we still want a stable, idempotent result: appending a link
+/// already present is a no-op.
+fn merge_issue_links(out: &mut Vec<String>, incoming: Vec<String>) {
+    for link in incoming {
+        if !out.contains(&link) {
+            out.push(link);
+        }
+    }
+}
+
+fn merge_repositories(
+    out: &mut BTreeMap<String, Repository>,
+    incoming: BTreeMap<String, Repository>,
+) -> crate::Result {
+    for (id, repo) in incoming {
+        match out.get(&id) {
+            Some(existing) => {
+                // `blob_link` is the sole hash input for `repo-` IDs, so
+                // ID equality must imply blob_link equality. If it doesn't,
+                // we've hit a hash collision (or a producer bug) and have
+                // no safe way to pick between the two.
+                if existing.blob_link != repo.blob_link {
+                    return Err(duvet_core::error!(
+                        "internal invariant violation: repository '{}' has different blob_link across inputs ('{}' vs '{}'); likely hash collision or producer bug",
+                        id,
+                        existing.blob_link,
+                        repo.blob_link
+                    ));
+                }
+            }
+            None => {
+                out.insert(id, repo);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn merge_sources(out: &mut SourcesV2, incoming: SourcesV2) -> crate::Result {
+    // Inline sources: `src-` IDs hash the contents only, so contents
+    // equality is implied by ID equality. `file_name` is *not* hashed —
+    // two reports can legitimately disagree on the path they observed for
+    // the same bytes (e.g. one stores `specs/rfc.txt`, another stores an
+    // absolute path), and we surface that as a hard error rather than
+    // silently picking a side.
+    for (id, src) in incoming.inline {
+        match out.inline.get(&id) {
+            Some(existing) => {
+                if existing.contents != src.contents {
+                    return Err(duvet_core::error!(
+                        "internal invariant violation: inline source '{}' has different contents across inputs; likely hash collision or producer bug",
+                        id
+                    ));
+                }
+                if existing.file_name != src.file_name {
+                    return Err(duvet_core::error!(
+                        "inline source '{}' has conflicting file_name across inputs: '{}' vs '{}'",
+                        id,
+                        existing.file_name,
+                        src.file_name
+                    ));
+                }
+            }
+            None => {
+                out.inline.insert(id, src);
+            }
+        }
+    }
+
+    // Linked sources: `lnk-` IDs hash both `file_name` and `repository_id`.
+    // The struct itself only carries those two fields, so ID equality
+    // implies struct equality. Any disagreement is a hash collision.
+    for (id, src) in incoming.linked {
+        match out.linked.get(&id) {
+            Some(existing) => {
+                if existing != &src {
+                    return Err(duvet_core::error!(
+                        "internal invariant violation: linked source '{}' differs across inputs; likely hash collision or producer bug",
+                        id
+                    ));
+                }
+            }
+            None => {
+                out.linked.insert(id, src);
+            }
+        }
+    }
+
+    // Unknown URL-keyed source buckets are passed through verbatim under
+    // strict equality — see `merge_extensions`.
+    merge_extensions("sources", &mut out.extensions, incoming.extensions)?;
+
+    Ok(())
+}
+
+fn merge_annotations(out: &mut AnnotationsV2, incoming: AnnotationsV2) -> crate::Result {
+    // Each annotation kind has its own conflict policy; see the per-kind
+    // helpers below for the precise rules.
+    for (id, anno) in incoming.specification {
+        merge_specification(&mut out.specification, id, anno)?;
+    }
+    for (id, anno) in incoming.section {
+        merge_section(&mut out.section, id, anno)?;
+    }
+    for (id, anno) in incoming.requirement {
+        merge_requirement(&mut out.requirement, id, anno)?;
+    }
+    for (id, anno) in incoming.cite {
+        merge_cite(&mut out.cite, id, anno)?;
+    }
+
+    merge_extensions("annotations", &mut out.extensions, incoming.extensions)?;
+
+    Ok(())
+}
+
+/// `spc-` IDs hash `(source_id, start, end)`, so `source` equality is
+/// implied by ID equality. `title` and `format` aren't hashed — they
+/// reflect parser metadata that can legitimately differ (and that we treat
+/// as semantically load-bearing, hence hard errors on mismatch).
+fn merge_specification(
+    out: &mut BTreeMap<String, SpecificationAnnotation>,
+    id: String,
+    anno: SpecificationAnnotation,
+) -> crate::Result {
+    match out.get(&id) {
+        Some(existing) => {
+            if existing.title != anno.title {
+                return Err(duvet_core::error!(
+                    "specification annotation '{}' has conflicting title across inputs: {:?} vs {:?}",
+                    id, existing.title, anno.title
+                ));
+            }
+            if existing.format != anno.format {
+                return Err(duvet_core::error!(
+                    "specification annotation '{}' has conflicting format across inputs: '{}' vs '{}'",
+                    id, existing.format, anno.format
+                ));
+            }
+            if existing.source != anno.source {
+                return Err(duvet_core::error!(
+                    "internal invariant violation: specification '{}' has different source across inputs; likely hash collision or producer bug",
+                    id
+                ));
+            }
+        }
+        None => {
+            out.insert(id, anno);
+        }
+    }
+    Ok(())
+}
+
+/// `sec-` IDs hash `(source_id, start, end)` like `spc-`. `short_name` and
+/// `long_name` are extracted by the parser and not hashed; mismatches are
+/// hard errors so consumers don't see ambiguous section labels.
+fn merge_section(
+    out: &mut BTreeMap<String, SectionAnnotation>,
+    id: String,
+    anno: SectionAnnotation,
+) -> crate::Result {
+    match out.get(&id) {
+        Some(existing) => {
+            if existing.short_name != anno.short_name {
+                return Err(duvet_core::error!(
+                    "section annotation '{}' has conflicting short_name across inputs: '{}' vs '{}'",
+                    id, existing.short_name, anno.short_name
+                ));
+            }
+            if existing.long_name != anno.long_name {
+                return Err(duvet_core::error!(
+                    "section annotation '{}' has conflicting long_name across inputs: {:?} vs {:?}",
+                    id,
+                    existing.long_name,
+                    anno.long_name
+                ));
+            }
+            if existing.source != anno.source {
+                return Err(duvet_core::error!(
+                    "internal invariant violation: section '{}' has different source across inputs; likely hash collision or producer bug",
+                    id
+                ));
+            }
+        }
+        None => {
+            out.insert(id, anno);
+        }
+    }
+    Ok(())
+}
+
+/// Requirements are special: `req-` IDs hash origin, ranges, source, *and*
+/// line, so `source` and `origin` equality follow from ID equality. `level`
+/// is an out-of-hash structural field we require agreement on. `coverage`
+/// is set-valued and unioned across inputs — different reports may witness
+/// disjoint cite IDs for the same requirement, and a merge that dropped
+/// either set would lose traceability.
+fn merge_requirement(
+    out: &mut BTreeMap<String, RequirementAnnotation>,
+    id: String,
+    anno: RequirementAnnotation,
+) -> crate::Result {
+    match out.get_mut(&id) {
+        Some(existing) => {
+            if existing.level != anno.level {
+                return Err(duvet_core::error!(
+                    "requirement annotation '{}' has conflicting level across inputs: {:?} vs {:?}",
+                    id,
+                    existing.level,
+                    anno.level
+                ));
+            }
+            if existing.source != anno.source {
+                return Err(duvet_core::error!(
+                    "internal invariant violation: requirement '{}' has different source across inputs; likely hash collision or producer bug",
+                    id
+                ));
+            }
+            if existing.origin != anno.origin {
+                return Err(duvet_core::error!(
+                    "internal invariant violation: requirement '{}' has different origin across inputs; likely hash collision or producer bug",
+                    id
+                ));
+            }
+
+            // Coverage is the merge of two cite-keyed range sets. We extend
+            // here and normalize (sort+dedup) once at the end, in
+            // `finalize_coverage`, to keep the per-merge cost linear.
+            for (cite_id, ranges) in anno.coverage {
+                existing.coverage.entry(cite_id).or_default().extend(ranges);
+            }
+        }
+        None => {
+            out.insert(id, anno);
+        }
+    }
+    Ok(())
+}
+
+/// `cite-` IDs hash `(source_id, line, target_source_id)`, so `source` and
+/// `target.src` are guaranteed by ID equality. `target.ranges`,
+/// `anno_type`, and `level` are out-of-hash structural fields — mismatches
+/// here would change the meaning of the citation, so we hard-error.
+///
+/// The "soft" cite metadata (`comment`, `feature`, `tracking_issue`,
+/// `tags`) is not load-bearing for traceability and routinely drifts
+/// across branches; we keep the first value seen and warn — see
+/// [`warn_on_soft_drift`].
+fn merge_cite(
+    out: &mut BTreeMap<String, CiteAnnotation>,
+    id: String,
+    anno: CiteAnnotation,
+) -> crate::Result {
+    match out.get(&id) {
+        Some(existing) => {
+            if existing.anno_type != anno.anno_type {
+                return Err(duvet_core::error!(
+                    "cite annotation '{}' has conflicting type across inputs: {:?} vs {:?}",
+                    id,
+                    existing.anno_type,
+                    anno.anno_type
+                ));
+            }
+            if existing.level != anno.level {
+                return Err(duvet_core::error!(
+                    "cite annotation '{}' has conflicting level across inputs: {:?} vs {:?}",
+                    id,
+                    existing.level,
+                    anno.level
+                ));
+            }
+            if existing.target != anno.target {
+                return Err(duvet_core::error!(
+                    "cite annotation '{}' has conflicting target across inputs",
+                    id
+                ));
+            }
+            if existing.source != anno.source {
+                return Err(duvet_core::error!(
+                    "internal invariant violation: cite '{}' has different source across inputs; likely hash collision or producer bug",
+                    id
+                ));
+            }
+
+            warn_on_soft_drift(&id, existing, &anno);
+        }
+        None => {
+            out.insert(id, anno);
+        }
+    }
+    Ok(())
+}
+
+fn warn_on_soft_drift(id: &str, existing: &CiteAnnotation, incoming: &CiteAnnotation) {
+    let mut drifted = Vec::new();
+    if existing.comment != incoming.comment {
+        drifted.push("comment");
+    }
+    if existing.feature != incoming.feature {
+        drifted.push("feature");
+    }
+    if existing.tracking_issue != incoming.tracking_issue {
+        drifted.push("tracking_issue");
+    }
+    if existing.tags != incoming.tags {
+        drifted.push("tags");
+    }
+    if !drifted.is_empty() {
+        eprintln!(
+            "warning: cite annotation '{}' has metadata drift across inputs ({}); keeping value from first input",
+            id,
+            drifted.join(", ")
+        );
+    }
+}
+
+/// Forward-compatibility passthrough for unknown URL-keyed buckets in
+/// `sources` / `annotations`. We can't introspect the value semantics, so
+/// we require strict equality on conflict; producers that want softer
+/// merge behavior should add a typed bucket and a per-kind handler above.
+fn merge_extensions(
+    bucket: &str,
+    out: &mut BTreeMap<String, serde_json::Value>,
+    incoming: BTreeMap<String, serde_json::Value>,
+) -> crate::Result {
+    for (key, value) in incoming {
+        match out.get(&key) {
+            Some(existing) if existing != &value => {
+                return Err(duvet_core::error!(
+                    "conflicting extension '{}' under {} across inputs",
+                    key,
+                    bucket
+                ));
+            }
+            Some(_) => {}
+            None => {
+                out.insert(key, value);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Sort + dedup every coverage `Vec<ByteRange>` after all inputs have been
+/// merged in. Keeps the merged output canonical regardless of input order.
+fn finalize_coverage(requirements: &mut BTreeMap<String, RequirementAnnotation>) {
+    for req in requirements.values_mut() {
+        for ranges in req.coverage.values_mut() {
+            ranges.sort();
+            ranges.dedup();
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::json_v2::{
+        AnnotationLevel, AnnotationType, ByteRange, InlineSource, SourceLocation, SourceRanges,
+        SourceRef,
+    };
+
+    fn empty() -> ReportV2 {
+        ReportV2 {
+            version: "2.0".to_string(),
+            issue_links: Vec::new(),
+            repositories: BTreeMap::new(),
+            sources: SourcesV2::default(),
+            annotations: AnnotationsV2::default(),
+        }
+    }
+
+    fn cite(
+        line: usize,
+        anno_type: AnnotationType,
+        target_ranges: Vec<ByteRange>,
+    ) -> CiteAnnotation {
+        CiteAnnotation {
+            source: SourceLocation {
+                src: "lnk-x".to_string(),
+                line: Some(line),
+            },
+            target: SourceRanges {
+                src: "src-spec".to_string(),
+                ranges: target_ranges,
+            },
+            anno_type,
+            level: AnnotationLevel::Auto,
+            comment: None,
+            feature: None,
+            tracking_issue: None,
+            tags: Vec::new(),
+        }
+    }
+
+    fn req(level: AnnotationLevel, ranges: Vec<ByteRange>) -> RequirementAnnotation {
+        RequirementAnnotation {
+            source: SourceLocation {
+                src: "lnk-x".to_string(),
+                line: Some(1),
+            },
+            origin: SourceRanges {
+                src: "src-spec".to_string(),
+                ranges,
+            },
+            level,
+            coverage: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn merge_empty_inputs_errors() {
+        let result = merge_reports(Vec::new());
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("at least one"), "msg = {msg}");
+    }
+
+    #[test]
+    fn merge_single_input_is_identity() {
+        let r = empty();
+        let merged = merge_reports(vec![r.clone()]).unwrap();
+        assert_eq!(merged, r);
+    }
+
+    #[test]
+    fn merge_two_disjoint() {
+        let mut a = empty();
+        a.repositories.insert(
+            "repo-a".to_string(),
+            Repository {
+                blob_link: "blob_a".to_string(),
+            },
+        );
+        let mut b = empty();
+        b.repositories.insert(
+            "repo-b".to_string(),
+            Repository {
+                blob_link: "blob_b".to_string(),
+            },
+        );
+
+        let merged = merge_reports(vec![a, b]).unwrap();
+        assert_eq!(merged.repositories.len(), 2);
+        assert!(merged.repositories.contains_key("repo-a"));
+        assert!(merged.repositories.contains_key("repo-b"));
+    }
+
+    #[test]
+    fn merge_dedups_shared_inline_source() {
+        let mut a = empty();
+        a.sources.inline.insert(
+            "src-1".to_string(),
+            InlineSource {
+                file_name: "spec.md".to_string(),
+                contents: "X".to_string(),
+            },
+        );
+        let b = a.clone();
+        let merged = merge_reports(vec![a, b]).unwrap();
+        assert_eq!(merged.sources.inline.len(), 1);
+    }
+
+    #[test]
+    fn merge_unions_requirement_coverage() {
+        let mut a = empty();
+        let mut req_a = req(AnnotationLevel::Must, vec![ByteRange { start: 0, end: 10 }]);
+        req_a
+            .coverage
+            .insert("cite-aa".to_string(), vec![ByteRange { start: 0, end: 5 }]);
+        a.annotations.requirement.insert("req-1".to_string(), req_a);
+
+        let mut b = empty();
+        let mut req_b = req(AnnotationLevel::Must, vec![ByteRange { start: 0, end: 10 }]);
+        req_b
+            .coverage
+            .insert("cite-bb".to_string(), vec![ByteRange { start: 5, end: 10 }]);
+        b.annotations.requirement.insert("req-1".to_string(), req_b);
+
+        let merged = merge_reports(vec![a, b]).unwrap();
+        let req = merged.annotations.requirement.get("req-1").unwrap();
+        assert_eq!(req.coverage.len(), 2);
+        assert!(req.coverage.contains_key("cite-aa"));
+        assert!(req.coverage.contains_key("cite-bb"));
+    }
+
+    #[test]
+    fn merge_dedups_overlapping_coverage_ranges() {
+        let mut a = empty();
+        let mut req_a = req(AnnotationLevel::Must, vec![ByteRange { start: 0, end: 10 }]);
+        req_a.coverage.insert(
+            "cite-aa".to_string(),
+            vec![
+                ByteRange { start: 0, end: 5 },
+                ByteRange { start: 7, end: 10 },
+            ],
+        );
+        a.annotations.requirement.insert("req-1".to_string(), req_a);
+
+        let mut b = empty();
+        let mut req_b = req(AnnotationLevel::Must, vec![ByteRange { start: 0, end: 10 }]);
+        req_b.coverage.insert(
+            "cite-aa".to_string(),
+            vec![
+                ByteRange { start: 0, end: 5 },
+                ByteRange { start: 5, end: 8 },
+            ],
+        );
+        b.annotations.requirement.insert("req-1".to_string(), req_b);
+
+        let merged = merge_reports(vec![a, b]).unwrap();
+        let ranges = &merged.annotations.requirement["req-1"].coverage["cite-aa"];
+        assert_eq!(
+            ranges,
+            &vec![
+                ByteRange { start: 0, end: 5 },
+                ByteRange { start: 5, end: 8 },
+                ByteRange { start: 7, end: 10 },
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_concats_issue_links_dedup() {
+        let mut a = empty();
+        a.issue_links = vec!["x".to_string(), "y".to_string()];
+        let mut b = empty();
+        b.issue_links = vec!["y".to_string(), "z".to_string()];
+
+        let merged = merge_reports(vec![a, b]).unwrap();
+        assert_eq!(
+            merged.issue_links,
+            vec!["x".to_string(), "y".to_string(), "z".to_string()]
+        );
+    }
+
+    #[test]
+    fn merge_errors_on_spec_title_mismatch() {
+        let mut a = empty();
+        a.annotations.specification.insert(
+            "spc-1".to_string(),
+            SpecificationAnnotation {
+                source: SourceRef {
+                    src: "src-x".to_string(),
+                    start: 0,
+                    end: 1,
+                },
+                title: Some("A".to_string()),
+                format: "markdown".to_string(),
+            },
+        );
+        let mut b = empty();
+        b.annotations.specification.insert(
+            "spc-1".to_string(),
+            SpecificationAnnotation {
+                source: SourceRef {
+                    src: "src-x".to_string(),
+                    start: 0,
+                    end: 1,
+                },
+                title: Some("B".to_string()),
+                format: "markdown".to_string(),
+            },
+        );
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("spc-1"), "msg = {msg}");
+        assert!(msg.contains("title"), "msg = {msg}");
+    }
+
+    #[test]
+    fn merge_errors_on_section_long_name_mismatch() {
+        let mut a = empty();
+        a.annotations.section.insert(
+            "sec-1".to_string(),
+            SectionAnnotation {
+                source: SourceRef {
+                    src: "src-x".to_string(),
+                    start: 0,
+                    end: 1,
+                },
+                short_name: "s".to_string(),
+                long_name: Some("A".to_string()),
+            },
+        );
+        let mut b = empty();
+        b.annotations.section.insert(
+            "sec-1".to_string(),
+            SectionAnnotation {
+                source: SourceRef {
+                    src: "src-x".to_string(),
+                    start: 0,
+                    end: 1,
+                },
+                short_name: "s".to_string(),
+                long_name: Some("B".to_string()),
+            },
+        );
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        assert!(format!("{err}").contains("long_name"));
+    }
+
+    #[test]
+    fn merge_errors_on_inline_source_file_name_mismatch() {
+        let mut a = empty();
+        a.sources.inline.insert(
+            "src-1".to_string(),
+            InlineSource {
+                file_name: "a.md".to_string(),
+                contents: "X".to_string(),
+            },
+        );
+        let mut b = empty();
+        b.sources.inline.insert(
+            "src-1".to_string(),
+            InlineSource {
+                file_name: "b.md".to_string(),
+                contents: "X".to_string(),
+            },
+        );
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        assert!(format!("{err}").contains("file_name"));
+    }
+
+    #[test]
+    fn merge_errors_on_requirement_level_mismatch() {
+        let mut a = empty();
+        a.annotations
+            .requirement
+            .insert("req-1".to_string(), req(AnnotationLevel::Must, vec![]));
+        let mut b = empty();
+        b.annotations
+            .requirement
+            .insert("req-1".to_string(), req(AnnotationLevel::Should, vec![]));
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        assert!(format!("{err}").contains("level"));
+    }
+
+    #[test]
+    fn merge_errors_on_cite_anno_type_mismatch() {
+        let mut a = empty();
+        a.annotations.cite.insert(
+            "cite-1".to_string(),
+            cite(1, AnnotationType::Citation, vec![]),
+        );
+        let mut b = empty();
+        b.annotations
+            .cite
+            .insert("cite-1".to_string(), cite(1, AnnotationType::Test, vec![]));
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        assert!(format!("{err}").contains("type"));
+    }
+
+    #[test]
+    fn merge_errors_on_cite_target_mismatch() {
+        let mut a = empty();
+        a.annotations.cite.insert(
+            "cite-1".to_string(),
+            cite(
+                1,
+                AnnotationType::Citation,
+                vec![ByteRange { start: 0, end: 5 }],
+            ),
+        );
+        let mut b = empty();
+        b.annotations.cite.insert(
+            "cite-1".to_string(),
+            cite(
+                1,
+                AnnotationType::Citation,
+                vec![ByteRange { start: 0, end: 6 }],
+            ),
+        );
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        assert!(format!("{err}").contains("target"));
+    }
+
+    #[test]
+    fn merge_errors_on_cite_level_mismatch() {
+        let mut c1 = cite(1, AnnotationType::Citation, vec![]);
+        c1.level = AnnotationLevel::Must;
+        let mut c2 = cite(1, AnnotationType::Citation, vec![]);
+        c2.level = AnnotationLevel::Should;
+
+        let mut a = empty();
+        a.annotations.cite.insert("cite-1".to_string(), c1);
+        let mut b = empty();
+        b.annotations.cite.insert("cite-1".to_string(), c2);
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        assert!(format!("{err}").contains("level"));
+    }
+
+    #[test]
+    fn merge_warns_on_cite_comment_drift_keeps_first() {
+        let mut c1 = cite(1, AnnotationType::Citation, vec![]);
+        c1.comment = Some("first".to_string());
+        let mut c2 = cite(1, AnnotationType::Citation, vec![]);
+        c2.comment = Some("second".to_string());
+
+        let mut a = empty();
+        a.annotations.cite.insert("cite-1".to_string(), c1);
+        let mut b = empty();
+        b.annotations.cite.insert("cite-1".to_string(), c2);
+
+        let merged = merge_reports(vec![a, b]).unwrap();
+        assert_eq!(
+            merged.annotations.cite["cite-1"].comment.as_deref(),
+            Some("first")
+        );
+    }
+
+    #[test]
+    fn merge_errors_on_extension_conflict() {
+        let mut a = empty();
+        a.sources
+            .extensions
+            .insert("https://x/y".to_string(), serde_json::json!({"v": 1}));
+        let mut b = empty();
+        b.sources
+            .extensions
+            .insert("https://x/y".to_string(), serde_json::json!({"v": 2}));
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("https://x/y"), "msg = {msg}");
+    }
+
+    #[test]
+    fn merge_passes_through_identical_extensions() {
+        let mut a = empty();
+        a.sources
+            .extensions
+            .insert("https://x/y".to_string(), serde_json::json!({"v": 1}));
+        let b = a.clone();
+        let merged = merge_reports(vec![a, b]).unwrap();
+        assert_eq!(merged.sources.extensions.len(), 1);
+    }
+
+    #[test]
+    fn merge_errors_on_unsupported_version() {
+        let mut a = empty();
+        a.version = "1.0".to_string();
+        let err = merge_reports(vec![a]).unwrap_err();
+        assert!(format!("{err}").contains("unsupported report version"));
+    }
+
+    #[test]
+    fn merge_errors_on_unsupported_version_in_second_input() {
+        let a = empty();
+        let mut b = empty();
+        b.version = "3.0".to_string();
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        assert!(format!("{err}").contains("unsupported report version"));
+    }
+
+    #[test]
+    fn merge_errors_on_repository_blob_link_collision() {
+        // Same repo-id, different blob_link — i.e. simulated hash collision.
+        let mut a = empty();
+        a.repositories.insert(
+            "repo-1".to_string(),
+            Repository {
+                blob_link: "blob_one".to_string(),
+            },
+        );
+        let mut b = empty();
+        b.repositories.insert(
+            "repo-1".to_string(),
+            Repository {
+                blob_link: "blob_two".to_string(),
+            },
+        );
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("invariant"), "msg = {msg}");
+        assert!(msg.contains("blob_link"), "msg = {msg}");
+    }
+
+    #[test]
+    fn merge_errors_on_inline_source_contents_collision() {
+        // Same src-id, different contents — simulated hash collision.
+        let mut a = empty();
+        a.sources.inline.insert(
+            "src-1".to_string(),
+            InlineSource {
+                file_name: "spec.md".to_string(),
+                contents: "X".to_string(),
+            },
+        );
+        let mut b = empty();
+        b.sources.inline.insert(
+            "src-1".to_string(),
+            InlineSource {
+                file_name: "spec.md".to_string(),
+                contents: "Y".to_string(),
+            },
+        );
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        assert!(format!("{err}").contains("invariant"));
+    }
+
+    // ── Property tests ──
+
+    fn fixture_a() -> ReportV2 {
+        let mut r = empty();
+        r.repositories.insert(
+            "repo-a".to_string(),
+            Repository {
+                blob_link: "blob_a".to_string(),
+            },
+        );
+        r.sources.inline.insert(
+            "src-1".to_string(),
+            InlineSource {
+                file_name: "spec.md".to_string(),
+                contents: "X".to_string(),
+            },
+        );
+        let mut req_x = req(AnnotationLevel::Must, vec![ByteRange { start: 0, end: 10 }]);
+        req_x
+            .coverage
+            .insert("cite-aa".to_string(), vec![ByteRange { start: 0, end: 5 }]);
+        r.annotations.requirement.insert("req-1".to_string(), req_x);
+        r.annotations.cite.insert(
+            "cite-aa".to_string(),
+            cite(10, AnnotationType::Citation, vec![]),
+        );
+        r
+    }
+
+    fn fixture_b() -> ReportV2 {
+        let mut r = empty();
+        r.repositories.insert(
+            "repo-b".to_string(),
+            Repository {
+                blob_link: "blob_b".to_string(),
+            },
+        );
+        r.sources.inline.insert(
+            "src-1".to_string(),
+            InlineSource {
+                file_name: "spec.md".to_string(),
+                contents: "X".to_string(),
+            },
+        );
+        let mut req_x = req(AnnotationLevel::Must, vec![ByteRange { start: 0, end: 10 }]);
+        req_x
+            .coverage
+            .insert("cite-bb".to_string(), vec![ByteRange { start: 5, end: 10 }]);
+        r.annotations.requirement.insert("req-1".to_string(), req_x);
+        r.annotations.cite.insert(
+            "cite-bb".to_string(),
+            cite(20, AnnotationType::Citation, vec![]),
+        );
+        r
+    }
+
+    fn fixture_c() -> ReportV2 {
+        let mut r = empty();
+        r.repositories.insert(
+            "repo-c".to_string(),
+            Repository {
+                blob_link: "blob_c".to_string(),
+            },
+        );
+        r
+    }
+
+    #[test]
+    fn property_commutativity_handcrafted() {
+        let a = fixture_a();
+        let b = fixture_b();
+        let forward = merge_reports(vec![a.clone(), b.clone()]).unwrap();
+        let reverse = merge_reports(vec![b, a]).unwrap();
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn property_associativity_handcrafted() {
+        let a = fixture_a();
+        let b = fixture_b();
+        let c = fixture_c();
+        let abc = merge_reports(vec![a.clone(), b.clone(), c.clone()]).unwrap();
+        let ab = merge_reports(vec![a, b]).unwrap();
+        let abc2 = merge_reports(vec![ab, c]).unwrap();
+        assert_eq!(abc, abc2);
+    }
+
+    #[test]
+    fn property_idempotency_handcrafted() {
+        let a = fixture_a();
+        let merged = merge_reports(vec![a.clone(), a.clone()]).unwrap();
+        assert_eq!(merged, a);
+    }
+
+    #[test]
+    fn property_serde_roundtrip_after_merge() {
+        let merged = merge_reports(vec![fixture_a(), fixture_b()]).unwrap();
+        let json = serde_json::to_string(&merged).unwrap();
+        let back: ReportV2 = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, merged);
+    }
+
+    // ── Light snapshot-based smoke test ──
+    //
+    // Read an existing v2 report fixture (the same one used by
+    // `real_report_snapshot_roundtrip` in `json_v2.rs`), self-merge it,
+    // assert the result equals the input. This exercises the merge code
+    // path against realistic data without needing fixture sets or a
+    // generator.
+
+    #[test]
+    fn merge_real_snapshot_self_idempotent() {
+        const SNAPSHOT: &str =
+            include_str!("../../../integration/snapshots/report-markdown_json_v2.snap");
+        let json = SNAPSHOT
+            .split_once("---\n")
+            .and_then(|(_, rest)| rest.split_once("---\n"))
+            .map(|(_, body)| body)
+            .expect("snapshot should have two `---` front-matter delimiters");
+        let report: ReportV2 = serde_json::from_str(json).expect("must deserialize");
+
+        let merged = merge_reports(vec![report.clone(), report.clone()]).unwrap();
+        assert_eq!(merged, report);
+    }
+}

--- a/integration/merge-multi-package.toml
+++ b/integration/merge-multi-package.toml
@@ -1,0 +1,87 @@
+# End-to-end test for `duvet merge`: one shared specification, two packages
+# that each cover a different (overlapping) subset of the spec. Verifies that
+# merging the two per-package reports yields a single report where the shared
+# spec deduplicates, both repositories survive, and the requirement covered
+# by both packages has two distinct cite entries in its coverage map.
+
+source = { local = true }
+cmd = [
+  "duvet report --config-path=package-a/.duvet/config.toml --json-v2=package-a/duvet_report_v2.json",
+  "duvet report --config-path=package-b/.duvet/config.toml --json-v2=package-b/duvet_report_v2.json",
+  "duvet merge --input=package-a/duvet_report_v2.json --input=package-b/duvet_report_v2.json --output=merged.json",
+]
+extra_json_snapshots = [
+  "package-a/duvet_report_v2.json",
+  "package-b/duvet_report_v2.json",
+  "merged.json",
+]
+
+[[file]]
+path = "my-spec.md"
+contents = """
+# My Specification
+
+## Feature A
+
+Feature A MUST be implemented.
+
+## Feature B
+
+Feature B MUST be implemented.
+
+## Feature C
+
+Feature C MUST be implemented.
+"""
+
+[[file]]
+path = "package-a/.duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "package-a/src/*.rs"
+blob-link = "https://github.com/org/package-a/blob/main"
+
+[[requirement]]
+pattern = "package-a/.duvet/requirements/**/*.toml"
+
+[[specification]]
+source = "my-spec.md"
+"""
+
+[[file]]
+path = "package-a/src/impl.rs"
+contents = """
+//= my-spec.md#feature-a
+//# Feature A MUST be implemented.
+
+//= my-spec.md#feature-b
+//# Feature B MUST be implemented.
+"""
+
+[[file]]
+path = "package-b/.duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "package-b/src/*.rs"
+blob-link = "https://github.com/org/package-b/blob/main"
+
+[[requirement]]
+pattern = "package-b/.duvet/requirements/**/*.toml"
+
+[[specification]]
+source = "my-spec.md"
+"""
+
+[[file]]
+path = "package-b/src/impl.rs"
+contents = """
+//= my-spec.md#feature-b
+//# Feature B MUST be implemented.
+
+//= my-spec.md#feature-c
+//# Feature C MUST be implemented.
+"""

--- a/integration/merge-three-package.toml
+++ b/integration/merge-three-package.toml
@@ -1,0 +1,121 @@
+# End-to-end test for 3-way `duvet merge`. Three packages each cover an
+# overlapping (Feature B) plus a distinct feature of one shared specification.
+# Exercises the N-way fold (vs. the 2-way path covered by
+# `merge-multi-package`): the merged output must dedup the spec inline source
+# to a single entry, preserve all three repository entries, preserve all the
+# distinct linked sources, and include all input cites and requirements
+# regardless of input order.
+
+source = { local = true }
+cmd = [
+  "duvet report --config-path=package-a/.duvet/config.toml --json-v2=package-a/duvet_report_v2.json",
+  "duvet report --config-path=package-b/.duvet/config.toml --json-v2=package-b/duvet_report_v2.json",
+  "duvet report --config-path=package-c/.duvet/config.toml --json-v2=package-c/duvet_report_v2.json",
+  "duvet merge --input=package-a/duvet_report_v2.json --input=package-b/duvet_report_v2.json --input=package-c/duvet_report_v2.json --output=merged.json",
+]
+extra_json_snapshots = [
+  "package-a/duvet_report_v2.json",
+  "package-b/duvet_report_v2.json",
+  "package-c/duvet_report_v2.json",
+  "merged.json",
+]
+
+[[file]]
+path = "my-spec.md"
+contents = """
+# My Specification
+
+## Feature A
+
+Feature A MUST be implemented.
+
+## Feature B
+
+Feature B MUST be implemented.
+
+## Feature C
+
+Feature C MUST be implemented.
+
+## Feature D
+
+Feature D MUST be implemented.
+"""
+
+[[file]]
+path = "package-a/.duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "package-a/src/*.rs"
+blob-link = "https://github.com/org/package-a/blob/main"
+
+[[requirement]]
+pattern = "package-a/.duvet/requirements/**/*.toml"
+
+[[specification]]
+source = "my-spec.md"
+"""
+
+[[file]]
+path = "package-a/src/impl.rs"
+contents = """
+//= my-spec.md#feature-a
+//# Feature A MUST be implemented.
+
+//= my-spec.md#feature-b
+//# Feature B MUST be implemented.
+"""
+
+[[file]]
+path = "package-b/.duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "package-b/src/*.rs"
+blob-link = "https://github.com/org/package-b/blob/main"
+
+[[requirement]]
+pattern = "package-b/.duvet/requirements/**/*.toml"
+
+[[specification]]
+source = "my-spec.md"
+"""
+
+[[file]]
+path = "package-b/src/impl.rs"
+contents = """
+//= my-spec.md#feature-b
+//# Feature B MUST be implemented.
+
+//= my-spec.md#feature-c
+//# Feature C MUST be implemented.
+"""
+
+[[file]]
+path = "package-c/.duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "package-c/src/*.rs"
+blob-link = "https://github.com/org/package-c/blob/main"
+
+[[requirement]]
+pattern = "package-c/.duvet/requirements/**/*.toml"
+
+[[specification]]
+source = "my-spec.md"
+"""
+
+[[file]]
+path = "package-c/src/impl.rs"
+contents = """
+//= my-spec.md#feature-b
+//# Feature B MUST be implemented.
+
+//= my-spec.md#feature-d
+//# Feature D MUST be implemented.
+"""

--- a/integration/snapshots/merge-multi-package.snap
+++ b/integration/snapshots/merge-multi-package.snap
@@ -1,0 +1,13 @@
+---
+source: xtask/src/tests.rs
+expression: snapshot
+---
+SPECIFICATION: [My Specification](my-spec.md)
+  SECTION: [Feature A](#feature-a)
+    TEXT[!MUST]: Feature A MUST be implemented.
+
+  SECTION: [Feature B](#feature-b)
+    TEXT[!MUST,implementation]: Feature B MUST be implemented.
+
+  SECTION: [Feature C](#feature-c)
+    TEXT[!MUST,implementation]: Feature C MUST be implemented.

--- a/integration/snapshots/merge-multi-package_json.snap
+++ b/integration/snapshots/merge-multi-package_json.snap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79cabd05b3384b9d46b14aa86a07ee09203b71050d23808a93f48a3845ee0a40
+size 27985

--- a/integration/snapshots/merge-multi-package_json_v2.snap
+++ b/integration/snapshots/merge-multi-package_json_v2.snap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db3866a3b97f7e5e823bb021b6fa44abac7e5cbb20d98baaad6817376757304c
+size 4679

--- a/integration/snapshots/merge-multi-package_merged.snap
+++ b/integration/snapshots/merge-multi-package_merged.snap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23ef4e6f186b0216952c9da1ef0c5f0e87f3ba5899bc72ce21dfa3f32a4b92d7
+size 7358

--- a/integration/snapshots/merge-multi-package_package-a_duvet_report_v2.snap
+++ b/integration/snapshots/merge-multi-package_package-a_duvet_report_v2.snap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5927785bf8fe2b8bd95a2316bd3d54e336a153b4210241eb8252d34f8fe64362
+size 4673

--- a/integration/snapshots/merge-multi-package_package-b_duvet_report_v2.snap
+++ b/integration/snapshots/merge-multi-package_package-b_duvet_report_v2.snap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49dd367a3031a808a5f293dfcdbe7117ca326ed829254c9869c7364d0cd45a09
+size 4677

--- a/integration/snapshots/merge-three-package.snap
+++ b/integration/snapshots/merge-three-package.snap
@@ -1,0 +1,16 @@
+---
+source: xtask/src/tests.rs
+expression: snapshot
+---
+SPECIFICATION: [My Specification](my-spec.md)
+  SECTION: [Feature A](#feature-a)
+    TEXT[!MUST]: Feature A MUST be implemented.
+
+  SECTION: [Feature B](#feature-b)
+    TEXT[!MUST,implementation]: Feature B MUST be implemented.
+
+  SECTION: [Feature C](#feature-c)
+    TEXT[!MUST]: Feature C MUST be implemented.
+
+  SECTION: [Feature D](#feature-d)
+    TEXT[!MUST,implementation]: Feature D MUST be implemented.

--- a/integration/snapshots/merge-three-package_json.snap
+++ b/integration/snapshots/merge-three-package_json.snap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:679a030e80fbd02d9c5feb540ff62c4d30a95f84deadb140ee5aca278e20a2ac
+size 28683

--- a/integration/snapshots/merge-three-package_json_v2.snap
+++ b/integration/snapshots/merge-three-package_json_v2.snap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36a181a5a6d0c9cc3f26dab7fc90e909fa545bf17c1e695809c58de4ecf96cb4
+size 5416

--- a/integration/snapshots/merge-three-package_merged.snap
+++ b/integration/snapshots/merge-three-package_merged.snap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dae82c625c25aca4963f22c5411477ed975556ccec66ecf022b88eca70e2e4f9
+size 11702

--- a/integration/snapshots/merge-three-package_package-a_duvet_report_v2.snap
+++ b/integration/snapshots/merge-three-package_package-a_duvet_report_v2.snap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5dc6e2fcb56fa48455848ec50d9664fea431789b3ae8e2df7703997d79da284
+size 5410

--- a/integration/snapshots/merge-three-package_package-b_duvet_report_v2.snap
+++ b/integration/snapshots/merge-three-package_package-b_duvet_report_v2.snap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9a8847ef904f81e94f52a9e7e2392184455619a54222e51fd7da58620daec0c
+size 5414

--- a/integration/snapshots/merge-three-package_package-c_duvet_report_v2.snap
+++ b/integration/snapshots/merge-three-package_package-c_duvet_report_v2.snap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a0061e774c2d8caf34f5fd3c36c57e2541ca7328fd5c46284ce630b95394953
+size 5414

--- a/xtask/src/tests.rs
+++ b/xtask/src/tests.rs
@@ -139,6 +139,12 @@ struct IntegrationTest {
     env: BTreeMap<String, String>,
     #[serde(default)]
     cwd: Option<String>,
+    /// Additional JSON files (paths relative to the test's working
+    /// directory) to capture as insta snapshots after the cmd loop runs.
+    /// Useful for tests that produce multiple JSON outputs (e.g. a `duvet
+    /// merge` test that writes per-package and merged reports).
+    #[serde(default)]
+    extra_json_snapshots: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -224,12 +230,13 @@ impl IntegrationTest {
     fn run(&self, target: &Path, sh: &Shell) -> Result {
         let Self { name, cmd, cwd, .. } = self;
 
+        let target_dir = if let Some(cwd) = cwd {
+            target.join(cwd)
+        } else {
+            target.to_path_buf()
+        };
+
         let (stderr, json_report, json_v2_report, snapshot_report) = {
-            let target_dir = if let Some(cwd) = cwd {
-                target.join(cwd)
-            } else {
-                target.to_path_buf()
-            };
             let _dir = sh.push_dir(&target_dir);
             let html_report = sh.current_dir().join("duvet_report.html");
             let json_report = sh.current_dir().join("duvet_report.json");
@@ -309,6 +316,16 @@ impl IntegrationTest {
             insta::assert_json_snapshot!(format!("{name}_json"), json);
             insta::assert_json_snapshot!(format!("{name}_json_v2"), json_v2);
         });
+
+        for rel in &self.extra_json_snapshots {
+            let path = target_dir.join(rel);
+            let contents = sh.read_file(&path)?;
+            let value: serde_json::Value = serde_json::from_str(&contents)?;
+            let slug = rel.trim_end_matches(".json").replace('/', "_");
+            settings.bind(|| {
+                insta::assert_json_snapshot!(format!("{name}_{slug}"), value);
+            });
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Adds `duvet merge`, a subcommand that combines N v2 JSON reports into a single v2 JSON report. Builds on the v2 schema's deterministic content-derived IDs (#207): same content in two inputs hashes to the same ID, so merging is a per-entity `BTreeMap` union with conflict checks on the fields that aren't part of each ID's hash.

```
duvet merge --input package-a/duvet_report_v2.json \
            --input package-b/duvet_report_v2.json \
            --output merged.json
```

## Conflict policy

Each field on every entity type falls into one of three buckets:

1. **Hash-input** (e.g. `Repository.blob_link`, `InlineSource.contents`, `RequirementAnnotation.origin`). ID equality implies field equality, so a mismatch is either a hash collision or a producer bug. The merger errors out — silently picking a side could merge structurally distinct entities. Errors are tagged "internal invariant violation".
2. **Structural conflict** (e.g. spec `title`/`format`, section `short_name`/`long_name`, requirement `level`, cite `anno_type`/`level`/`target`, extension values). Out-of-hash fields where producers must agree; mismatches hard-error.
3. **Soft drift** (cite `comment`, `feature`, `tracking_issue`, `tags`). Routinely differs across branches and isn't load-bearing for traceability — reconciled deterministically so the binary merge is commutative and associative (and the N-way fold is therefore order-independent). For the `Option<String>` fields, `Some` beats `None`, and when both sides are `Some` the lexicographically smaller value wins. `tags` becomes the sorted union of both sets. Any field that actually differed is logged as a stderr warning so the drift remains observable.

`RequirementAnnotation.coverage` is set-valued: cite-keyed range lists are unioned across inputs, then sort+dedup'd at the end so the merged output is canonical regardless of input order. `issue_links` is likewise a sorted, deduped union (the schema is a free-form `Vec<String>` with no ID, so a canonical sort order is what keeps the merge commutative).

## Tests

- 36 unit/property tests in `duvet/src/report/json_v2_merge.rs` covering every error path, soft-drift warnings, set unions, and the algebraic properties (commutativity, associativity, idempotency) — 7 of them are property tests. One test self-merges a real-world v2 snapshot.
- `merge-multi-package` integration fixture: two packages with overlapping coverage of one shared spec, merged end-to-end via the `duvet merge` CLI; output captured as insta snapshots.
- `merge-three-package` integration fixture: 3-way fold across three packages each citing one shared feature plus one distinct feature, exercising the N>2 path.

## Test plan

- [x] `cargo xtask checks` — clippy + rustfmt + typos clean
- [x] `cargo xtask test` — full suite passes (lib + integration + doc)
- [x] Self-merge of a real-world v2 snapshot is identity (`merge_real_snapshot_self_idempotent`)
- [x] Property tests assert `merge(a,b) == merge(b,a)` and `merge(merge(a,b),c) == merge(a,b,c)`