### PR TITLE
feat(json_v2): add canonical url to SpecificationAnnotation

### DIFF
--- a/duvet/src/report/json_v2.rs
+++ b/duvet/src/report/json_v2.rs
@@ -177,6 +177,8 @@ pub struct SpecificationAnnotation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     pub format: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -524,6 +526,13 @@ fn build_spec_and_section_annotations(
             })
             .unwrap_or(0);
 
+        let url = match &target.path {
+            crate::target::TargetPath::Url(u) => {
+                Some(crate::target::TargetPath::canonical_url(u.as_str()).into_owned())
+            }
+            crate::target::TargetPath::Path(_) => None,
+        };
+
         let spc_anno_id = ids::spc_id(src_id, 0, file_len);
         let new_spec = SpecificationAnnotation {
             source: SourceRef {
@@ -533,6 +542,7 @@ fn build_spec_and_section_annotations(
             },
             title: target_report.specification.title.clone(),
             format: target_report.specification.format.to_string(),
+            url,
         };
         if let Some(existing) = spec_annotations.get(&spc_anno_id) {
             debug_assert_eq!(
@@ -975,6 +985,7 @@ mod tests {
                 },
                 title: Some("Spec".to_string()),
                 format: "markdown".to_string(),
+                url: Some("https://www.rfc-editor.org/rfc/rfc9000.txt".to_string()),
             },
         );
         report.annotations.section.insert(
@@ -1030,6 +1041,29 @@ mod tests {
         let json = serde_json::to_string_pretty(&report).unwrap();
         let deserialized: ReportV2 = serde_json::from_str(&json).unwrap();
         assert_eq!(report, deserialized);
+    }
+
+    #[test]
+    fn spec_url_none_is_omitted_in_json() {
+        let mut report = empty_report();
+        report.annotations.specification.insert(
+            "spc-001".to_string(),
+            SpecificationAnnotation {
+                source: SourceRef {
+                    src: "src-x".to_string(),
+                    start: 0,
+                    end: 1,
+                },
+                title: Some("Spec".to_string()),
+                format: "markdown".to_string(),
+                url: None,
+            },
+        );
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(
+            !json.contains("\"url\""),
+            "url key should be omitted when None: {json}"
+        );
     }
 
     #[test]

--- a/duvet/src/report/json_v2_merge.rs
+++ b/duvet/src/report/json_v2_merge.rs
@@ -274,14 +274,17 @@ fn merge_annotations(
 /// `spc-` IDs hash `(source_id, start, end)`, so `source` equality is
 /// implied by ID equality. `title` and `format` aren't hashed — they
 /// reflect parser metadata that can legitimately differ (and that we treat
-/// as semantically load-bearing, hence hard errors on mismatch).
+/// as semantically load-bearing, hence hard errors on mismatch). `url` is
+/// also out-of-hash structural, but uses Some-beats-None semantics so a
+/// path-backed input can merge cleanly with a URL-backed input for the
+/// same content; a `Some/Some` mismatch is still a hard error.
 fn merge_specification(
     out: &mut BTreeMap<String, SpecificationAnnotation>,
     id: String,
     anno: SpecificationAnnotation,
     idx: usize,
 ) -> crate::Result {
-    match out.get(&id) {
+    match out.get_mut(&id) {
         Some(existing) => {
             if existing.title != anno.title {
                 return Err(duvet_core::error!(
@@ -300,6 +303,16 @@ fn merge_specification(
                     "internal invariant violation: input #{} has specification '{}' with source differing from previously seen; likely hash collision or producer bug -- this is rare; please file a bug with both input reports attached.",
                     idx, id
                 ));
+            }
+            match (&existing.url, &anno.url) {
+                (Some(a), Some(b)) if a != b => {
+                    return Err(duvet_core::error!(
+                        "input #{} has specification annotation '{}' with url {:?} conflicting with previously seen {:?} (likely a producer bug or accidental content collision; spc- IDs do not hash url)",
+                        idx, id, anno.url, existing.url
+                    ));
+                }
+                (None, Some(_)) => existing.url = anno.url,
+                _ => {}
             }
         }
         None => {
@@ -752,6 +765,7 @@ mod tests {
                 },
                 title: Some("A".to_string()),
                 format: "markdown".to_string(),
+                url: None,
             },
         );
         let b = empty();
@@ -766,6 +780,7 @@ mod tests {
                 },
                 title: Some("C".to_string()),
                 format: "markdown".to_string(),
+                url: None,
             },
         );
 
@@ -789,6 +804,7 @@ mod tests {
                 },
                 title: Some("A".to_string()),
                 format: "markdown".to_string(),
+                url: None,
             },
         );
         let mut b = empty();
@@ -802,12 +818,96 @@ mod tests {
                 },
                 title: Some("B".to_string()),
                 format: "markdown".to_string(),
+                url: None,
             },
         );
         let err = merge_reports(vec![a, b]).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("spc-1"), "msg = {msg}");
         assert!(msg.contains("title"), "msg = {msg}");
+    }
+
+    fn spec_with_url(url: Option<&str>) -> SpecificationAnnotation {
+        SpecificationAnnotation {
+            source: SourceRef {
+                src: "src-x".to_string(),
+                start: 0,
+                end: 1,
+            },
+            title: Some("RFC 9000".to_string()),
+            format: "ietf".to_string(),
+            url: url.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn merge_specs_same_url_ok() {
+        let mut a = empty();
+        a.annotations.specification.insert(
+            "spc-1".to_string(),
+            spec_with_url(Some("https://www.rfc-editor.org/rfc/rfc9000.txt")),
+        );
+        let b = a.clone();
+        let merged = merge_reports(vec![a, b]).unwrap();
+        assert_eq!(
+            merged.annotations.specification["spc-1"].url.as_deref(),
+            Some("https://www.rfc-editor.org/rfc/rfc9000.txt")
+        );
+    }
+
+    #[test]
+    fn merge_specs_some_beats_none_left_first() {
+        let mut a = empty();
+        a.annotations.specification.insert(
+            "spc-1".to_string(),
+            spec_with_url(Some("https://www.rfc-editor.org/rfc/rfc9000.txt")),
+        );
+        let mut b = empty();
+        b.annotations
+            .specification
+            .insert("spc-1".to_string(), spec_with_url(None));
+        let merged = merge_reports(vec![a, b]).unwrap();
+        assert_eq!(
+            merged.annotations.specification["spc-1"].url.as_deref(),
+            Some("https://www.rfc-editor.org/rfc/rfc9000.txt")
+        );
+    }
+
+    #[test]
+    fn merge_specs_some_beats_none_right_first() {
+        let mut a = empty();
+        a.annotations
+            .specification
+            .insert("spc-1".to_string(), spec_with_url(None));
+        let mut b = empty();
+        b.annotations.specification.insert(
+            "spc-1".to_string(),
+            spec_with_url(Some("https://www.rfc-editor.org/rfc/rfc9000.txt")),
+        );
+        let merged = merge_reports(vec![a, b]).unwrap();
+        assert_eq!(
+            merged.annotations.specification["spc-1"].url.as_deref(),
+            Some("https://www.rfc-editor.org/rfc/rfc9000.txt")
+        );
+    }
+
+    #[test]
+    fn merge_specs_url_mismatch_errors() {
+        let mut a = empty();
+        a.annotations.specification.insert(
+            "spc-1".to_string(),
+            spec_with_url(Some("https://www.rfc-editor.org/rfc/rfc9000.txt")),
+        );
+        let mut b = empty();
+        b.annotations.specification.insert(
+            "spc-1".to_string(),
+            spec_with_url(Some("https://www.rfc-editor.org/rfc/rfc9001.txt")),
+        );
+        let err = merge_reports(vec![a, b]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("spc-1"), "msg = {msg}");
+        assert!(msg.contains("url"), "msg = {msg}");
+        assert!(msg.contains("input #1"), "msg = {msg}");
     }
 
     #[test]

--- a/duvet/src/target.rs
+++ b/duvet/src/target.rs
@@ -174,7 +174,7 @@ impl TargetPath {
         }
     }
 
-    fn canonical_url(url: &str) -> Cow<'_, str> {
+    pub(crate) fn canonical_url(url: &str) -> Cow<'_, str> {
         fn remove_extension(url: &str) -> &str {
             url.trim_end_matches('/')
                 .trim_end_matches(".txt")

--- a/integration/snapshots/h3_json_v2.snap
+++ b/integration/snapshots/h3_json_v2.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4da14f43ff39fa25eb647d82238d8c18608c1b91eb0b6f7f253810194435ab6f
-size 626196
+oid sha256:a7ea1be864107d2d60cf25fc3903736e2a8b7efb1ded9b1c5bdeda9bc9314a43
+size 626298

--- a/integration/snapshots/init-quick-start_json_v2.snap
+++ b/integration/snapshots/init-quick-start_json_v2.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b6585e1e9c5d725a7c628da381963f9a51d041306434c7182bf1593c2a6f262c
-size 34069
+oid sha256:9ec8f5e31ca2b7935bf9ca71203b9889e048504cfb734dac396ff529457ab183
+size 34130

--- a/integration/snapshots/s2n-quic_json_v2.snap
+++ b/integration/snapshots/s2n-quic_json_v2.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59231c80219a9fc9c87dcf120c721ddbf25e9b049bedc20a73a5cec6a9ab091e
-size 5515015
+oid sha256:f95ade036b7de728d8a8d890455c81d4a76b069822e1c3a639622ea551bd4c29
+size 5517694

--- a/integration/snapshots/s2n-tls_json_v2.snap
+++ b/integration/snapshots/s2n-tls_json_v2.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:167bf4d2e1c9613f8ad3bab29b5905b00ad4b0e353fec179d44d2b255a9f4ed8
-size 2637659
+oid sha256:f9702c69c7cd63d930a4ec5ca564df03b887b4c79c0cbd42238e39a208a28094
+size 2638798

--- a/schemas/report-v2.json
+++ b/schemas/report-v2.json
@@ -358,6 +358,12 @@
             "string",
             "null"
           ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Carry each spec's source URL (canonicalized via canonical_url so RFC mirror variants collapse to one form) on SpecificationAnnotation so the v2-native frontend can render per-spec view-spec links and so merging across packages that reach the same RFC via different mirrors produces matching url strings.

The field is not part of the spc- hash; identical content reached via different mirror URLs must continue to produce the same spc- ID. Merge treats url as structural with a Some-beats-None upgrade so a path- backed spec in one package merges cleanly with a URL-backed spec for the same content from another. Some/Some mismatch is a hard error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
