### PR TITLE
fix(query): pair discharge requires a single witness report

### DIFF
--- a/design/query/decisions.md
+++ b/design/query/decisions.md
@@ -315,6 +315,13 @@ and other test suites that produce separate reports.
 The `--coverage-report` flag accepts multiple paths
 with glob expansion.
 
+Refined by [Decision 13](#decision-13):
+OR semantics remain correct for per-annotation questions
+("was this ever executed?")
+and for false-failure prevention,
+but discharging a test/implementation pair
+requires a single report that witnessed both sides.
+
 ---
 
 ## Decision 7: Executed coverage variant {#decision-7}
@@ -655,3 +662,100 @@ So Option B's intent — "languages without classifiers keep working, no
 regression" — is preserved, but the baseline is now verified rather than an
 untested heuristic. The two-code-path con remains (classified vs. degraded), and
 both paths are now verified.
+
+---
+
+## Decision 13: Same-witness pair discharge {#decision-13}
+
+**Context:** Decision 6 chose OR semantics across reports:
+an annotation is executed if ANY report shows it executed.
+Its recorded con —
+"Can't distinguish 'test A executed this'
+from 'test B executed this' with aggregate formats" —
+was scoped to aggregate formats in prose,
+but the implementation folded every annotation independently
+across all reports, for all inputs.
+
+Each coverage report is a single *measurement*:
+one coherent observation of what executed together.
+With one report per test run,
+report B can show the test executed (implementation missed)
+while report A shows the implementation executed (test missed).
+No single measurement saw both sides,
+yet the coverage check reported a successful correlation.
+The check's question is
+"is there a report where the test ran AND the implementation ran"
+— ∃r: test(r) ∧ impl(r) —
+but the independent fold silently rewrote it as
+"is there a report where the test ran,
+and a report where the implementation ran"
+— (∃r: test(r)) ∧ (∃r: impl(r)).
+The existential does not distribute over the conjunction:
+the fold erased exactly the information
+that per-test reports contain.
+
+### Option A: Keep independent folding for pair discharge
+
+- Pro: No change.
+- Con: Passes the vacuous case above —
+  the exact pairing failure the check exists to catch.
+  A union of execution facts across reports
+  answers no question duvet asks:
+  "executed somewhere" and "executed together"
+  are different claims,
+  and only the second discharges
+  a test/implementation pair.
+
+### Option B: Same-witness discharge
+
+A *witness* for a test T is a report that shows T executed.
+A pair is discharged only by a witness
+that also shows the implementation executed:
+
+```
+witnesses_for(T)  = { report r : T executed in r }
+test_executed(T)  = witnesses_for(T) ≠ ∅
+discharged(T, I)  = ∃ w ∈ witnesses_for(T) : I executed in w
+ever_executed(I)  = ∃ any report r : I executed in r    # summary only
+```
+
+- Pro: Discharge evidence now comes from a single measurement.
+  Correct for per-test reports.
+  Aggregate-report behavior is unchanged:
+  one aggregate report witnesses everything it shows executed,
+  so it discharges the same pairs as before.
+  OR semantics survive where they were right:
+  a pair discharged by any one witness
+  must not be failed by another report that missed it
+  (Decision 6's motivating case),
+  and the ever-executed summary stays a global OR.
+- Con: Mixing aggregate and per-test reports
+  lets the aggregate report discharge a pair
+  that the per-test report missed.
+  This is inherent to accepting aggregate measurements,
+  not to the discharge rule.
+
+### Decision: Option B (same-witness discharge)
+
+This refines Decision 6 rather than reversing it.
+OR across reports remains the semantics
+for per-annotation questions
+("was this ever executed?");
+pair discharge is a conjunction of execution facts
+and must be answered inside a single witness.
+
+The general rule this decision records,
+so this class of problem does not recur:
+when a check conjoins two or more execution facts,
+the semantics must state which report(s)
+the facts may come from.
+Quantifier scope is part of the meaning of the check,
+not an implementation detail of the fold.
+
+This decision is the report-file instantiation of the general
+witness model specified in
+[`design/witness/spec.md`](../witness/spec.md)
+(Property W1: same-witness discharge),
+where witnesses may also be prover obligations;
+see [`design/witness/decisions.md`](../witness/decisions.md)
+for that feature's design record.

--- a/design/query/design.md
+++ b/design/query/design.md
@@ -425,13 +425,50 @@ and the coverage model figures out that the method was executed.
 The `--coverage-report` flag accepts multiple paths
 (with glob expansion).
 When multiple reports are provided,
-they are parsed in parallel and checked independently.
-An annotation is considered executed
-if ANY report shows it as executed
-(OR semantics across reports).
+they are parsed in parallel,
+and each report is a potential *witness* —
+a single measurement of what executed together.
+
+For a test annotation T:
+
+```
+witnesses_for(T)  = { report r : T executed in r }
+test_executed(T)  = witnesses_for(T) ≠ ∅
+```
+
+A correlated pair (test T, implementation I) is *discharged*
+only when a single witness saw both sides executed:
+
+```
+discharged(T, I)  = ∃ w ∈ witnesses_for(T) : I executed in w
+```
+
+A test executed in one report
+and an implementation executed only in a different report
+do not correlate:
+no measurement demonstrates
+that the test exercised the implementation.
+This matters for one-report-per-test workflows;
+a single aggregate report behaves as before,
+since one report witnesses
+everything it shows executed.
+
+Two OR-semantics aggregates remain across all reports:
+an implementation is counted as executed in the summary
+if ANY report shows it executed,
+and a pair discharged by any one witness
+is never failed by another report that missed it.
+
+When no witness discharges a pair,
+the diagnostic status reported for the implementation
+is folded across the witnesses with the preference
+`Unknown` over `Structural` over `NotExecuted`,
+because `Unknown` carries line-level diagnostic information.
 
 This supports workflows where coverage data comes from
 multiple test runs or multiple coverage tools.
+See [Decision 6](decisions.md#decision-6)
+as refined by [Decision 13](decisions.md#decision-13).
 
 ## 6. CLI Interface {#cli-interface}
 

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -522,24 +522,37 @@ async fn execute_coverage_check(
     }
 
     for test in complete_coverage.iter().chain(&incomplete_coverage) {
-        // Fold the test's own execution status across ALL reports first, with
-        // OR semantics: a test that ran in any report is executed (design
-        // §5.2). Emitting a verdict per report instead pushed a test into both
-        // `successful` (a report where its impl ran) and `failed` (a report
-        // where the impl was missed), double-counting it and failing the check
-        // even when one report proves full coverage.
-        let test_executed = fold_execution_status(&test.target, &execution_data_maps);
+        // Witnesses for this test: the reports that show the test itself
+        // executed (design §5.2). A pair (test, implementation) is discharged
+        // only by a single witness that also shows the implementation
+        // executed — a test executed in one report and an implementation
+        // executed only in a different report do not correlate, because no
+        // single measurement demonstrates that the test exercised the
+        // implementation (Decision 13). Folding each side independently
+        // across ALL reports asked (∃r: test(r)) ∧ (∃r: impl(r)) when the
+        // check means ∃r: test(r) ∧ impl(r), passing exactly the vacuous
+        // cross-report case the check exists to catch.
+        let witnesses: Vec<&ExecutionDataMap> = execution_data_maps
+            .iter()
+            .filter(|exec_data| {
+                matches!(
+                    executed_status_for(&test.target, exec_data),
+                    ExecutionStatus::Executed
+                )
+            })
+            .collect();
 
-        if matches!(test_executed, ExecutionStatus::Executed) {
-            // Fold each covering implementation across reports the same way, so
-            // an implementation executed in any report counts as executed. This
-            // matches the summary reduction used for `executed_implementations`
-            // below.
+        if !witnesses.is_empty() {
+            // The test executed in at least one report. Evaluate each
+            // covering implementation across the witnesses only, with OR
+            // semantics within that set: a pair discharged by any one
+            // witness must not be failed by another report that missed it
+            // (Decision 6's motivating case, preserved by Decision 13).
             let mut executed_implementations = Vec::new();
             let mut not_executed_implementations = Vec::new();
 
             for annotation in &test.covering_annotations {
-                let status = fold_execution_status(annotation, &execution_data_maps);
+                let status = fold_execution_status(annotation, witnesses.iter().copied());
                 if matches!(status, ExecutionStatus::Executed) {
                     executed_implementations.push(annotation.clone());
                 } else {
@@ -562,6 +575,11 @@ async fn execute_coverage_check(
                 failed.push(result);
             }
         } else {
+            // No witnesses: fold the test's own status across all reports
+            // for the diagnostic (Unknown is preferred over Structural /
+            // NotExecuted because it carries line information).
+            let test_executed = fold_execution_status(&test.target, &execution_data_maps);
+
             // Unknown tests are NOT skipped in executed-coverage mode: they
             // represent annotation placement errors that must be fixed
             // regardless of which test you're working on. Only NotExecuted
@@ -749,15 +767,19 @@ fn empty_duplicates() -> Duplicates {
     }
 }
 
-/// Fold an annotation's execution status across every coverage report with OR
-/// semantics: if any report shows it `Executed`, the result is `Executed`
-/// (design §5.2 — executed if ANY report shows it executed). Among the
-/// remaining statuses, `Unknown` is preferred over `Structural`/`NotExecuted`
-/// because it carries diagnostic line information; `NotExecuted` is the base
-/// case when there are no reports.
-fn fold_execution_status(
+/// Fold an annotation's execution status across the given coverage reports
+/// with OR semantics: if any report shows it `Executed`, the result is
+/// `Executed` (design §5.2). Among the remaining statuses, `Unknown` is
+/// preferred over `Structural`/`NotExecuted` because it carries diagnostic
+/// line information; `NotExecuted` is the base case when there are no reports.
+///
+/// The caller chooses the quantifier scope by choosing the reports (design
+/// §5.2, Decision 13): fold over ALL reports for per-annotation questions
+/// ("was this ever executed?"), or over a single test's witnesses for pair
+/// discharge ("did the implementation run in a report where the test ran?").
+fn fold_execution_status<'a>(
     annotation: &Arc<Annotation>,
-    execution_data_maps: &[ExecutionDataMap],
+    execution_data_maps: impl IntoIterator<Item = &'a ExecutionDataMap>,
 ) -> ExecutionStatus {
     let mut folded = ExecutionStatus::NotExecuted;
     for exec_data in execution_data_maps {

--- a/integration/query-coverage-cross-report-pair.toml
+++ b/integration/query-coverage-cross-report-pair.toml
@@ -1,20 +1,27 @@
 source = { local = true }
-cmd = ["duvet query -c coverage -r report-a.xml -r report-b.xml -f jacoco-xml"]
+cmd = ["duvet query -c coverage -r report-b.xml -r report-a.xml -f jacoco-xml"]
 report_output = false
 
-# Regression test for multi-report OR semantics (design 5.2, Decisions 6 & 13).
+# Regression test for same-witness pair correlation (design 5.2).
 #
-# One implementation + one test annotate the same spec text. Two reports both
-# show the test executed; report A shows the implementation executed, report B
-# shows it missed. Report A therefore witnesses BOTH sides of the pair, so the
-# pair is discharged and this is a single successful correlation. The extra
-# report B must not cause a false failure or double-counting: the old
-# per-report verdict pushed the same test into both `successful` (report A)
-# and `failed` (report B), failing the check even though report A proves full
-# coverage.
+# One implementation + one test annotate the same spec text. Report B shows
+# the test executed and the implementation MISSED; report A shows the
+# implementation executed and the test MISSED. No single report witnessed
+# both sides of the pair, so the correlation must FAIL: nothing demonstrates
+# that this test exercised this implementation.
 #
-# Contrast with query-coverage-cross-report-pair.toml, where NO single report
-# witnesses both sides and the check must fail.
+# This is the discriminating case for per-test coverage discipline (one
+# report per test run). Folding each annotation's execution status across
+# all reports independently — the old behavior — passed this vacuously:
+# "test executed somewhere" AND "impl executed somewhere" with no common
+# witness. Discharge requires a single report r where both the test and the
+# implementation are executed:
+#
+#   discharged(T, I) = ∃ w ∈ witnesses_for(T) : I executed in w
+#
+# Contrast with query-coverage-multi-report-or.toml, which pins the benign
+# direction: there report A witnesses BOTH sides, so the pair is discharged
+# and the extra report B must not cause a false failure.
 [[file]]
 path = ".duvet/config.toml"
 contents = """
@@ -67,25 +74,7 @@ contents = """
 This MUST do the thing
 """
 
-# report A: implementation line (Impl.java:8) executed; test line executed
-[[file]]
-path = "report-a.xml"
-contents = """
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
-<report name="A">
-    <package name="com/example">
-        <sourcefile name="Impl.java">
-            <line nr="8" mi="0" ci="3" mb="0" cb="0"/>
-        </sourcefile>
-        <sourcefile name="ImplTest.java">
-            <line nr="8" mi="0" ci="3" mb="0" cb="0"/>
-        </sourcefile>
-    </package>
-</report>
-"""
-
-# report B: implementation line MISSED; test line executed
+# report B: test line (ImplTest.java:8) executed; implementation line MISSED
 [[file]]
 path = "report-b.xml"
 contents = """
@@ -98,6 +87,24 @@ contents = """
         </sourcefile>
         <sourcefile name="ImplTest.java">
             <line nr="8" mi="0" ci="3" mb="0" cb="0"/>
+        </sourcefile>
+    </package>
+</report>
+"""
+
+# report A: implementation line executed; test line MISSED
+[[file]]
+path = "report-a.xml"
+contents = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
+<report name="A">
+    <package name="com/example">
+        <sourcefile name="Impl.java">
+            <line nr="8" mi="0" ci="3" mb="0" cb="0"/>
+        </sourcefile>
+        <sourcefile name="ImplTest.java">
+            <line nr="8" mi="3" ci="0" mb="0" cb="0"/>
         </sourcefile>
     </package>
 </report>

--- a/integration/snapshots/query-coverage-cross-report-pair_stderr.snap
+++ b/integration/snapshots/query-coverage-cross-report-pair_stderr.snap
@@ -1,0 +1,53 @@
+---
+source: xtask/src/tests.rs
+expression: stderr
+---
+$ duvet query -c coverage -r report-b.xml -r report-a.xml -f jacoco-xml
+EXIT: Some(1)
+    Starting duvet in query mode...
+  Extracting requirements
+    Scanning sources
+     Scanned 3 sources 
+     Parsing annotations
+      Parsed 3 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 1 sections 
+    Matching references
+     Matched 3 references 
+  
+Coverage: ✗ FAIL
+
+  Coverage reports checked: 2
+  Executed tests: 1
+  Executed implementations: 1
+  Successful correlations: 0
+  Failed correlations: 1
+  Tests with no implementation: 0
+
+  × Failed correlation
+   ╭─[src/test/java/com/example/ImplTest.java:5:13]
+ 4 │         public void testThing() {
+ 5 │ ╭─▶         //= spec.md#section-1
+ 6 │ │           //= type=test
+ 7 │ ├─▶         //# This MUST do the thing
+   · ╰──── Executed test
+ 8 │             new Impl().doThing();
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Failed correlation
+   ╭─[src/main/java/com/example/Impl.java:5:13]
+ 4 │         public void doThing() {
+ 5 │ ╭─▶         //= spec.md#section-1
+ 6 │ │           //= type=implementation
+ 7 │ ├─▶         //# This MUST do the thing
+   · ╰──── Not executed implementation
+ 8 │             run();
+   ╰────
+
+
+
+Overall: ✗ FAIL


### PR DESCRIPTION
## Summary

The `coverage` check folded a test annotation's and an implementation annotation's execution status **independently** across all supplied coverage reports, so no single report was ever required to have seen both. With per-test reports (the workflow that gives coverage correlation its meaning), a test annotation could be discharged by an implementation that a *different* test executed — exactly the vacuous pairing the check exists to catch.

This change requires a single common witness: a pair (test, impl) passes only when at least one report shows the test executed **and** that same report shows the implementation executed.

- `design/query/decisions.md` gains Decision 13 recording the semantics and why the original OR-fold decision's con (scoped to aggregate reports) was over-generalized by the implementation
- `design.md` §5.2 rewritten to state the per-witness intent
- New integration test `query-coverage-cross-report-pair` pins the failing direction (test executed in report A, impl executed only in report B ⇒ FAIL); the existing `query-coverage-multi-report-or` test is byte-identical under the fix (its report contains both sides)

## Testing

- New discriminator test fails as intended (exit 1, diagnostic names the witness that missed the implementation)
- `query-coverage-multi-report-or` snapshot unchanged
- `cargo test -p duvet query::` green
- Verified coverage model (`duvet-coverage`) unchanged — the per-annotation scoring beneath the fold is untouched

## Note

First of a series: a follow-up PR builds a witness abstraction on this semantics to admit prover-based coverage sources (Verus SST elaboration records) alongside runtime reports.