### PR TITLE
fix(json): emit absolute path for specifications key

### DIFF
--- a/duvet/src/report/json.rs
+++ b/duvet/src/report/json.rs
@@ -5,6 +5,7 @@ use super::{Reference, ReportResult, TargetReport};
 use crate::{
     annotation::{AnnotationLevel, AnnotationType},
     specification::Line,
+    target::TargetPath,
     Error, Result,
 };
 use duvet_core::{file::Slice, path::Path};
@@ -92,7 +93,15 @@ pub fn report(report: &ReportResult, file: &Path) -> Result {
 pub fn report_writer<Output: Write>(report: &ReportResult, output: &mut Output) -> Result {
     let mut specs = BTreeMap::new();
     for (source, report) in report.targets.iter() {
-        let id = format!("{}", source.path);
+        // The specifications key must exactly match each annotation's
+        // `target_path` (see `Annotation::resolve_target_path`). Paths there
+        // are always emitted absolute, so we bypass `duvet_core::Path`'s
+        // Display impl (which strips the current-dir prefix) and use the
+        // underlying std::path::Path's non-stripping Display.
+        let id = match &source.path {
+            TargetPath::Url(url) => url.to_string(),
+            TargetPath::Path(path) => path.as_ref().display().to_string(),
+        };
         let mut output = Cursor::new(vec![]);
         report_source(report, &mut output)?;
         let output = unsafe { String::from_utf8_unchecked(output.into_inner()) };

--- a/xtask/src/tests.rs
+++ b/xtask/src/tests.rs
@@ -322,6 +322,29 @@ impl IntegrationTest {
             let json_file = sh.read_file(&json_report)?;
             let json: serde_json::Value = serde_json::from_str(&json_file)?;
 
+            // Cross-referential invariant: every annotation's `target_path`
+            // must be a key in `specifications`. When it isn't, the bundled
+            // HTML renderer throws `e.specification is undefined` and shows a
+            // blank page. Regression guard for the PWD-dependent Display bug
+            // fixed in duvet/src/report/json.rs.
+            if let (Some(specs), Some(annos)) =
+                (json.get("specifications"), json.get("annotations"))
+            {
+                if let (Some(specs_obj), Some(annos_arr)) = (specs.as_object(), annos.as_array()) {
+                    let keys: std::collections::HashSet<_> = specs_obj.keys().collect();
+                    for anno in annos_arr {
+                        if let Some(tp) = anno.get("target_path").and_then(|v| v.as_str()) {
+                            let tp = tp.to_string();
+                            assert!(
+                                keys.contains(&tp),
+                                "annotation target_path {tp:?} is not a key in specifications ({:?})",
+                                keys
+                            );
+                        }
+                    }
+                }
+            }
+
             let snapshot = sh.read_file(&snapshot_report)?;
 
             let json_v2_file = sh.read_file(&json_v2_report)?;


### PR DESCRIPTION
## Summary
- JSON report's `specifications` key was routed through `duvet_core::Path`'s Display impl, which strips the current-working-directory prefix. `Annotation::resolve_target_path` is always absolute, so the two disagreed whenever duvet was run from a directory that wasn't the ancestor of the source path.
- The bundled HTML renderer looks the annotation's `target_path` up in `specifications`; when the lookup failed, `e.specification.sections` threw and the page rendered blank.
- `duvet report --ci` still exited 0 because the snapshot check doesn't cross-reference the two fields, so the drift was silent.

## Fix
- `duvet/src/report/json.rs`: match on `TargetPath` and use `std::path::Path::display()` (non-stripping) for the specifications key. URL targets unchanged.
- `xtask/src/tests.rs`: add an invariant assertion in the integration harness — every annotation's `target_path` must be a key in `specifications`. Every existing integration test now guards against this class of regression.

## Testing
- [x] Confirmed the bug against aws-lc's `third_party/vectors` Duvet setup (blank HTML, `e.specification is undefined` in browser console)
- [x] Confirmed the fix renders the HTML report correctly in Firefox and Safari
- [x] `cargo test` passes (skipping the `specification::ietf::tests::rfc_*` tests that require the rsync'd RFC archive from `cargo xtask test`)
- [ ] CI: full `cargo xtask test` including the 44 integration snapshots