### PR TITLE
style(config): replace Some(x).filter with bool::then_some (fixes clippy on stable 1.97)

### DIFF
--- a/duvet/src/config.rs
+++ b/duvet/src/config.rs
@@ -72,7 +72,7 @@ pub struct HtmlReport {
 
 impl HtmlReport {
     pub fn path(&self) -> Option<&Path> {
-        Some(&self.path).filter(|_| self.enabled)
+        self.enabled.then_some(&self.path)
     }
 }
 
@@ -84,7 +84,7 @@ pub struct JsonReport {
 
 impl JsonReport {
     pub fn path(&self) -> Option<&Path> {
-        Some(&self.path).filter(|_| self.enabled)
+        self.enabled.then_some(&self.path)
     }
 }
 
@@ -96,7 +96,7 @@ pub struct SnapshotReport {
 
 impl SnapshotReport {
     pub fn path(&self) -> Option<&Path> {
-        Some(&self.path).filter(|_| self.enabled)
+        self.enabled.then_some(&self.path)
     }
 }
 


### PR DESCRIPTION
## Summary

The `checks` CI job installs floating **stable** clippy and runs with `-D warnings`. Rust 1.97's clippy introduced the [`some_filter`](https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#some_filter) lint, which fires on three pre-existing sites in `duvet/src/config.rs` — so the `checks` job currently fails on `main` for **every** PR, regardless of content.

`self.enabled.then_some(&self.path)` states the intent directly.

## Testing

- `cargo clippy -p duvet --all-features --all-targets` — zero errors locally.
- `cargo build -p duvet` passes.

Split out of #227, which contains this identical fix. Together with #236 (cargo-deny args) and #237 (www lockfile), this is the third of three independent `main` CI breakages; all three must land for any PR to go fully green.