### PR TITLE
ci(deny): pass --config as a pre-subcommand common option

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -32,4 +32,9 @@ jobs:
 
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          command: check --config .github/config/cargo-deny.toml
+          # `--config` and `--all-features` are cargo-deny *common* options and
+          # must precede the subcommand. The action assembles them from the
+          # `arguments` input (placed before `command`); appending `--config`
+          # after `check` fails with "unexpected argument '--config'".
+          command: check
+          arguments: --all-features --config .github/config/cargo-deny.toml


### PR DESCRIPTION
## Summary

Fixes the `dependencies` workflow, which currently fails on every run: `--config` (and `--all-features`) are cargo-deny *common* options and must precede the subcommand. The EmbarkStudios/cargo-deny-action assembles them from the `arguments` input (placed before `command`); appending `--config` after `check` fails with `unexpected argument '--config'`.

## Testing

- The identical change has been running green on the #227 branch (`deny` check passes there).

Split out of #227 so CI is repaired for every PR, not just that one.