### PR TITLE
ci: run duvet's own annotation checks on every build (dogfood)

### DIFF
--- a/.duvet/config.toml
+++ b/.duvet/config.toml
@@ -1,15 +1,27 @@
 '$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
 
-# Only `duvet-coverage` carries real requirement annotations (the coverage
-# model proofs). `duvet/**` is intentionally NOT scanned for now: duvet's
-# annotation parser also reads string literals, so example annotations in
-# duvet's own test fixtures and help strings (e.g. `//= spec.md#...`,
-# `//= https://.../rfc2324...`) would be picked up as real citations. Once
-# that parser issue is fixed, `duvet/**` can be scanned safely.
+# `duvet-coverage` carries the coverage-model proof annotations. `duvet/**`
+# still cannot be scanned wholesale: duvet's annotation parser also reads
+# string literals, so example annotations in duvet's own test fixtures and
+# help strings (e.g. `//= spec.md#...`,
+# `//= https://.../rfc2324...`) would be picked up as real citations. The
+# known fixture carriers are `duvet/src/query.rs` (rfc2324 examples in clap
+# help strings), `duvet/src/query/checks/coverage.rs`, and
+# `duvet/src/query/classify/java.rs` (classifier test fixtures).
+# Fixture-clean files under `duvet/src` are enumerated explicitly below so
+# the spec's §8 (dispatch/escalation) citations can live at their
+# implementing sites; when adding citations to a new file there, add it
+# here. Once that parser issue is fixed, `duvet/**` can be scanned safely.
 # See https://github.com/awslabs/duvet/issues/226
 
 [[source]]
 pattern = "duvet-coverage/**/*.rs"
+
+[[source]]
+pattern = "duvet/src/query/engine.rs"
+
+[[source]]
+pattern = "duvet/src/report.rs"
 
 [[specification]]
 source = "design/query/coverage-model-spec.md"

--- a/.duvet/snapshot.txt
+++ b/.duvet/snapshot.txt
@@ -1,25 +1,25 @@
 SPECIFICATION: [Duvet Coverage Model: Formal Specification](design/query/coverage-model-spec.md)
   SECTION: [1.3 Classification Function and Unknown Lines](#classification-function)
-    TEXT[!MUST]: A line classified as `{Annotation}` MUST NOT also have
-    TEXT[!MUST]: `Statement` or `Declaration` in its property set.
-    TEXT[!MUST]: Classifiers MUST apply a post-processing pass
-    TEXT[!MUST]: after AST classification:
-    TEXT[!MUST]: for any line that has `Annotation`, `Comment`, or `Whitespace`,
-    TEXT[!MUST]: remove `Statement` and `Declaration` from its property set.
+    TEXT[!MUST,implementation,test]: A line classified as `{Annotation}` MUST NOT also have
+    TEXT[!MUST,implementation,test]: `Statement` or `Declaration` in its property set.
+    TEXT[!MUST,implementation,test]: Classifiers MUST apply a post-processing pass
+    TEXT[!MUST,implementation,test]: after AST classification:
+    TEXT[!MUST,implementation,test]: for any line that has `Annotation`, `Comment`, or `Whitespace`,
+    TEXT[!MUST,implementation,test]: remove `Statement` and `Declaration` from its property set.
 
   SECTION: [1.5 Scopes](#scopes)
     TEXT[test]: A scope is a contiguous range of lines
     TEXT[test]: delimited by `ScopeOpen` and `ScopeClose` properties.
     TEXT[test]: Scopes nest.
-    TEXT[!MUST]: **Scope Balance Contract:** {#scope-balance-contract}
-    TEXT[!MUST]: A classifier MUST emit a balanced `ScopeOpen`/`ScopeClose` stream:
-    TEXT[!MUST]: matching each `ScopeClose` against the most recent unmatched `ScopeOpen`,
-    TEXT[!MUST]: no `ScopeClose` occurs with no open to match,
-    TEXT[!MUST]: and no `ScopeOpen` is left unmatched at end of file.
-    TEXT[!MUST]: When the stream is unbalanced,
-    TEXT[!MUST]: the coverage model MUST NOT score annotations against the collapsed scope tree;
-    TEXT[!MUST]: it MUST surface the file as a defeated classification and escalate
-    TEXT[!MUST]: (see [Classifier Selection and Dispatch](#dispatch)).
+    TEXT[!MUST,implementation,test]: **Scope Balance Contract:** {#scope-balance-contract}
+    TEXT[!MUST,implementation,test]: A classifier MUST emit a balanced `ScopeOpen`/`ScopeClose` stream:
+    TEXT[!MUST,implementation,test]: matching each `ScopeClose` against the most recent unmatched `ScopeOpen`,
+    TEXT[!MUST,implementation,test]: no `ScopeClose` occurs with no open to match,
+    TEXT[!MUST,implementation,test]: and no `ScopeOpen` is left unmatched at end of file.
+    TEXT[!MUST,implementation,test]: When the stream is unbalanced,
+    TEXT[!MUST,implementation,test]: the coverage model MUST NOT score annotations against the collapsed scope tree;
+    TEXT[!MUST,implementation,test]: it MUST surface the file as a defeated classification and escalate
+    TEXT[!MUST,implementation,test]: (see [Classifier Selection and Dispatch](#dispatch)).
 
   SECTION: [5. Correctness Properties](#correctness-properties)
     TEXT[!MUST,implementation,test]: These properties MUST be proven with Verus.
@@ -104,16 +104,16 @@ SPECIFICATION: [Duvet Coverage Model: Formal Specification](design/query/coverag
     TEXT[implication]: then `target.line_number > annotation.end_line`.
 
   SECTION: [Property 11: Scope-Stream Balance Detection](#property-11-scope-stream-balance-detection)
-    TEXT[!MUST,implementation]: The implementation MUST prove that the balance detector returns balanced if and
-    TEXT[!MUST,implementation]: only if the `ScopeOpen`/`ScopeClose` stream over the classified lines is balanced:
-    TEXT[!MUST,implementation]: no `ScopeClose` occurs while the scope depth is zero, and the depth is zero at
-    TEXT[!MUST,implementation]: end of file.
+    TEXT[!MUST,implementation,test]: The implementation MUST prove that the balance detector returns balanced if and
+    TEXT[!MUST,implementation,test]: only if the `ScopeOpen`/`ScopeClose` stream over the classified lines is balanced:
+    TEXT[!MUST,implementation,test]: no `ScopeClose` occurs while the scope depth is zero, and the depth is zero at
+    TEXT[!MUST,implementation,test]: end of file.
     TEXT[test]: A stream with no scope delimiters is balanced, and its whole-file scope is
     TEXT[test]: legitimate.
 
   SECTION: [7.4 Properties](#degraded-properties)
-    TEXT[!MUST]: These properties MUST be proven with Verus for the degraded path,
-    TEXT[!MUST]: alongside the Section 5 properties for the classified path.
+    TEXT[!MUST,implementation,test]: These properties MUST be proven with Verus for the degraded path,
+    TEXT[!MUST,implementation,test]: alongside the Section 5 properties for the classified path.
 
   SECTION: [Property D1: Direct Observation](#property-d1-direct-observation)
     TEXT[!MUST,implication]: The implementation MUST prove that the degraded status is a direct observation
@@ -137,9 +137,9 @@ SPECIFICATION: [Duvet Coverage Model: Formal Specification](design/query/coverag
     TEXT[!MUST,implication]: `is_annotation_executed` returns, namely `Executed`.
 
   SECTION: [8.2 Trust Taxonomy and Response](#trust-taxonomy)
-    TEXT[!MUST]: duvet MUST NOT silently substitute the coarse model or score against
-    TEXT[!MUST]:   the collapsed scope tree; it MUST escalate, reporting each located issue.
+    TEXT[!MUST,implementation,test]: duvet MUST NOT silently substitute the coarse model or score against
+    TEXT[!MUST,implementation,test]:   the collapsed scope tree; it MUST escalate, reporting each located issue.
 
   SECTION: [8.3 Escalation](#escalation)
-    TEXT[!MUST]: When `report` consumes coverage, a defeated commitment MUST be a hard
-    TEXT[!MUST]: error there, because `report` is the authoritative artifact.
+    TEXT[!MUST,exception]: When `report` consumes coverage, a defeated commitment MUST be a hard
+    TEXT[!MUST,exception]: error there, because `report` is the authoritative artifact.

--- a/.duvet/snapshot.txt
+++ b/.duvet/snapshot.txt
@@ -138,7 +138,8 @@ SPECIFICATION: [Duvet Coverage Model: Formal Specification](design/query/coverag
 
   SECTION: [8.2 Trust Taxonomy and Response](#trust-taxonomy)
     TEXT[!MUST,implementation,test]: duvet MUST NOT silently substitute the coarse model or score against
-    TEXT[!MUST,implementation,test]:   the collapsed scope tree; it MUST escalate, reporting each located issue.
+    TEXT[!MUST,implementation,test]:   the collapsed scope tree;
+    TEXT[!MUST,implementation,test]: it MUST escalate, reporting each located issue.
 
   SECTION: [8.3 Escalation](#escalation)
     TEXT[!MUST,exception]: When `report` consumes coverage, a defeated commitment MUST be a hard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,13 +92,6 @@ jobs:
         run: |
           cargo xtask build
 
-      - name: Duvet annotation checks (dogfood)
-        # duvet run on its own repo, judged by exit code alone: every spec
-        # requirement carries an implementation annotation, every
-        # implementation annotation carries a test annotation, and no
-        # (type, quote) pair has more than one owner.
-        run: ./target/debug/duvet query -c implementation,test,duplicates
-
       - name: Run cargo udeps
         run: cargo udeps --workspace --all-targets
         env:
@@ -206,3 +199,45 @@ jobs:
         run: duvet --help
       - name: duvet report
         run: duvet report
+
+  dogfood: # duvet runs on itself: the branch-built duvet checks the repo's own
+    # requirement annotations against .duvet/config.toml. `report --ci`
+    # compares the freshly generated snapshot against the committed
+    # .duvet/snapshot.txt and fails on any drift; the annotation checks
+    # are judged by exit code alone — no output parsing, no thresholds,
+    # no expected-failure lists.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable
+          rustup override set stable
+
+      - uses: camshaft/rust-cache@v1
+
+      - name: Cache node_modules
+        uses: actions/cache@v6
+        continue-on-error: true
+        with:
+          path: duvet/www/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('duvet/www/package-lock.json') }}
+
+      - name: Build duvet
+        run: |
+          cargo xtask build
+
+      - name: Run duvet on its own annotations
+        # Snapshot gate: any coverage regression — or an unintended new
+        # citation — drifts the generated snapshot from the committed one
+        # and fails this step; improving coverage requires regenerating
+        # and committing the snapshot.
+        run: ./target/debug/duvet report --ci
+
+      - name: Annotation checks
+        # Tree-wide invariant, plain customer invocation: every spec
+        # requirement carries an implementation annotation, every
+        # implementation annotation carries a test annotation, and no
+        # (type, quote) pair has more than one owner.
+        run: ./target/debug/duvet query -c implementation,test,duplicates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,13 @@ jobs:
         run: |
           cargo xtask build
 
+      - name: Duvet annotation checks (dogfood)
+        # duvet run on its own repo, judged by exit code alone: every spec
+        # requirement carries an implementation annotation, every
+        # implementation annotation carries a test annotation, and no
+        # (type, quote) pair has more than one owner.
+        run: ./target/debug/duvet query -c implementation,test,duplicates
+
       - name: Run cargo udeps
         run: cargo udeps --workspace --all-targets
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
 
 name: ci
 
+permissions:
+  contents: read
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10

--- a/duvet-coverage/src/classify_postpass.rs
+++ b/duvet-coverage/src/classify_postpass.rs
@@ -51,6 +51,16 @@ verus! {
 /// For every index `i` where the input `classifications[i]` contains
 /// `ScopeOpen`, the output also contains `ScopeOpen` at that index.
 /// Symmetrically for `ScopeClose`.
+//= design/query/coverage-model-spec.md#classification-function
+//= type=implementation
+//# Classifiers MUST apply a post-processing pass
+//# after AST classification:
+//# for any line that has `Annotation`, `Comment`, or `Whitespace`,
+//# remove `Statement` and `Declaration` from its property set.
+//= design/query/coverage-model-spec.md#classification-function
+//= type=implementation
+//# A line classified as `{Annotation}` MUST NOT also have
+//# `Statement` or `Declaration` in its property set.
 pub fn clean_classifications(
     classifications: &mut [Option<BTreeSet<LineProperty>>],
     code_start: &[bool],
@@ -181,6 +191,10 @@ mod tests {
             "ScopeOpen must survive cleaning, got: {props:?}"
         );
         // Declaration should be stripped (annotation line)
+        //= design/query/coverage-model-spec.md#classification-function
+        //= type=test
+        //# A line classified as `{Annotation}` MUST NOT also have
+        //# `Statement` or `Declaration` in its property set.
         assert!(
             !props.contains(&LineProperty::Declaration),
             "Declaration should be stripped from annotation line, got: {props:?}"
@@ -196,6 +210,12 @@ mod tests {
         clean_classifications(&mut classifications, &code_start);
 
         let props = classifications[0].as_ref().unwrap();
+        //= design/query/coverage-model-spec.md#classification-function
+        //= type=test
+        //# Classifiers MUST apply a post-processing pass
+        //# after AST classification:
+        //# for any line that has `Annotation`, `Comment`, or `Whitespace`,
+        //# remove `Statement` and `Declaration` from its property set.
         assert!(!props.contains(&LineProperty::Statement));
         assert!(props.contains(&LineProperty::Comment));
     }

--- a/duvet-coverage/src/degraded.rs
+++ b/duvet-coverage/src/degraded.rs
@@ -35,15 +35,7 @@
 //! not propagate, so its blindness to `NonLinearControl` cannot cause an unsound
 //! inference. It reports only what coverage directly says about the target line.
 
-// Meta-requirement about this proof file itself: "MUST be proven with
-// Verus" is implemented HERE (the D-properties below are the Verus
-// proofs, checked by CI's verify job) and demonstrated by the runtime
-// tests in this file's tests mod — the same pattern `proofs.rs` uses
-// for the Section 5 twin of this quote.
 #[cfg(verus_keep_ghost)]
-//= design/query/coverage-model-spec.md#degraded-properties
-//# These properties MUST be proven with Verus for the degraded path,
-//# alongside the Section 5 properties for the classified path.
 use crate::{
     annotation_execution::execution_status_of, predicates::validly_in_exec_set,
     target_resolution::annotation_target_spec,
@@ -122,6 +114,14 @@ fn coverage_status_at(coverage: &CoverageReport, line: u64) -> (result: Option<C
 ///   Missing coverage never yields a verdict (it yields `Unknown`).
 /// - **P3 (target below annotation):** any decided target lies strictly below
 ///   `annotation.end_line`.
+// Meta-requirement about this file's proofs: "MUST be proven with Verus" is
+// implemented by the D-property proofs, anchored here at the first proof site
+// (this fn's `ensures` carry D1/D2; D3/D4 are the lemmas below), checked by
+// CI's verify job.
+//= design/query/coverage-model-spec.md#degraded-properties
+//= type=implementation
+//# These properties MUST be proven with Verus for the degraded path,
+//# alongside the Section 5 properties for the classified path.
 //= design/query/coverage-model-spec.md#property-d1-direct-observation
 //= type=implication
 //# The implementation MUST prove that the degraded status is a direct

--- a/duvet-coverage/src/degraded.rs
+++ b/duvet-coverage/src/degraded.rs
@@ -35,7 +35,15 @@
 //! not propagate, so its blindness to `NonLinearControl` cannot cause an unsound
 //! inference. It reports only what coverage directly says about the target line.
 
+// Meta-requirement about this proof file itself: "MUST be proven with
+// Verus" is implemented HERE (the D-properties below are the Verus
+// proofs, checked by CI's verify job) and demonstrated by the runtime
+// tests in this file's tests mod — the same pattern `proofs.rs` uses
+// for the Section 5 twin of this quote.
 #[cfg(verus_keep_ghost)]
+//= design/query/coverage-model-spec.md#degraded-properties
+//# These properties MUST be proven with Verus for the degraded path,
+//# alongside the Section 5 properties for the classified path.
 use crate::{
     annotation_execution::execution_status_of, predicates::validly_in_exec_set,
     target_resolution::annotation_target_spec,
@@ -264,7 +272,14 @@ mod tests {
     }
 
     // Minimal universal classification: whitespace + annotation known, rest None.
+    // The proof side of this quote is the Verus `ensures`/proof fns above
+    // (checked by CI's verify job); this test demonstrates the proven
+    // degraded path on a concrete input, per the `proofs.rs` pattern.
     #[test]
+    //= design/query/coverage-model-spec.md#degraded-properties
+    //= type=test
+    //# These properties MUST be proven with Verus for the degraded path,
+    //# alongside the Section 5 properties for the classified path.
     fn hit_on_nearest_line_is_executed() {
         // annotation lines 1-2, blank line 3, covered code line 4.
         let c = vec![

--- a/duvet-coverage/src/scopes.rs
+++ b/duvet-coverage/src/scopes.rs
@@ -427,13 +427,16 @@ pub open spec fn scope_stream_balanced_spec(e: Seq<ScopeEvent>) -> bool {
 //# only if the `ScopeOpen`/`ScopeClose` stream over the classified lines is balanced:
 //# no `ScopeClose` occurs while the scope depth is zero, and the depth is zero at
 //# end of file.
-//= design/query/coverage-model-spec.md#property-11-scope-stream-balance-detection
-//= type=test
-//# The implementation MUST prove that the balance detector returns balanced if and
-//# only if the `ScopeOpen`/`ScopeClose` stream over the classified lines is balanced:
-//# no `ScopeClose` occurs while the scope depth is zero, and the depth is zero at
-//# end of file.
 pub fn scope_imbalance_site(events: &[ScopeEvent]) -> (result: Option<u64>)
+    // The `ensures` below IS the verification of Property 11 (the iff with the
+    // depth-counter spec), machine-checked by CI's verify job — so the test
+    // annotation anchors on the clause that verifies, not on the fn header.
+    //= design/query/coverage-model-spec.md#property-11-scope-stream-balance-detection
+    //= type=test
+    //# The implementation MUST prove that the balance detector returns balanced if and
+    //# only if the `ScopeOpen`/`ScopeClose` stream over the classified lines is balanced:
+    //# no `ScopeClose` occurs while the scope depth is zero, and the depth is zero at
+    //# end of file.
     ensures
         (result is None) <==> scope_stream_balanced_spec(events@),
 {

--- a/duvet-coverage/src/scopes.rs
+++ b/duvet-coverage/src/scopes.rs
@@ -409,8 +409,26 @@ pub open spec fn scope_stream_balanced_spec(e: Seq<ScopeEvent>) -> bool {
 /// aid. The soundness-critical guarantee is the `is None <==> balanced`
 /// equivalence in the `ensures`; the witness line itself is not otherwise
 /// constrained by the proof.
+// The contract is the classifier's responsibility, detected downstream
+// (this detector) rather than proven about the classifier — the emitting
+// classifiers live in `duvet/src/query/classify/` (unscannable fixture
+// carriers, see `.duvet/config.toml`), so the contract's citation lives
+// on its enforcement point:
+//= design/query/coverage-model-spec.md#scopes
+//= type=implementation
+//# **Scope Balance Contract:** {#scope-balance-contract}
+//# A classifier MUST emit a balanced `ScopeOpen`/`ScopeClose` stream:
+//# matching each `ScopeClose` against the most recent unmatched `ScopeOpen`,
+//# no `ScopeClose` occurs with no open to match,
+//# and no `ScopeOpen` is left unmatched at end of file.
 //= design/query/coverage-model-spec.md#property-11-scope-stream-balance-detection
 //= type=implementation
+//# The implementation MUST prove that the balance detector returns balanced if and
+//# only if the `ScopeOpen`/`ScopeClose` stream over the classified lines is balanced:
+//# no `ScopeClose` occurs while the scope depth is zero, and the depth is zero at
+//# end of file.
+//= design/query/coverage-model-spec.md#property-11-scope-stream-balance-detection
+//= type=test
 //# The implementation MUST prove that the balance detector returns balanced if and
 //# only if the `ScopeOpen`/`ScopeClose` stream over the classified lines is balanced:
 //# no `ScopeClose` occurs while the scope depth is zero, and the depth is zero at
@@ -693,6 +711,13 @@ mod tests {
     fn stray_close_is_flagged_and_tree_collapses() {
         // A `}` with nothing open: stray close (depth underflow at the event).
         let e = vec![ev(1, false)];
+        //= design/query/coverage-model-spec.md#scopes
+        //= type=test
+        //# **Scope Balance Contract:** {#scope-balance-contract}
+        //# A classifier MUST emit a balanced `ScopeOpen`/`ScopeClose` stream:
+        //# matching each `ScopeClose` against the most recent unmatched `ScopeOpen`,
+        //# no `ScopeClose` occurs with no open to match,
+        //# and no `ScopeOpen` is left unmatched at end of file.
         assert_eq!(scope_imbalance_site(&e), Some(1));
         // Tie: build_scope_tree ignores the stray close, so no pairs → whole-file.
         let sc = build_scope_tree(&e, 2);

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -385,6 +385,7 @@ async fn execute_coverage_check(
     // to `report` once it consumes coverage. We report *that* and *where*, never
     // a *cause* (mislabeled vs. classifier gap is undecidable here).
     //= design/query/coverage-model-spec.md#scopes
+    //= type=implementation
     //# When the stream is unbalanced,
     //# the coverage model MUST NOT score annotations against the collapsed scope tree;
     //# it MUST surface the file as a defeated classification and escalate
@@ -395,20 +396,7 @@ async fn execute_coverage_check(
     //# the collapsed scope tree; it MUST escalate, reporting each located issue.
     {
         use crate::query::classify::{ClassifierFailure, ClassifierIssue};
-        let mut defeated: std::collections::BTreeMap<
-            &std::path::Path,
-            Vec<crate::query::classify::ClassifierIssue>,
-        > = std::collections::BTreeMap::new();
-        for map in &execution_data_maps {
-            for (path, data) in map {
-                if let crate::query::checks::coverage::FileExecutionData::DefeatedClassification {
-                    issues,
-                } = data
-                {
-                    defeated.entry(path.as_path()).or_default().extend(issues);
-                }
-            }
-        }
+        let defeated = collect_defeated_issues(&execution_data_maps);
         for (path, issues) in &defeated {
             let (parse, unbalanced): (Vec<&ClassifierIssue>, Vec<&ClassifierIssue>) = issues
                 .iter()
@@ -809,6 +797,31 @@ fn fold_execution_status<'a>(
     folded
 }
 
+/// Aggregate every located issue from files whose classification was defeated,
+/// across all reports — the escalation's input. Extracted so a unit test can
+/// pin that each located issue reaches the escalation surface (none dropped,
+/// none merged away); the loud per-file report in `execute_coverage_check`
+/// iterates exactly this.
+fn collect_defeated_issues(
+    execution_data_maps: &[ExecutionDataMap],
+) -> std::collections::BTreeMap<std::path::PathBuf, Vec<crate::query::classify::ClassifierIssue>> {
+    let mut defeated: std::collections::BTreeMap<
+        std::path::PathBuf,
+        Vec<crate::query::classify::ClassifierIssue>,
+    > = std::collections::BTreeMap::new();
+    for map in execution_data_maps {
+        for (path, data) in map {
+            if let crate::query::checks::coverage::FileExecutionData::DefeatedClassification {
+                issues,
+            } = data
+            {
+                defeated.entry(path.clone()).or_default().extend(issues);
+            }
+        }
+    }
+    defeated
+}
+
 fn deduplicate_annotation_coverage(
     coverage_list: Vec<AnnotationCoverage>,
 ) -> Vec<AnnotationCoverage> {
@@ -920,10 +933,60 @@ mod tests {
         //= design/query/coverage-model-spec.md#trust-taxonomy
         //= type=test
         //# duvet MUST NOT silently substitute the coarse model or score against
-        //# the collapsed scope tree; it MUST escalate, reporting each located issue.
+        //# the collapsed scope tree;
         assert!(matches!(
             executed_status_for(&ann, &map),
             ExecutionStatus::Unknown { line_number: 7 }
         ));
+    }
+
+    /// Escalation carries every located issue: the aggregation feeding the
+    /// loud per-file report (the escalation surface) preserves each located
+    /// issue from every defeated file across all reports — none dropped,
+    /// none merged away. The printing itself is presentation glue; what is
+    /// pinned here is that each located issue reaches it.
+    #[test]
+    fn escalation_reports_each_located_issue() {
+        let unbalanced = |line| ClassifierIssue {
+            reason: ClassifierFailure::UnbalancedScopes,
+            line,
+        };
+        let parse = |line| ClassifierIssue {
+            reason: ClassifierFailure::ParseError,
+            line,
+        };
+        let mut map_a = ExecutionDataMap::default();
+        map_a.insert(
+            std::path::PathBuf::from("a/broken.rs"),
+            FileExecutionData::DefeatedClassification {
+                issues: vec![unbalanced(7), parse(2)],
+            },
+        );
+        let mut map_b = ExecutionDataMap::default();
+        map_b.insert(
+            std::path::PathBuf::from("b/also_broken.rs"),
+            FileExecutionData::DefeatedClassification {
+                issues: vec![unbalanced(11)],
+            },
+        );
+        let defeated = collect_defeated_issues(&[map_a, map_b]);
+        //= design/query/coverage-model-spec.md#trust-taxonomy
+        //= type=test
+        //# it MUST escalate, reporting each located issue.
+        assert_eq!(defeated.len(), 2);
+        assert_eq!(
+            defeated[std::path::Path::new("a/broken.rs")]
+                .iter()
+                .map(|i| i.line)
+                .collect::<Vec<_>>(),
+            [7, 2]
+        );
+        assert_eq!(
+            defeated[std::path::Path::new("b/also_broken.rs")]
+                .iter()
+                .map(|i| i.line)
+                .collect::<Vec<_>>(),
+            [11]
+        );
     }
 }

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -384,6 +384,15 @@ async fn execute_coverage_check(
     // (annotations are `Unknown`, the run continues); the hard-error gate belongs
     // to `report` once it consumes coverage. We report *that* and *where*, never
     // a *cause* (mislabeled vs. classifier gap is undecidable here).
+    //= design/query/coverage-model-spec.md#scopes
+    //# When the stream is unbalanced,
+    //# the coverage model MUST NOT score annotations against the collapsed scope tree;
+    //# it MUST surface the file as a defeated classification and escalate
+    //# (see [Classifier Selection and Dispatch](#dispatch)).
+    //= design/query/coverage-model-spec.md#trust-taxonomy
+    //= type=implementation
+    //# duvet MUST NOT silently substitute the coarse model or score against
+    //# the collapsed scope tree; it MUST escalate, reporting each located issue.
     {
         use crate::query::classify::{ClassifierFailure, ClassifierIssue};
         let mut defeated: std::collections::BTreeMap<
@@ -841,4 +850,80 @@ fn expand_coverage_globs(reports: &[String]) -> Result<Vec<String>> {
     }
 
     Ok(expanded_paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::{
+        checks::coverage::FileExecutionData,
+        classify::{ClassifierFailure, ClassifierIssue},
+    };
+    use std::sync::Arc;
+
+    /// Minimal annotation in `path`: `//= spec#s` on line 1, `code();` on
+    /// line 2. Single-line string literal on purpose — a multiline fixture
+    /// with `//=` at line start would be ingested as a real annotation now
+    /// that this file is a scanned source (see `.duvet/config.toml`).
+    fn annotation(path: &str) -> Arc<Annotation> {
+        use crate::annotation::AnnotationLevel;
+        use duvet_core::file::SourceFile as CoreSourceFile;
+        let contents = "//= spec#s\ncode();\n";
+        let source = CoreSourceFile::new(path, contents).unwrap();
+        let text = source.substr_range(0..10).unwrap();
+        let target = source.substr_range(4..10).unwrap();
+        let quote = source.substr_range(11..18).unwrap();
+        Arc::new(Annotation {
+            source: source.path().clone(),
+            anno_line: 1,
+            original_target: target,
+            original_text: text,
+            original_quote: quote,
+            anno: AnnotationType::Citation,
+            target: "spec#s".to_string(),
+            quote: String::new(),
+            comment: String::new(),
+            manifest_dir: source.path().clone(),
+            level: AnnotationLevel::Auto,
+            format: crate::specification::Format::Auto,
+            tracking_issue: String::new(),
+            feature: String::new(),
+            tags: Default::default(),
+            blob_link: None,
+        })
+    }
+
+    /// A file whose classification was defeated (here: an unbalanced scope
+    /// stream) is never scored: its annotations resolve to a located
+    /// `Unknown` anchored at the issue — not an `Executed`/`NotExecuted`
+    /// verdict computed against the collapsed whole-file scope tree, and not
+    /// a silent hand-off to the coarse degraded model.
+    #[test]
+    fn defeated_classification_is_surfaced_not_scored() {
+        let ann = annotation("a/broken.rs");
+        let mut map = ExecutionDataMap::default();
+        map.insert(
+            std::path::PathBuf::from("a/broken.rs"),
+            FileExecutionData::DefeatedClassification {
+                issues: vec![ClassifierIssue {
+                    reason: ClassifierFailure::UnbalancedScopes,
+                    line: 7,
+                }],
+            },
+        );
+        //= design/query/coverage-model-spec.md#scopes
+        //= type=test
+        //# When the stream is unbalanced,
+        //# the coverage model MUST NOT score annotations against the collapsed scope tree;
+        //# it MUST surface the file as a defeated classification and escalate
+        //# (see [Classifier Selection and Dispatch](#dispatch)).
+        //= design/query/coverage-model-spec.md#trust-taxonomy
+        //= type=test
+        //# duvet MUST NOT silently substitute the coarse model or score against
+        //# the collapsed scope tree; it MUST escalate, reporting each located issue.
+        assert!(matches!(
+            executed_status_for(&ann, &map),
+            ExecutionStatus::Unknown { line_number: 7 }
+        ));
+    }
 }

--- a/duvet/src/report.rs
+++ b/duvet/src/report.rs
@@ -61,12 +61,8 @@ pub struct Report {
 impl Report {
     //= design/query/coverage-model-spec.md#escalation
     //= type=exception
-    //= reason=`report` does not consume coverage yet: no coverage source
-    //= reason=reaches this path today, so the conditional ("When `report`
-    //= reason=consumes coverage") is vacuous. The hard-error obligation
-    //= reason=lands with the LCOV mixed-coverage follow-up that wires
-    //= reason=coverage into report; until then there is no code site that
-    //= reason=could implement it.
+    //= reason=`report` does not yet consume coverage; the hard-error gate lands with the LCOV follow-up.
+
     //# When `report` consumes coverage, a defeated commitment MUST be a hard
     //# error there, because `report` is the authoritative artifact.
     pub async fn exec(&self) -> Result {

--- a/duvet/src/report.rs
+++ b/duvet/src/report.rs
@@ -59,6 +59,16 @@ pub struct Report {
 }
 
 impl Report {
+    //= design/query/coverage-model-spec.md#escalation
+    //= type=exception
+    //= reason=`report` does not consume coverage yet: no coverage source
+    //= reason=reaches this path today, so the conditional ("When `report`
+    //= reason=consumes coverage") is vacuous. The hard-error obligation
+    //= reason=lands with the LCOV mixed-coverage follow-up that wires
+    //= reason=coverage into report; until then there is no code site that
+    //= reason=could implement it.
+    //# When `report` consumes coverage, a defeated commitment MUST be a hard
+    //# error there, because `report` is the authoritative artifact.
     pub async fn exec(&self) -> Result {
         let config = self.project.config().await?;
         let config = config.as_ref();

--- a/duvet/src/report.rs
+++ b/duvet/src/report.rs
@@ -62,7 +62,6 @@ impl Report {
     //= design/query/coverage-model-spec.md#escalation
     //= type=exception
     //= reason=`report` does not yet consume coverage; the hard-error gate lands with the LCOV follow-up.
-
     //# When `report` consumes coverage, a defeated commitment MUST be a hard
     //# error there, because `report` is the authoritative artifact.
     pub async fn exec(&self) -> Result {


### PR DESCRIPTION
# ci: run duvet's own annotation checks on every build (dogfood)

## What gates

A dedicated `dogfood` job with two named, exit-code-only steps — no output
parsing, no thresholds, no expected-failure lists:

1. **Run duvet on its own annotations** — `duvet report --ci`: the committed
   `.duvet/snapshot.txt` pins every requirement's coverage state; any drift
   fails.
2. **Annotation checks** — `duvet query -c implementation,test,duplicates`:
   every spec requirement carries an implementation annotation, every
   implementation annotation carries a test annotation, and no (type, quote)
   pair has more than one owner.

The job mirrors the shape #247 extends (it adds SST-artifact download and the
witness-query slice to this same job), so #247's rebase is additive.

## Annotation debt fixed (measured on main @ 3d6c3d1)

Before: Implementation FAIL (7 of 21 requirements unannotated, all in
`design/query/coverage-model-spec.md`), Tests FAIL (1 untested), Duplicates
PASS. After: all three PASS. Per-quote, with the convention applied:

| Spec quote | Fix | Convention |
|---|---|---|
| §1.3 `{Annotation}` excludes `Statement`/`Declaration` | impl on `clean_classifications`, test above the stripping assert | citation at implementing site; test at the verifying assert |
| §1.3 classifiers MUST apply a post-processing pass | same file, impl + test | same |
| §1.5 Scope Balance Contract | impl on `scope_imbalance_site` (the enforcement point — the emitting classifiers are unscannable fixture carriers), test in `stray_close_is_flagged_and_tree_collapses` | one owner per (type, quote), pointer comment at the detector |
| Property 11 balance detection | impl on the fn header; **`type=test` on the `ensures` clause** — the clause that verifies is the test's anchor | test annotations for proven properties anchor on the ensures clause (the discharge unit #247's witness machinery roots) |
| §7.4 "MUST be proven with Verus" | citation on the first D-property proof site (`degraded_execution_status`, whose `ensures` carry D1/D2), `type=test` on the runtime demonstration test (migrates to the CI verify step with #247) | meta-requirements anchor on the first proof-bearing item, never on imports |
| §1.5 unbalanced stream MUST NOT be scored / §8.2 | impl citations on the engine's defeated-classification reporting block | spec's own §8.3 note: citations land at the implementing sites in the `duvet` crate |
| §8.2 test obligations | **quote split**: the non-scoring clause is tested by `defeated_classification_is_surfaced_not_scored`; the "reporting each located issue" clause by `escalation_reports_each_located_issue`, over the extracted `collect_defeated_issues` aggregation the loud report iterates | a test annotation quotes only what its asserts verify |
| §8.3 `report` hard error on defeated commitment | `type=exception` with reason — `report` does not consume coverage yet, the conditional is vacuous until the LCOV follow-up | exception for genuinely unimplementable-today text; follow-up: remove the requirement from the spec until the LCOV PR implements it |

## Two items reviewers should look at

1. **`.duvet/config.toml` now enumerates two fixture-clean `duvet/src` files**
   (`query/engine.rs`, `report.rs`) as scanned sources, so the §8 citations can
   live at their implementing sites. `duvet/**` wholesale still waits on #226;
   the config note lists the known fixture carriers.
2. **Two unit tests beyond pure annotation fixes.** The §1.5/§8.2 escalation
   citations create test obligations whose existing verifying tests live only
   in unscannable fixture-carrier files. Retyping the annotations to dodge the
   check would be deciding the property true instead of proving it, so the
   tests carry the obligations honestly: a `DefeatedClassification` entry
   resolves to a located `Unknown` — never scored against the collapsed tree —
   and the escalation aggregation preserves each located issue from every
   defeated file (none dropped, none merged away). The aggregation is extracted
   into `collect_defeated_issues` so the second test executes exactly the code
   the loud report iterates.

The snapshot is regenerated; `duvet report --ci`, `duvet query -c
implementation,test,duplicates`, unit tests, and clippy (`-D warnings`) all
pass.

## Relation to #247

#247 extends this same `dogfood` job with proof-witness coverage gates
(`query -c coverage` over Verus SST logs). This PR is independent of and ahead
of it: it lands the annotation-hygiene floor on main so #247 rebases onto a
tree where the job exists and the three basic checks already gate. The
ensures-clause test placement here is forward-compatible by design: under
#247's discharge-unit model (spec §5.3), that annotation roots the clause-level
unit and is discharged by the verus-sst proof witness with no further move.
