### PR TITLE
fix(report): error on spec references that are missing a section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+* An annotation that references a specification without a `#section` is now reported as an error instead of being silently ignored. Coverage is computed per section, so a section-less reference can never be scored; previously it produced no reference and no diagnostic. If your project relied on the silent behavior, this will surface as new errors in `duvet report`.
+
 ## 0.4.0 (2025-01-22)
 
 ### Features

--- a/duvet/src/reference.rs
+++ b/duvet/src/reference.rs
@@ -84,7 +84,16 @@ pub async fn build_references(
     let mut references = vec![];
 
     let Some(section_id) = section_id else {
-        // TODO return a warning that referring to a spec without a section doesn't make sense
+        // A reference that names a spec but no `#section` cannot be scored:
+        // coverage is computed per section, so there is nothing to match the
+        // annotation's quote against. Treat it as an error and enumerate every
+        // offending annotation (same collect-and-list contract as the
+        // missing-section case below) so the user can fix them all in one pass.
+        for annotation in annotations.iter() {
+            let mut error = error!("reference to {} is missing a section", target.path);
+            error = error.with_source_slice(annotation.original_target.clone(), "referenced here");
+            errors.push(error);
+        }
         return (references.into(), errors.into());
     };
 


### PR DESCRIPTION
## Summary

A reference that names a specification but no `#section` cannot be scored: coverage is computed per section, so there is nothing to match the annotation's quote against. Previously these were silently ignored (a long-standing `TODO`) — the annotation produced no reference and no diagnostic, so a typo'd or incomplete target looked like a pass.

Now every offending annotation gets a located error (same collect-and-list contract as the adjacent missing-section case) so the user can fix them all in one pass.

## Behavior change

Projects with section-less references will now fail `duvet report`. Called out in the CHANGELOG. This is deliberately its own PR (not a rider on #227) so the change is visible in history and easy to discuss/revert on its own.

## Testing

- Full `cargo xtask test` suite passes (198 unit + all integration/snapshot tests) — no existing test relied on the silent behavior.
- Manual check: `//= spec.md` (no section) now produces a located `reference to spec.md is missing a section` error and exit code 1.

Split out of #227.