### PR TITLE
style(report): drop needless borrow in json report id formatting

### DIFF
--- a/duvet/src/report/json.rs
+++ b/duvet/src/report/json.rs
@@ -92,7 +92,7 @@ pub fn report(report: &ReportResult, file: &Path) -> Result {
 pub fn report_writer<Output: Write>(report: &ReportResult, output: &mut Output) -> Result {
     let mut specs = BTreeMap::new();
     for (source, report) in report.targets.iter() {
-        let id = format!("{}", &source.path);
+        let id = format!("{}", source.path);
         let mut output = Cursor::new(vec![]);
         report_source(report, &mut output)?;
         let output = unsafe { String::from_utf8_unchecked(output.into_inner()) };


### PR DESCRIPTION
## Summary

`format!("{}", &source.path)` borrows for no reason; format args already take the value by reference. One-character cleanup.

## Testing

- `cargo build -p duvet` passes.

Split out of #227.