### PR TITLE
Make duvet-coverage publishable, with vstd as a verification-only dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,9 @@ jobs:
           rustup toolchain install "$TOOLCHAIN"
 
       - name: Verify duvet-coverage proofs
-        run: cargo verus build -p duvet-coverage
+        # `--features verify` pulls in vstd, which is verification-only and
+        # optional so it stays out of the published dependency graph.
+        run: cargo verus build -p duvet-coverage --features verify
 
   action: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -125,11 +125,17 @@ verifier on every push and PR. To verify locally:
 4. **Verify the proofs.**
 
    ```console
-   $ cargo verus build -p duvet-coverage
+   $ cargo verus build -p duvet-coverage --features verify
    ```
 
    Expected output: `verified N functions, 0 errors`. A non-zero error
    count indicates a regression in the proofs.
+
+   The `verify` feature is what pulls in `vstd`. It is off by default so
+   that `vstd` stays out of the published dependency graph — every `vstd`
+   path in `duvet-coverage` is ghost, so a plain `cargo build` erases all
+   of them. Omitting `--features verify` here will fail with unresolved
+   `vstd` imports.
 
 The Verus prebuilt binary (and the `z3` it bundles) are built against
 glibc 2.34+ / 2.31+, so older distributions (Amazon Linux 2, Ubuntu
@@ -145,7 +151,7 @@ check — `vargo build` accepts `--no-solver-version-check`, and the verify
 step uses the `-V` form:
 
 ```console
-$ cargo verus build -p duvet-coverage -- -V no-solver-version-check
+$ cargo verus build -p duvet-coverage --features verify -- -V no-solver-version-check
 ```
 
 Otherwise, rely on CI for verification.

--- a/duvet-coverage/Cargo.toml
+++ b/duvet-coverage/Cargo.toml
@@ -1,21 +1,41 @@
 [package]
 name = "duvet-coverage"
-version = "0.1.0"
+version = "0.4.3"
+description = "Internal crate used by duvet"
+authors = ["Ryan Emery <ryanemer@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"
-description = "Coverage model types and algorithms for duvet"
-publish = false
+repository = "https://github.com/awslabs/duvet"
+rust-version = "1.88"
+
+[features]
+# Verification-only. Pulls in the Verus spec library so `cargo verus build
+# --features verify` can check the proofs. A plain `cargo build` leaves this
+# off: every `vstd` path in this crate is ghost, so the non-ghost expansion
+# erases all of them and nothing verus-shaped reaches the published artifact.
+verify = ["dep:vstd", "dep:verus_builtin"]
 
 [dependencies]
-# vstd ships only as date-pinned pre-release versions on crates.io, and the
-# verus binary and vstd are released in lockstep — the version here MUST match
-# the Verus release verified against (VERUS_VERSION in
+# The `verus!` macro is what performs ghost erasure, so it is needed on every
+# build, verified or not. It is a proc-macro: compiled at build time, never
+# linked into a consumer's binary.
+#
+# The verus crates ship only as date-pinned pre-releases on crates.io, and the
+# verus binary and its libraries are released in lockstep — the versions here
+# MUST match the Verus release verified against (VERUS_VERSION in
 # .github/workflows/ci.yml). Cargo.lock is gitignored, so a floating
-# requirement would let CI resolve a newer vstd than the pinned verus and fail
-# spuriously; an exact `=` pin keeps local and CI reproducible. Bump this
-# together with VERUS_VERSION. publish = false, so it is not propagated into
-# the published duvet artifact.
-vstd = "=0.0.0-2026-05-24-0157"
+# requirement would let CI resolve newer libraries than the pinned verus and
+# fail spuriously; an exact `=` pin keeps local and CI reproducible. Bump these
+# together with VERUS_VERSION.
+#
+# These pins are published constraints: an exact `=` requirement on a
+# pre-release version cannot be unified with any other requirement in a
+# consumer's tree, and a yank upstream would make every duvet release pinning
+# it unbuildable from a fresh registry. Keep the mandatory set as small as it
+# is — one proc-macro — and keep the rest behind `verify`.
+verus_builtin_macros = "=0.0.0-2026-05-24-0157"
+verus_builtin = { version = "=0.0.0-2026-05-17-0151", optional = true }
+vstd = { version = "=0.0.0-2026-05-24-0157", optional = true }
 
 [dev-dependencies]
 # Property-based testing harness, pinned to the same major as the `duvet` crate

--- a/duvet-coverage/src/annotation_execution.rs
+++ b/duvet-coverage/src/annotation_execution.rs
@@ -11,10 +11,10 @@ use crate::{execution_propagation::execution_set, target_resolution::annotation_
 use crate::predicates::validly_in_exec_set;
 #[cfg(verus_keep_ghost)]
 use crate::target_resolution::annotation_target_spec;
+use verus_builtin_macros::verus;
 // Ghost-only import; see the note in `lib.rs`.
 #[cfg(feature = "verify")]
 use vstd::prelude::*;
-use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/annotation_execution.rs
+++ b/duvet-coverage/src/annotation_execution.rs
@@ -11,7 +11,10 @@ use crate::{execution_propagation::execution_set, target_resolution::annotation_
 use crate::predicates::validly_in_exec_set;
 #[cfg(verus_keep_ghost)]
 use crate::target_resolution::annotation_target_spec;
+// Ghost-only import; see the note in `lib.rs`.
+#[cfg(feature = "verify")]
 use vstd::prelude::*;
+use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/classify_postpass.rs
+++ b/duvet-coverage/src/classify_postpass.rs
@@ -29,10 +29,10 @@
 
 use crate::types::*;
 use std::collections::BTreeSet;
+use verus_builtin_macros::verus;
 // Ghost-only import; see the note in `lib.rs`.
 #[cfg(feature = "verify")]
 use vstd::prelude::*;
-use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/classify_postpass.rs
+++ b/duvet-coverage/src/classify_postpass.rs
@@ -29,7 +29,10 @@
 
 use crate::types::*;
 use std::collections::BTreeSet;
+// Ghost-only import; see the note in `lib.rs`.
+#[cfg(feature = "verify")]
 use vstd::prelude::*;
+use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/degraded.rs
+++ b/duvet-coverage/src/degraded.rs
@@ -41,10 +41,10 @@ use crate::{
     target_resolution::annotation_target_spec,
 };
 use crate::{target_resolution::annotation_target, types::*};
+use verus_builtin_macros::verus;
 // Ghost-only import; see the note in `lib.rs`.
 #[cfg(feature = "verify")]
 use vstd::prelude::*;
-use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/degraded.rs
+++ b/duvet-coverage/src/degraded.rs
@@ -41,7 +41,10 @@ use crate::{
     target_resolution::annotation_target_spec,
 };
 use crate::{target_resolution::annotation_target, types::*};
+// Ghost-only import; see the note in `lib.rs`.
+#[cfg(feature = "verify")]
 use vstd::prelude::*;
+use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/execution_propagation.rs
+++ b/duvet-coverage/src/execution_propagation.rs
@@ -15,10 +15,10 @@ pub use crate::predicates::{
 };
 use crate::types::*;
 use std::collections::BTreeSet;
+use verus_builtin_macros::verus;
 // Ghost-only import; see the note in `lib.rs`.
 #[cfg(feature = "verify")]
 use vstd::prelude::*;
-use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/execution_propagation.rs
+++ b/duvet-coverage/src/execution_propagation.rs
@@ -15,7 +15,10 @@ pub use crate::predicates::{
 };
 use crate::types::*;
 use std::collections::BTreeSet;
+// Ghost-only import; see the note in `lib.rs`.
+#[cfg(feature = "verify")]
 use vstd::prelude::*;
+use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/lib.rs
+++ b/duvet-coverage/src/lib.rs
@@ -45,14 +45,16 @@ const _: () = assert!(
     "duvet-coverage proofs require usize >= u64 (64-bit platform)"
 );
 
-// The Verus prelude is ghost-only: every `vstd` path in this crate sits inside
-// a `verus!` block or a ghost item, so all of them are erased by the non-ghost
-// expansion. Gating the import behind `verify` keeps `vstd` out of the
-// published dependency graph. `verus!` itself comes from the proc-macro crate,
-// which is needed unconditionally to perform that erasure.
+// `verus!` is what performs ghost erasure, so it is needed on every build,
+// verified or not. It is a proc-macro: compiled at build time, never linked
+// into a consumer's binary.
+use verus_builtin_macros::verus;
+// The Verus prelude, by contrast, is ghost-only: every `vstd` path in this
+// crate sits inside a `verus!` block or a ghost item, so the non-ghost
+// expansion erases all of them. Gating it behind `verify` keeps `vstd` out of
+// the published dependency graph.
 #[cfg(feature = "verify")]
 use vstd::prelude::*;
-use verus_builtin_macros::verus;
 
 verus! {
     // Fix the platform pointer width for verification so that u64 <-> usize

--- a/duvet-coverage/src/lib.rs
+++ b/duvet-coverage/src/lib.rs
@@ -45,7 +45,14 @@ const _: () = assert!(
     "duvet-coverage proofs require usize >= u64 (64-bit platform)"
 );
 
+// The Verus prelude is ghost-only: every `vstd` path in this crate sits inside
+// a `verus!` block or a ghost item, so all of them are erased by the non-ghost
+// expansion. Gating the import behind `verify` keeps `vstd` out of the
+// published dependency graph. `verus!` itself comes from the proc-macro crate,
+// which is needed unconditionally to perform that erasure.
+#[cfg(feature = "verify")]
 use vstd::prelude::*;
+use verus_builtin_macros::verus;
 
 verus! {
     // Fix the platform pointer width for verification so that u64 <-> usize

--- a/duvet-coverage/src/predicates.rs
+++ b/duvet-coverage/src/predicates.rs
@@ -14,7 +14,10 @@
 //! compose them into property statements.
 
 use crate::types::*;
+// Ghost-only import; see the note in `lib.rs`.
+#[cfg(feature = "verify")]
 use vstd::prelude::*;
+use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/predicates.rs
+++ b/duvet-coverage/src/predicates.rs
@@ -14,10 +14,10 @@
 //! compose them into property statements.
 
 use crate::types::*;
+use verus_builtin_macros::verus;
 // Ghost-only import; see the note in `lib.rs`.
 #[cfg(feature = "verify")]
 use vstd::prelude::*;
-use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/proofs.rs
+++ b/duvet-coverage/src/proofs.rs
@@ -31,7 +31,10 @@ use crate::{
     annotation_execution::is_annotation_executed, execution_propagation::execution_set,
     target_resolution::annotation_target, types::*,
 };
+// Ghost-only import; see the note in `lib.rs`.
+#[cfg(feature = "verify")]
 use vstd::prelude::*;
+use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/proofs.rs
+++ b/duvet-coverage/src/proofs.rs
@@ -31,10 +31,10 @@ use crate::{
     annotation_execution::is_annotation_executed, execution_propagation::execution_set,
     target_resolution::annotation_target, types::*,
 };
+use verus_builtin_macros::verus;
 // Ghost-only import; see the note in `lib.rs`.
 #[cfg(feature = "verify")]
 use vstd::prelude::*;
-use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/scopes.rs
+++ b/duvet-coverage/src/scopes.rs
@@ -28,7 +28,10 @@
 #[cfg(verus_keep_ghost)]
 pub use crate::predicates::{scope_contains, scopes_match_classifications, scopes_well_formed};
 use crate::types::*;
+// Ghost-only import; see the note in `lib.rs`.
+#[cfg(feature = "verify")]
 use vstd::prelude::*;
+use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/scopes.rs
+++ b/duvet-coverage/src/scopes.rs
@@ -28,10 +28,10 @@
 #[cfg(verus_keep_ghost)]
 pub use crate::predicates::{scope_contains, scopes_match_classifications, scopes_well_formed};
 use crate::types::*;
+use verus_builtin_macros::verus;
 // Ghost-only import; see the note in `lib.rs`.
 #[cfg(feature = "verify")]
 use vstd::prelude::*;
-use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/target_resolution.rs
+++ b/duvet-coverage/src/target_resolution.rs
@@ -6,10 +6,10 @@
 #[cfg(verus_keep_ghost)]
 pub use crate::predicates::line_is_skippable;
 use crate::types::*;
+use verus_builtin_macros::verus;
 // Ghost-only import; see the note in `lib.rs`.
 #[cfg(feature = "verify")]
 use vstd::prelude::*;
-use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/target_resolution.rs
+++ b/duvet-coverage/src/target_resolution.rs
@@ -6,7 +6,10 @@
 #[cfg(verus_keep_ghost)]
 pub use crate::predicates::line_is_skippable;
 use crate::types::*;
+// Ghost-only import; see the note in `lib.rs`.
+#[cfg(feature = "verify")]
 use vstd::prelude::*;
+use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/types.rs
+++ b/duvet-coverage/src/types.rs
@@ -4,10 +4,10 @@
 //! Core types for the coverage model.
 
 use std::collections::{BTreeMap, BTreeSet};
+use verus_builtin_macros::verus;
 // Ghost-only import; see the note in `lib.rs`.
 #[cfg(feature = "verify")]
 use vstd::prelude::*;
-use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet-coverage/src/types.rs
+++ b/duvet-coverage/src/types.rs
@@ -4,7 +4,10 @@
 //! Core types for the coverage model.
 
 use std::collections::{BTreeMap, BTreeSet};
+// Ghost-only import; see the note in `lib.rs`.
+#[cfg(feature = "verify")]
 use vstd::prelude::*;
+use verus_builtin_macros::verus;
 
 verus! {
 

--- a/duvet/Cargo.toml
+++ b/duvet/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.88"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 duvet-core = { version = "0.4", path = "../duvet-core" }
-duvet-coverage = { version = "0.1", path = "../duvet-coverage" }
+duvet-coverage = { version = "0.4", path = "../duvet-coverage" }
 futures = { version = "0.3" }
 glob = "0.3"
 lazy_static = "1"

--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -14,7 +14,7 @@ impl Publish {
 
         cmd!(sh, "git diff --exit-code").run()?;
 
-        for pkg in ["duvet-macros", "duvet-core", "duvet"] {
+        for pkg in ["duvet-macros", "duvet-core", "duvet-coverage", "duvet"] {
             let _dir = sh.push_dir(pkg);
             cmd!(sh, "cargo publish --allow-dirty").run()?;
         }


### PR DESCRIPTION
## Problem

`cargo publish` for `duvet` fails with:

```
no matching package named `duvet-coverage` found
location searched: crates.io index
required by package `duvet v0.4.3`
```

`duvet-coverage` carries `publish = false`, but `duvet` depends on it, so
the crate has to be on crates.io for `duvet` to publish. This blocked the
v0.4.3 release partway through — `duvet-macros` and `duvet-core` 0.4.3 are
already on crates.io, `duvet` is still at 0.4.2.

## Changes

Two commits, reviewable independently.

**1. `refactor(coverage): make vstd a verification-only dependency`**

Publishing the crate as-is would have made `vstd` a mandatory,
exact-pinned, permanently-pre-release dependency of every `cargo install
duvet`. All 37 `vstd` releases on crates.io are `0.0.0-<date>`
pre-releases; the only non-prerelease is yanked. An `=` pin on a
pre-release cannot unify with any other requirement in a consumer's tree,
and an upstream yank would make every `duvet` release pinning it
unbuildable from a fresh registry.

It turns out none of that is necessary. Every `vstd` path in the crate is
ghost — it sits inside a `verus!` block or a ghost item — so the non-ghost
expansion erases all of them. The only survivors were the top-level `use
vstd::prelude::*;` statements. Guarding those behind a new `verify`
feature and taking `verus!` from `verus_builtin_macros` directly drops
`vstd` and `verus_builtin` out of the default build.

`verus_builtin_macros` stays mandatory: that macro is what performs the
erasure. It is a proc-macro, so it is compiled at build time and never
linked into a consumer's binary.

This is the sanctioned use of conditional compilation under Verus —
guarding `use` statements only. Gating *executable* code this way can
introduce unsoundness ([Ghost
Erasure](https://verus-lang.github.io/verus/guide/erasure.html)). Prior
art for the dependency shape:
[`smoothutf8`](https://github.com/iainmcgin/smooth-utf8), the one
published crate on crates.io that makes `vstd` optional.

**2. `chore(coverage): publish duvet-coverage`**

Drop `publish = false`, align the version with the other helper crates at
0.4.3, add the metadata they carry, and add the crate to the `xtask
publish` order ahead of `duvet`.

## Verification

| Check | Result |
|---|---|
| `cargo verus build -p duvet-coverage --features verify` — before | `48 verified, 0 errors` |
| `cargo verus build -p duvet-coverage --features verify` — after | `48 verified, 0 errors` (identical) |
| `cargo test -p duvet-coverage` (feature off) | 63 passed, 0 failed |
| `cargo test -p duvet --lib query` | 75 passed, 0 failed |
| `cargo tree -p duvet --edges normal \| grep vstd` | no matches |
| `cargo publish --dry-run -p duvet-coverage` | 14 files, no warnings, no `vstd` in the verification build |
| `cargo fmt --all -- --check` | clean |

The workspace test run has 68 pre-existing failures in
`specification::ietf::tests` (66; that snapshot directory is gitignored
and absent from a fresh checkout) and two `report::json_v2*` snapshot
tests reading git-lfs pointer files. None are in `query`, `coverage`, or
`classify` — the modules that consume `duvet-coverage`.

## One invariant is now load-bearing

**Every `vstd` path in `duvet-coverage` is ghost.** It holds today, jointly
witnessed by the verified build and the default build both passing. If
someone later puts a `vstd` type in an exec signature, the default build
fails at compile time with an unresolved import — loud, not silent. Worth
knowing before touching the `#[cfg(feature = "verify")]` guards.

## Note for whoever finishes the release

`cargo xtask publish` walks `["duvet-macros", "duvet-core",
"duvet-coverage", "duvet"]`, and the first two 0.4.3 versions are already
published, so a straight re-run will fail on them. `duvet-coverage` then
`duvet` are the two that still need to go out.
