### PR TITLE
fix(cli): honor NO_COLOR and disable ANSI color when stderr is not a terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+* Honor `NO_COLOR` and disable ANSI escape codes in diagnostic output when stderr is not a terminal.
+
 ## 0.4.0 (2025-01-22)
 
 ### Features

--- a/duvet/Cargo.toml
+++ b/duvet/Cargo.toml
@@ -19,6 +19,7 @@ duvet-core = { version = "0.4", path = "../duvet-core" }
 futures = { version = "0.3" }
 glob = "0.3"
 lazy_static = "1"
+miette = "7"
 mimalloc = { version = "0.1", default-features = false }
 once_cell = "1"
 pulldown-cmark = { version = "0.13", default-features = false }

--- a/duvet/src/main.rs
+++ b/duvet/src/main.rs
@@ -1,10 +1,31 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io::IsTerminal;
+
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() {
+    // Install a miette report handler whose color output reflects the actual
+    // destination, not whatever miette's default lazy autodetection sees.
+    //
+    // Diagnostics in duvet are commonly rendered via `format!("{:?}", error)`
+    // inside Display impls. At that point the formatter is a
+    // `core::fmt::Formatter` and miette's default handler has no way to
+    // consult the eventual destination, so it ships ANSI escapes
+    // unconditionally. Captured stdout/stderr in CI then contains color codes
+    // that no one will see and that break snapshot tests.
+    //
+    // Honor `NO_COLOR` (https://no-color.org/) and disable color when stderr
+    // is not a terminal. `set_hook` is fallible only if a hook is already set;
+    // ignore the error so test harnesses that call into the duvet library
+    // multiple times still work.
+    let use_color = std::env::var_os("NO_COLOR").is_none() && std::io::stderr().is_terminal();
+    let _ = miette::set_hook(Box::new(move |_| {
+        Box::new(miette::MietteHandlerOpts::new().color(use_color).build())
+    }));
+
     let format = tracing_subscriber::fmt::format().compact(); // Use a less verbose output format.
 
     let env_filter = tracing_subscriber::EnvFilter::builder()


### PR DESCRIPTION
## Summary

Install a miette report handler up front whose color decision reflects the actual destination. Diagnostics rendered via `format!("{:?}", error)` inside Display impls go through a `core::fmt::Formatter`, where miette's default lazy autodetection cannot consult the eventual destination and ships ANSI escapes unconditionally — captured CI output and piped stderr contain color codes nobody will see.

Honor [NO_COLOR](https://no-color.org/) and disable color when stderr is not a terminal. `set_hook` failure (hook already set) is deliberately ignored so test harnesses calling into the library repeatedly still work.

Adds a direct `miette = "7"` dependency to `duvet` (already in the tree via `duvet-core`).

## Testing

- `cargo xtask build` and `cargo fmt --check` pass.
- Functional check: forced a quote-mismatch diagnostic with stderr piped — output contains zero ANSI escape sequences.

Split out of #227.