### PR TITLE
chore: release v0.4.3

### DIFF
--- a/duvet-core/Cargo.toml
+++ b/duvet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duvet-core"
-version = "0.4.2"
+version = "0.4.3"
 description = "Internal crate used by duvet"
 authors = ["Cameron Bytheway <bythewc@amazon.com>"]
 edition = "2021"

--- a/duvet-macros/Cargo.toml
+++ b/duvet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duvet-macros"
-version = "0.4.2"
+version = "0.4.3"
 description = "Internal crate used by duvet"
 authors = ["Cameron Bytheway <bythewc@amazon.com>"]
 edition = "2021"

--- a/duvet/Cargo.toml
+++ b/duvet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duvet"
-version = "0.4.2"
+version = "0.4.3"
 description = "A requirements traceability tool"
 authors = [
     "Cameron Bytheway <bythewc@amazon.com>",


### PR DESCRIPTION
Bumps the published crates (`duvet-macros`, `duvet-core`, `duvet`) from `0.4.2` to `0.4.3`, following the same pattern as #216.

### Versioning rationale
Everything landed since `v0.4.2` is backward-compatible (4 `feat:`, 4 `fix:`, **0 breaking changes**). Under the crate's `0.x` convention — the whole `0.4.x` line is API-compatible and `0.4 → 0.5` is reserved for breaking changes — this is a **patch** bump. This matches #216, which shipped 5 `feat:` commits as a patch.

### Notable changes since v0.4.2
- feat: `duvet query` subcommand with a Verus-verified coverage model (#227)
- feat: `duvet merge` subcommand for combining v2 JSON reports (#220)
- feat: json-v2 report format with roundtrip + stable identifiers (#207)
- feat(json_v2): canonical url on `SpecificationAnnotation` (#229)
- fix(query): pair discharge requires a single witness report (#244)
- fix(report): error on spec references missing a section (#239)
- fix(cli): honor `NO_COLOR` when stderr is not a terminal (#238)

(See the populated `## Unreleased` section in CHANGELOG.md for the full list.)
