### PR TITLE
ci: remove rust-toolchain pin; derive MSRV from Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,9 @@ jobs:
       - name: Evaluate definitions
         id: definitions
         run: |
-          rustup show active-toolchain
-          export MSRV=$(rustup show active-toolchain | awk -F'-' '{print $1}')
+          export MSRV=$(grep -m1 '^rust-version' duvet/Cargo.toml | sed -E 's/^rust-version *= *"(.+)"/\1/')
           if [ -z "$MSRV" ]; then
-            echo "Error: MSRV did not parse correctly"
+            echo "Error: MSRV did not parse correctly from duvet/Cargo.toml"
             exit 1
           fi
           echo "msrv=$MSRV" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -27,9 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: "Remove rust-toolchain"
-        run: rm rust-toolchain
-
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           # `--config` and `--all-features` are cargo-deny *common* options and

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.88.0"
-components = [ "rustc", "clippy", "rustfmt" ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,6 +3,7 @@ name = "xtask"
 version = "0.0.0"
 edition = "2021"
 publish = false
+rust-version = "1.88"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
## Summary

The repo-root `rust-toolchain` file pinned the toolchain to 1.88.0. rust-analyzer requires 1.94.0 or newer and refuses to work against a 1.88 sysroot, producing "too old" pop-ups for any developer running a recent rust-analyzer build.

The MSRV is already correctly declared via `rust-version = "1.88"` in each crate's `Cargo.toml`, so the toolchain file was redundant for MSRV purposes and harmful for local tooling.

## Changes

- **Delete `rust-toolchain`** — rust-analyzer uses the developer's installed stable toolchain instead of being forced to 1.88
- **Update CI MSRV derivation** — read `rust-version` from `duvet/Cargo.toml` directly instead of parsing `rustup show active-toolchain` (which read the now-deleted file)
- **Add `rust-version = "1.88"` to `xtask/Cargo.toml`** — consistent with the other crates in the workspace

## Reference

Mirrors the fix applied in [aws/s2n-quic#3180](https://github.com/aws/s2n-quic/pull/3180) for the same problem.