### PR TITLE
perf(query): do per-file coverage model work once, not per report

### DIFF
--- a/.duvet/requirements/design/query/coverage-model-spec/escalation.toml
+++ b/.duvet/requirements/design/query/coverage-model-spec/escalation.toml
@@ -4,6 +4,8 @@ target = "design/query/coverage-model-spec.md#escalation"
 #
 # On a defeated commitment, duvet reports *what* and *where* — the located issues —
 # but never *why*, because mislabeled-file versus classifier-gap is undecidable.
+# Each located issue MUST be reported exactly once per file, regardless of how
+# many coverage reports cover the file.
 # In `query`, the inner-loop tool run against in-progress code, escalation is
 # non-blocking: the file's annotations resolve to a located `Unknown` and the run
 # continues. When `report` consumes coverage, a defeated commitment MUST be a hard
@@ -14,6 +16,13 @@ target = "design/query/coverage-model-spec.md#escalation"
 # > implementing citations land once `duvet/**` is scannable (see the `.duvet`
 # > config note / issue #226). Balance *detection* (Property 11) lives in the
 # > verified `duvet-coverage` crate and is cited from `scope_imbalance_site`.
+
+[[spec]]
+level = "MUST"
+quote = '''
+Each located issue MUST be reported exactly once per file, regardless of how
+many coverage reports cover the file.
+'''
 
 [[spec]]
 level = "MUST"

--- a/.duvet/snapshot.txt
+++ b/.duvet/snapshot.txt
@@ -145,5 +145,7 @@ SPECIFICATION: [Duvet Coverage Model: Formal Specification](design/query/coverag
     TEXT[implementation,test]:   duvet reports `Unknown`.
 
   SECTION: [8.3 Escalation](#escalation)
+    TEXT[!MUST,implementation,test]: Each located issue MUST be reported exactly once per file, regardless of how
+    TEXT[!MUST,implementation,test]: many coverage reports cover the file.
     TEXT[!MUST,exception]: When `report` consumes coverage, a defeated commitment MUST be a hard
     TEXT[!MUST,exception]: error there, because `report` is the authoritative artifact.

--- a/.duvet/snapshot.txt
+++ b/.duvet/snapshot.txt
@@ -140,6 +140,9 @@ SPECIFICATION: [Duvet Coverage Model: Formal Specification](design/query/coverag
     TEXT[!MUST,implementation,test]: duvet MUST NOT silently substitute the coarse model or score against
     TEXT[!MUST,implementation,test]:   the collapsed scope tree;
     TEXT[!MUST,implementation,test]: it MUST escalate, reporting each located issue.
+    TEXT[implementation,test]: **Drift** — coverage refers to a line outside the classified source (a coverage
+    TEXT[implementation,test]:   key past end of file). Every model reads coverage, so no model can be trusted;
+    TEXT[implementation,test]:   duvet reports `Unknown`.
 
   SECTION: [8.3 Escalation](#escalation)
     TEXT[!MUST,exception]: When `report` consumes coverage, a defeated commitment MUST be a hard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * New `duvet-coverage` internal crate providing a Verus-verified two-phase coverage model. Algorithms for scope tree construction, target resolution, and execution-set propagation are formally proven against the correctness properties in `design/query/coverage-model-spec.md`. Used by `duvet query --check coverage` for languages with a tree-sitter classifier; other languages use a verified degraded model that reads coverage directly at the annotation's target line.
 * Java line classifier built on tree-sitter; extends the coverage check to handle method declarations, interface bodies, fields without initializers, and other constructs that bytecode-based coverage tools (e.g., JaCoCo) do not report.
 * JaCoCo XML coverage report parser.
+* The `coverage` check performs report-independent per-file work (path matching, tree-sitter classification, scope tree construction, annotation stamping) once across all coverage reports instead of once per report, reducing runtimes from minutes to seconds on corpora with many reports (e.g., per-test-method JaCoCo output).
 
 ### Bug Fixes
 
@@ -17,6 +18,7 @@
 * The `duplicates` check reports every duplicate relationship instead of hiding exact-duplicate pairs behind a partial-quote coverer.
 * The `coverage` check ORs execution status across multiple coverage reports before deciding a correlation, so a test passes when any report proves full coverage (design §5.2).
 * The `coverage` check reports tests whose cited specification has no correlated implementation annotation rather than silently passing (design §2.4).
+* The defeated-classification escalation message no longer repeats each file's located issue list once per covering coverage report; each issue is listed once per file.
 
 ## 0.4.0 (2025-01-22)
 

--- a/design/query/coverage-model-spec.md
+++ b/design/query/coverage-model-spec.md
@@ -857,6 +857,8 @@ and the response depends on *which* trust was lost:
 
 On a defeated commitment, duvet reports *what* and *where* — the located issues —
 but never *why*, because mislabeled-file versus classifier-gap is undecidable.
+Each located issue MUST be reported exactly once per file, regardless of how
+many coverage reports cover the file.
 In `query`, the inner-loop tool run against in-progress code, escalation is
 non-blocking: the file's annotations resolve to a located `Unknown` and the run
 continues. When `report` consumes coverage, a defeated commitment MUST be a hard

--- a/duvet-coverage/src/annotation_execution.rs
+++ b/duvet-coverage/src/annotation_execution.rs
@@ -125,9 +125,11 @@ pub fn is_annotation_executed(
 /// annotations in one file computes the set once and pays O(target walk +
 /// set lookup) per annotation instead of O(whole-file propagation) per
 /// annotation. Verified callers discharge the clauses from `execution_set`'s
-/// postconditions; the unverified query engine discharges them by construction
-/// (it stores the set beside the very inputs it was computed from — see the
-/// trust-boundary note in duvet's `executed_status_for`).
+/// postconditions. Unverified callers should not call this directly — a
+/// `requires` compiles away for them, leaving the pairing as an unchecked
+/// axiom; use [`crate::file_execution::FileExecution`] instead, which carries
+/// the pairing as a machine-checked type invariant and discharges these
+/// clauses itself.
 pub fn is_annotation_executed_with_exec_set(
     annotation: &AnnotationSpan,
     classifications: &[Option<LineClass>],

--- a/duvet-coverage/src/annotation_execution.rs
+++ b/duvet-coverage/src/annotation_execution.rs
@@ -4,6 +4,7 @@
 //! Phase 3: Annotation Execution Check (spec Section 4).
 
 use crate::{execution_propagation::execution_set, target_resolution::annotation_target, types::*};
+use std::collections::BTreeSet;
 // `annotation_target_spec` and `validly_in_exec_set` are spec fns (ghost-only);
 // they exist only when Verus is processing the crate, referenced from `ensures`
 // and the `execution_status_of` spec twin.
@@ -89,6 +90,80 @@ pub fn is_annotation_executed(
             &&& classifications@[line.unwrap() as int - 1].is_some()
         },
         // Property 6, bullet (b): no unknown line lies on the propagation path.
+        // See `is_annotation_executed_with_exec_set` for the full rationale.
+        status == ExecutionStatus::Executed ==> {
+            let line = annotation_target_spec(annotation, classifications, file_length);
+            &&& line.is_some()
+            &&& validly_in_exec_set(line.unwrap(), classifications, scopes, coverage)
+        },
+{
+    // Self-contained form: compute the execution set here and delegate. The
+    // set's postconditions discharge the `_with_exec_set` preconditions, so the
+    // two entry points are verifiedly equivalent. Callers scoring MANY
+    // annotations against the SAME (classifications, scopes, coverage) should
+    // instead call `execution_set` once and use
+    // `is_annotation_executed_with_exec_set` per annotation — the set does not
+    // depend on the annotation, and recomputing it per annotation is the
+    // difference between O(file) and O(annotations × file).
+    let exec_set = execution_set(classifications, scopes, coverage);
+    is_annotation_executed_with_exec_set(
+        annotation,
+        classifications,
+        scopes,
+        coverage,
+        file_length,
+        &exec_set,
+    )
+}
+
+/// The annotation-execution verdict, given a *precomputed* execution set.
+///
+/// `exec_set` MUST be `execution_set(classifications, scopes, coverage)` —
+/// the three exec-set `requires` clauses below are, verbatim, that function's
+/// `ensures`. The pairing is the whole point: the execution set depends only on
+/// the file-level inputs, never on the annotation, so a caller scoring N
+/// annotations in one file computes the set once and pays O(target walk +
+/// set lookup) per annotation instead of O(whole-file propagation) per
+/// annotation. Verified callers discharge the clauses from `execution_set`'s
+/// postconditions; the unverified query engine discharges them by construction
+/// (it stores the set beside the very inputs it was computed from — see the
+/// trust-boundary note in duvet's `executed_status_for`).
+pub fn is_annotation_executed_with_exec_set(
+    annotation: &AnnotationSpan,
+    classifications: &[Option<LineClass>],
+    scopes: &[Scope],
+    coverage: &CoverageReport,
+    file_length: u64,
+    exec_set: &BTreeSet<u64>,
+) -> (status: ExecutionStatus)
+    requires
+        annotation.end_line < u64::MAX,
+        forall|line: u64| coverage@.contains_key(line) ==> (line as int - 1) >= 0 && (line as int - 1) < classifications@.len(),
+        forall|i: int| 0 <= i < scopes@.len() ==> (#[trigger] scopes@[i]).close_line < u64::MAX,
+        forall|i: int| 0 <= i < scopes@.len() ==> (#[trigger] scopes@[i]).open_line >= 1,
+        // `exec_set` is exactly the verified execution set for these inputs:
+        // `execution_set`'s three postconditions, restated as preconditions.
+        forall|line: u64| coverage@.contains_key(line) && coverage@[line] == CoverageStatus::Hit
+            ==> exec_set@.contains(line),
+        forall|line: u64| exec_set@.contains(line)
+            ==> validly_in_exec_set(line, classifications, scopes, coverage),
+        forall|line: u64| validly_in_exec_set(line, classifications, scopes, coverage)
+            ==> exec_set@.contains(line),
+    ensures
+        // Equivalence with the status spec twin: the status is a pure function of
+        // the resolved target line and the shared inputs (basis for Property 5).
+        status == execution_status_of(
+            annotation_target_spec(annotation, classifications, file_length),
+            classifications, scopes, coverage),
+        // Property 6 (Unknown Safety), bullet (a): Executed requires a classified
+        // target. If the result is Executed, the resolved target line exists and
+        // is classified (not an unknown line).
+        status == ExecutionStatus::Executed ==> {
+            let line = annotation_target_spec(annotation, classifications, file_length);
+            &&& line.is_some()
+            &&& classifications@[line.unwrap() as int - 1].is_some()
+        },
+        // Property 6, bullet (b): no unknown line lies on the propagation path.
         // The spec (design §property-6-unknown-safety) requires that every line
         // between the directly-hit line L and the target is classified `Some(_)`.
         // Rather than leave that implicit in the four-predicate chain
@@ -121,7 +196,6 @@ pub fn is_annotation_executed(
                         assert(props@ == classifications@[target_line.line_number as int - 1].unwrap()@);
                     }
                     if props.contains(&LineProperty::NonLinearControl) { return ExecutionStatus::Unknown { line_number: target_line.line_number }; }
-                    let exec_set = execution_set(classifications, scopes, coverage);
                     if exec_set.contains(&target_line.line_number) { return ExecutionStatus::Executed; }
                     if props.contains(&LineProperty::Statement) { return ExecutionStatus::NotExecuted; }
                     if props.contains(&LineProperty::Declaration) && !props.contains(&LineProperty::Statement) {

--- a/duvet-coverage/src/annotation_execution.rs
+++ b/duvet-coverage/src/annotation_execution.rs
@@ -124,13 +124,15 @@ pub fn is_annotation_executed(
 /// the file-level inputs, never on the annotation, so a caller scoring N
 /// annotations in one file computes the set once and pays O(target walk +
 /// set lookup) per annotation instead of O(whole-file propagation) per
-/// annotation. Verified callers discharge the clauses from `execution_set`'s
-/// postconditions. Unverified callers should not call this directly — a
-/// `requires` compiles away for them, leaving the pairing as an unchecked
-/// axiom; use [`crate::file_execution::FileExecution`] instead, which carries
-/// the pairing as a machine-checked type invariant and discharges these
-/// clauses itself.
-pub fn is_annotation_executed_with_exec_set(
+/// annotation. In-crate callers discharge the clauses from `execution_set`'s
+/// postconditions (the wrapper above) or from a type invariant
+/// ([`crate::file_execution::FileExecution`]). Crate-visible only, on
+/// purpose: a `requires` compiles away for unverified callers, so a public
+/// version would leave the set/inputs pairing as an unchecked axiom in
+/// their hands — external callers get `FileExecution`, which carries the
+/// pairing as a machine-checked type invariant and discharges these clauses
+/// itself.
+pub(crate) fn is_annotation_executed_with_exec_set(
     annotation: &AnnotationSpan,
     classifications: &[Option<LineClass>],
     scopes: &[Scope],

--- a/duvet-coverage/src/annotation_execution.rs
+++ b/duvet-coverage/src/annotation_execution.rs
@@ -336,6 +336,65 @@ fn scope_contains_statement(classifications: &[Option<LineClass>], lo: u64, hi: 
     found
 }
 
+// Spec twin of `fold_execution_status_step`: the exact preference order the
+// exec fn implements. `Executed` absorbs; otherwise a later `Unknown`
+// overwrites anything non-executed (it carries diagnostic line information,
+// and the latest witness wins, matching the historical fold); `Structural`
+// and `NotExecuted` are taken only over `NotExecuted` (the base case).
+pub open spec fn fold_step_spec(folded: ExecutionStatus, status: ExecutionStatus) -> ExecutionStatus {
+    if folded == ExecutionStatus::Executed {
+        folded
+    } else {
+        match status {
+            ExecutionStatus::Executed => status,
+            ExecutionStatus::Unknown { .. } => status,
+            _ => if folded == ExecutionStatus::NotExecuted { status } else { folded },
+        }
+    }
+}
+
+/// One step of folding an annotation's execution status across coverage
+/// reports (design/query/design.md §5.2): OR semantics on `Executed`, with
+/// `Unknown` preferred over `Structural` over `NotExecuted` among the rest.
+///
+/// The `ensures` carry the fold's correctness contract so the (unverified)
+/// per-report loop in duvet's query engine only supplies iteration:
+/// - **OR / absorption:** the result is `Executed` iff either input is —
+///   folding over a report set yields `Executed` iff SOME report proved
+///   execution, and once absorbed no later report can retract it.
+/// - **No invention:** the result is always one of the two inputs; the fold
+///   can never synthesize a status (and in particular never a line number)
+///   that no report produced.
+/// - **Definitional twin:** the result is exactly [`fold_step_spec`], pinning
+///   the full preference order, not just the executed bit.
+///
+/// There are no `requires`, so nothing compiles away for unverified callers.
+pub fn fold_execution_status_step(
+    folded: ExecutionStatus,
+    status: ExecutionStatus,
+) -> (result: ExecutionStatus)
+    ensures
+        result == fold_step_spec(folded, status),
+        result == ExecutionStatus::Executed
+            <==> (folded == ExecutionStatus::Executed || status == ExecutionStatus::Executed),
+        result == folded || result == status,
+{
+    if matches!(folded, ExecutionStatus::Executed) {
+        return folded;
+    }
+    match status {
+        ExecutionStatus::Executed => status,
+        ExecutionStatus::Unknown { .. } => status,
+        _ => {
+            if matches!(folded, ExecutionStatus::NotExecuted) {
+                status
+            } else {
+                folded
+            }
+        }
+    }
+}
+
 } // verus!
 
 #[cfg(test)]

--- a/duvet-coverage/src/annotation_execution.rs
+++ b/duvet-coverage/src/annotation_execution.rs
@@ -367,7 +367,7 @@ pub open spec fn fold_step_spec(folded: ExecutionStatus, status: ExecutionStatus
 /// - **No invention:** the result is always one of the two inputs; the fold
 ///   can never synthesize a status (and in particular never a line number)
 ///   that no report produced.
-/// - **Definitional twin:** the result is exactly [`fold_step_spec`], pinning
+/// - **Definitional twin:** the result is exactly `fold_step_spec`, pinning
 ///   the full preference order, not just the executed bit.
 ///
 /// There are no `requires`, so nothing compiles away for unverified callers.

--- a/duvet-coverage/src/execution_propagation.rs
+++ b/duvet-coverage/src/execution_propagation.rs
@@ -62,7 +62,16 @@ fn collect_hit_lines(coverage: &CoverageReport) -> (result: BTreeSet<u64>)
     s
 }
 
-pub(crate) fn execution_set(
+// Public (not just crate-visible) so an unverified caller can compute the
+// execution set ONCE per (file, coverage-report) pair and share it across every
+// annotation in that file via `is_annotation_executed_with_exec_set`. The set
+// depends only on (classifications, scopes, coverage) — never on the
+// annotation — so recomputing it per annotation (as the self-contained
+// `is_annotation_executed` does) is pure waste: O(annotations × file) instead
+// of O(file). The `ensures` here are exactly the `requires` of
+// `is_annotation_executed_with_exec_set`, so a caller that pipes this result
+// into that function preserves the verified contract by construction.
+pub fn execution_set(
     classifications: &[Option<LineClass>],
     scopes: &[Scope],
     coverage: &CoverageReport,

--- a/duvet-coverage/src/execution_propagation.rs
+++ b/duvet-coverage/src/execution_propagation.rs
@@ -62,16 +62,17 @@ fn collect_hit_lines(coverage: &CoverageReport) -> (result: BTreeSet<u64>)
     s
 }
 
-// Public (not just crate-visible) so an unverified caller can compute the
-// execution set ONCE per (file, coverage-report) pair and share it across every
-// annotation in that file via `is_annotation_executed_with_exec_set`. The set
-// depends only on (classifications, scopes, coverage) — never on the
-// annotation — so recomputing it per annotation (as the self-contained
-// `is_annotation_executed` does) is pure waste: O(annotations × file) instead
-// of O(file). The `ensures` here are exactly the `requires` of
-// `is_annotation_executed_with_exec_set`, so a caller that pipes this result
-// into that function preserves the verified contract by construction.
-pub fn execution_set(
+// Crate-visible only. The set depends only on (classifications, scopes,
+// coverage) — never on the annotation — so a caller scoring many annotations
+// should compute it once, not per annotation. But the safe way to do that is
+// [`crate::file_execution::FileExecution`], which pairs the set with the
+// exact inputs it was computed from as a machine-checked type invariant. A
+// public raw `execution_set` would invite unverified callers to hold the
+// set/inputs pairing by discipline — the axiom `FileExecution` exists to
+// eliminate. The `ensures` here are exactly the `requires` of
+// `is_annotation_executed_with_exec_set`, so in-crate callers that pipe one
+// into the other preserve the verified contract by construction.
+pub(crate) fn execution_set(
     classifications: &[Option<LineClass>],
     scopes: &[Scope],
     coverage: &CoverageReport,
@@ -92,7 +93,9 @@ pub fn execution_set(
         // (`clear_path` and friends in predicates.rs).
         forall|line: u64| result@.contains(line)
             ==> validly_in_exec_set(line, classifications, scopes, coverage),
-        // Property 4 (Completeness): every line with a valid path is in the result
+        // Completeness (converse of the Property 1 clause above): every line
+        // with a valid path is in the result. Not a numbered spec property —
+        // spec Property 4 is Monotonicity, which follows from this iff.
         forall|line: u64| validly_in_exec_set(line, classifications, scopes, coverage)
             ==> result@.contains(line),
 {

--- a/duvet-coverage/src/file_execution.rs
+++ b/duvet-coverage/src/file_execution.rs
@@ -361,15 +361,13 @@ mod tests {
         assert!(file_execution_with_keys(&[1, 6], 5).is_none());
     }
 
-    //= design/query/coverage-model-spec.md#trust-taxonomy
-    //= type=test
-    //# **Drift** — coverage refers to a line outside the classified source (a coverage
-    //# key past end of file). Every model reads coverage, so no model can be trusted;
-    //# duvet reports `Unknown`.
     #[test]
     fn zero_coverage_key_refuses_construction() {
         // Line numbers are 1-based; key 0 has no valid 0-based index — outside
         // the classified source on the low end, the mirror of past-EOF drift.
+        // Same Drift requirement as `coverage_key_past_eof_refuses_construction`,
+        // which carries the `type=test` citation (duvet's duplicates check
+        // rejects two tests quoting identical requirement text).
         assert!(file_execution_with_keys(&[0, 1], 5).is_none());
     }
 

--- a/duvet-coverage/src/file_execution.rs
+++ b/duvet-coverage/src/file_execution.rs
@@ -6,7 +6,7 @@
 //!
 //! [`FileExecution`] exists to eliminate a trusted-base axiom that previously
 //! lived in duvet's unverified query glue: "the stored `exec_set` is
-//! [`execution_set`] of the stored (classifications, scopes, coverage)".
+//! `execution_set` of the stored (classifications, scopes, coverage)".
 //! `is_annotation_executed_with_exec_set` `requires` that pairing, but a
 //! `requires` compiles away for unverified callers, so a caller that stored
 //! the set beside its inputs had to maintain the pairing by discipline —
@@ -64,7 +64,7 @@ pub open spec fn pairs_in_bounds(pairs: Seq<(u64, CoverageStatus)>, len: int) ->
 /// A file's per-report execution model: the classified line properties, the
 /// scope tree, the coverage map, and the execution set — with the guarantee,
 /// carried by the type itself, that the execution set is exactly
-/// [`execution_set`] of the other three.
+/// `execution_set` of the other three.
 ///
 /// The report-independent inputs (`classifications`, `scopes`) are held via
 /// `Arc` so a caller scoring one file against many coverage reports shares

--- a/duvet-coverage/src/file_execution.rs
+++ b/duvet-coverage/src/file_execution.rs
@@ -1,0 +1,308 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A verified, sealed pairing of a file's coverage inputs with their
+//! execution set.
+//!
+//! [`FileExecution`] exists to eliminate a trusted-base axiom that previously
+//! lived in duvet's unverified query glue: "the stored `exec_set` is
+//! [`execution_set`] of the stored (classifications, scopes, coverage)".
+//! `is_annotation_executed_with_exec_set` `requires` that pairing, but a
+//! `requires` compiles away for unverified callers, so a caller that stored
+//! the set beside its inputs had to maintain the pairing by discipline —
+//! and a desync would silently flip Executed/NotExecuted verdicts with every
+//! proof still green.
+//!
+//! Here the pairing is a machine-checked *type invariant* instead:
+//! [`FileExecution::new`] is the only constructor, it computes the execution
+//! set from the very inputs it stores (checking the runtime-checkable
+//! preconditions instead of assuming them), and the fields are private with
+//! no mutating methods and no interior mutability. Verus enforces the
+//! invariant at every construction and mutation point inside this (verified)
+//! crate; Rust's privacy makes construction and mutation outside this module
+//! impossible. So every `FileExecution` value any caller can obtain satisfies
+//! the invariant, and [`FileExecution::annotation_status`] discharges the
+//! verified checker's exec-set `requires` from the invariant rather than
+//! from the caller's discipline.
+
+use crate::{
+    annotation_execution::is_annotation_executed_with_exec_set,
+    execution_propagation::execution_set, types::*,
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+// Ghost-only imports; they exist only when Verus is processing the crate,
+// referenced from the type invariant and `ensures`.
+#[cfg(verus_keep_ghost)]
+use crate::annotation_execution::execution_status_of;
+#[cfg(verus_keep_ghost)]
+use crate::predicates::validly_in_exec_set;
+#[cfg(verus_keep_ghost)]
+use crate::target_resolution::annotation_target_spec;
+use verus_builtin_macros::verus;
+// Ghost-only import; see the note in `lib.rs`.
+#[cfg(feature = "verify")]
+use vstd::prelude::*;
+
+verus! {
+
+/// Spec: every scope's bounds satisfy the verified checkers' scope
+/// preconditions (`open_line >= 1`, `close_line < u64::MAX`).
+pub open spec fn scopes_in_bounds(scopes: Seq<Scope>) -> bool {
+    forall|i: int| 0 <= i < scopes.len() ==>
+        (#[trigger] scopes[i]).open_line >= 1 && scopes[i].close_line < u64::MAX
+}
+
+/// Spec: every coverage key maps to a valid 0-based classification index.
+pub open spec fn pairs_in_bounds(pairs: Seq<(u64, CoverageStatus)>, len: int) -> bool {
+    forall|i: int| 0 <= i < pairs.len() ==>
+        1 <= (#[trigger] pairs[i]).0 && pairs[i].0 - 1 < len
+}
+
+/// A file's per-report execution model: the classified line properties, the
+/// scope tree, the coverage map, and the execution set — with the guarantee,
+/// carried by the type itself, that the execution set is exactly
+/// [`execution_set`] of the other three.
+///
+/// The report-independent inputs (`classifications`, `scopes`) are held via
+/// `Arc` so a caller scoring one file against many coverage reports shares
+/// them across every per-report `FileExecution` instead of cloning them.
+///
+/// Residual trusted base for the pairing guarantee (everything else is
+/// machine-checked): Rust's field privacy — no code outside this module can
+/// construct a value or mutate a field — and the absence of interior
+/// mutability in the field types. There is deliberately no `Clone`: Verus
+/// checks even derived constructions against the type invariant, and callers
+/// share instances by reference or `Arc` instead.
+#[derive(Debug)]
+pub struct FileExecution {
+    classifications: Arc<Vec<Option<LineClass>>>,
+    scopes: Arc<Vec<Scope>>,
+    coverage: CoverageReport,
+    exec_set: BTreeSet<u64>,
+    file_length: u64,
+}
+
+impl FileExecution {
+    /// Spec view of the stored classifications. `closed`: the field is the
+    /// module's private business; callers compose against the name.
+    pub closed spec fn spec_classifications(self) -> Seq<Option<LineClass>> {
+        self.classifications@
+    }
+
+    /// Spec view of the stored scope tree.
+    pub closed spec fn spec_scopes(self) -> Seq<Scope> {
+        self.scopes@
+    }
+
+    /// Spec view of the stored coverage map (as the reference the underlying
+    /// predicates take).
+    pub closed spec fn spec_coverage(&self) -> &CoverageReport {
+        &self.coverage
+    }
+
+    /// Spec view of the stored file length.
+    pub closed spec fn spec_file_length(self) -> u64 {
+        self.file_length
+    }
+
+    /// The pairing invariant. Verus enforces this at every construction point
+    /// in verified code; privacy prevents construction anywhere else. The
+    /// exec-set clauses are quantified over every slice whose view equals the
+    /// stored vectors' views — slices with equal views are equal values, so
+    /// this is exactly "the pairing holds for the stored data", phrased so
+    /// both the constructor (which proves it about `as_slice()` of its
+    /// arguments) and `annotation_status` (which instantiates it at
+    /// `as_slice()` of the fields) can use it directly.
+    #[verifier::type_invariant]
+    spec fn wf(self) -> bool {
+        &&& forall|line: u64| #[trigger] self.coverage@.contains_key(line)
+            ==> (line as int - 1) >= 0 && (line as int - 1) < self.classifications@.len()
+        &&& scopes_in_bounds(self.scopes@)
+        &&& forall|line: u64| self.coverage@.contains_key(line)
+            && self.coverage@[line] == CoverageStatus::Hit
+            ==> self.exec_set@.contains(line)
+        &&& forall|c: &[Option<LineClass>], s: &[Scope]|
+            #![trigger c@, s@]
+            c@ == self.classifications@ && s@ == self.scopes@
+            ==> forall|line: u64|
+                #![trigger self.exec_set@.contains(line)]
+                #![trigger validly_in_exec_set(line, c, s, &self.coverage)]
+                self.exec_set@.contains(line)
+                    <==> validly_in_exec_set(line, c, s, &self.coverage)
+    }
+
+    /// Sole constructor. Checks the runtime-checkable preconditions of the
+    /// verified model — every coverage key maps to a valid classification
+    /// index, and every scope's bounds are in range — and computes the
+    /// verified execution set from the inputs it stores. Returns `None` when
+    /// a precondition fails: source/coverage drift or a JaCoCo `<line nr=...>`
+    /// past EOF violates the coverage bound, and then no verified verdict is
+    /// trustworthy for this file+report, so the caller should report the
+    /// conservative `Unknown` rather than consult the model.
+    ///
+    /// `coverage_pairs` is taken as (line, status) pairs rather than a
+    /// prebuilt map so the bounds check and the map construction are one
+    /// verified loop. Later duplicates overwrite earlier ones; callers that
+    /// need a merge policy (duvet's Hit-priority merge) apply it before
+    /// handing the pairs over.
+    ///
+    /// `file_length` participates in target resolution only; no verified
+    /// precondition constrains it, so it is stored as given.
+    pub fn new(
+        classifications: Arc<Vec<Option<LineClass>>>,
+        scopes: Arc<Vec<Scope>>,
+        coverage_pairs: &[(u64, CoverageStatus)],
+        file_length: u64,
+    ) -> (result: Option<FileExecution>)
+        ensures
+            result is Some <==> {
+                &&& pairs_in_bounds(coverage_pairs@, classifications@.len() as int)
+                &&& scopes_in_bounds(scopes@)
+            },
+    {
+        broadcast use vstd::slice::group_slice_axioms;
+
+        let n = classifications.len();
+
+        // Scope-bounds precondition, checked rather than assumed.
+        let mut si: usize = 0;
+        while si < scopes.len()
+            invariant
+                si <= scopes@.len(),
+                forall|i: int| 0 <= i < si ==>
+                    (#[trigger] scopes@[i]).open_line >= 1 && scopes@[i].close_line < u64::MAX,
+            decreases scopes@.len() - si,
+        {
+            let s = &scopes[si];
+            if !(s.open_line >= 1 && s.close_line < u64::MAX) {
+                return None;
+            }
+            si += 1;
+        }
+
+        // Coverage-keys precondition, checked while building the map.
+        let mut coverage: CoverageReport = BTreeMap::new();
+        let mut i: usize = 0;
+        while i < coverage_pairs.len()
+            invariant
+                i <= coverage_pairs@.len(),
+                n == classifications@.len(),
+                forall|j: int| 0 <= j < i ==>
+                    1 <= (#[trigger] coverage_pairs@[j]).0
+                    && coverage_pairs@[j].0 - 1 < classifications@.len(),
+                forall|line: u64| #[trigger] coverage@.contains_key(line)
+                    ==> (line as int - 1) >= 0 && (line as int - 1) < classifications@.len(),
+            decreases coverage_pairs@.len() - i,
+        {
+            let (line, status) = coverage_pairs[i];
+            if !(line >= 1 && ((line - 1) as usize) < n) {
+                return None;
+            }
+            coverage.insert(line, status);
+            i += 1;
+        }
+
+        // The pairing, by construction: compute the set from the stored data.
+        let c0: &[Option<LineClass>] = classifications.as_slice();
+        let s0: &[Scope] = scopes.as_slice();
+        let exec_set = execution_set(c0, s0, &coverage);
+
+        proof {
+            // `execution_set`'s ensures give the pairing for (c0, s0);
+            // generalize to every view-equal slice pair, since slices with
+            // equal views are equal values.
+            assert forall|c: &[Option<LineClass>], s: &[Scope]|
+                #![trigger c@, s@]
+                c@ == classifications@ && s@ == scopes@
+                implies forall|line: u64|
+                    #![trigger exec_set@.contains(line)]
+                    #![trigger validly_in_exec_set(line, c, s, &coverage)]
+                    exec_set@.contains(line)
+                        <==> validly_in_exec_set(line, c, s, &coverage) by {
+                assert(c =~= c0);
+                assert(s =~= s0);
+            }
+        }
+
+        Some(FileExecution {
+            classifications,
+            scopes,
+            coverage,
+            exec_set,
+            file_length,
+        })
+    }
+
+    /// The annotation-execution verdict for one annotation span, against this
+    /// file+report. Same contract as
+    /// [`is_annotation_executed_with_exec_set`] — the spec-twin equivalence
+    /// and both Unknown-Safety bullets, stated for every slice pair whose
+    /// views equal the stored inputs — but the exec-set `requires` are
+    /// discharged from the type invariant instead of from the caller.
+    ///
+    /// The one remaining `requires` is runtime-checkable per annotation;
+    /// unverified callers must check `end_line < u64::MAX` before calling
+    /// (it compiles away otherwise).
+    pub fn annotation_status(&self, annotation: &AnnotationSpan) -> (status: ExecutionStatus)
+        requires
+            annotation.end_line < u64::MAX,
+        ensures
+            forall|c: &[Option<LineClass>], s: &[Scope]|
+                #![trigger c@, s@]
+                c@ == self.spec_classifications() && s@ == self.spec_scopes() ==> {
+                    // Equivalence with the status spec twin (basis for Property 5).
+                    &&& status == execution_status_of(
+                        annotation_target_spec(annotation, c, self.spec_file_length()),
+                        c, s, self.spec_coverage())
+                    // Property 6 (Unknown Safety), bullet (a).
+                    &&& status == ExecutionStatus::Executed ==> {
+                        let line = annotation_target_spec(annotation, c, self.spec_file_length());
+                        &&& line.is_some()
+                        &&& c@[line.unwrap() as int - 1].is_some()
+                    }
+                    // Property 6, bullet (b).
+                    &&& status == ExecutionStatus::Executed ==> {
+                        let line = annotation_target_spec(annotation, c, self.spec_file_length());
+                        &&& line.is_some()
+                        &&& validly_in_exec_set(line.unwrap(), c, s, self.spec_coverage())
+                    }
+                },
+    {
+        broadcast use vstd::slice::group_slice_axioms;
+
+        proof {
+            use_type_invariant(self);
+        }
+        let c0: &[Option<LineClass>] = self.classifications.as_slice();
+        let s0: &[Scope] = self.scopes.as_slice();
+        proof {
+            assert(c0@ == self.classifications@);
+            assert(s0@ == self.scopes@);
+        }
+        let status = is_annotation_executed_with_exec_set(
+            annotation,
+            c0,
+            s0,
+            &self.coverage,
+            self.file_length,
+            &self.exec_set,
+        );
+        proof {
+            // Transfer the callee's ensures from (c0, s0) to every view-equal
+            // slice pair: slices with equal views are equal values.
+            assert forall|c: &[Option<LineClass>], s: &[Scope]|
+                #![trigger c@, s@]
+                c@ == self.classifications@ && s@ == self.scopes@
+                implies c == c0 && s == s0 by {
+                assert(c =~= c0);
+                assert(s =~= s0);
+            }
+        }
+        status
+    }
+}
+
+} // verus!

--- a/duvet-coverage/src/file_execution.rs
+++ b/duvet-coverage/src/file_execution.rs
@@ -151,6 +151,16 @@ impl FileExecution {
     ///
     /// `file_length` participates in target resolution only; no verified
     /// precondition constrains it, so it is stored as given.
+    //
+    // The refusal path is the implementation of the spec's Drift response:
+    // a coverage key outside the classified source means no model's verdict
+    // can be trusted, and the `None` this returns is what the caller turns
+    // into the conservative `Unknown` (`executed_status_for` in duvet).
+    //= design/query/coverage-model-spec.md#trust-taxonomy
+    //= type=implementation
+    //# **Drift** — coverage refers to a line outside the classified source (a coverage
+    //# key past end of file). Every model reads coverage, so no model can be trusted;
+    //# duvet reports `Unknown`.
     pub fn new(
         classifications: Arc<Vec<Option<LineClass>>>,
         scopes: Arc<Vec<Scope>>,
@@ -306,3 +316,81 @@ impl FileExecution {
 }
 
 } // verus!
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{CoverageStatus, Scope};
+
+    // --- FileExecution::new precondition boundary ---
+    //
+    // The verified constructor runtime-checks the model's coverage-keys and
+    // scope-bounds preconditions and refuses (returns `None`) rather than
+    // compute against inputs the proofs never reasoned about. These live here,
+    // beside the constructor, so they can carry Duvet citations — the glue
+    // crate (`duvet/src/query/checks/coverage.rs`) is excluded from annotation
+    // scanning as a fixture carrier (see `.duvet/config.toml` / issue #226).
+
+    /// Build a FileExecution over `len` unclassified lines with the given
+    /// coverage keys (all Hit) and no scopes.
+    fn file_execution_with_keys(keys: &[u64], len: usize) -> Option<FileExecution> {
+        let classifications: Arc<Vec<Option<LineClass>>> = Arc::new(vec![None; len]);
+        let scopes: Arc<Vec<Scope>> = Arc::new(vec![]);
+        let pairs: Vec<(u64, CoverageStatus)> =
+            keys.iter().map(|&k| (k, CoverageStatus::Hit)).collect();
+        FileExecution::new(classifications, scopes, &pairs, len as u64)
+    }
+
+    #[test]
+    fn in_bounds_coverage_constructs() {
+        // 5 classified lines; coverage keys 1..=5 all map to valid indices.
+        assert!(file_execution_with_keys(&[1, 3, 5], 5).is_some());
+    }
+
+    //= design/query/coverage-model-spec.md#trust-taxonomy
+    //= type=test
+    //# **Drift** — coverage refers to a line outside the classified source (a coverage
+    //# key past end of file). Every model reads coverage, so no model can be trusted;
+    //# duvet reports `Unknown`.
+    #[test]
+    fn coverage_key_past_eof_refuses_construction() {
+        // Key 6 -> index 5, out of range for 5 classified lines. This is the
+        // JaCoCo-nr-past-EOF / source-coverage-drift case that would otherwise
+        // reach the verified fn with an input it never reasoned about. The
+        // `None` is what the caller reports as `Unknown`.
+        assert!(file_execution_with_keys(&[1, 6], 5).is_none());
+    }
+
+    //= design/query/coverage-model-spec.md#trust-taxonomy
+    //= type=test
+    //# **Drift** — coverage refers to a line outside the classified source (a coverage
+    //# key past end of file). Every model reads coverage, so no model can be trusted;
+    //# duvet reports `Unknown`.
+    #[test]
+    fn zero_coverage_key_refuses_construction() {
+        // Line numbers are 1-based; key 0 has no valid 0-based index — outside
+        // the classified source on the low end, the mirror of past-EOF drift.
+        assert!(file_execution_with_keys(&[0, 1], 5).is_none());
+    }
+
+    #[test]
+    fn empty_coverage_constructs() {
+        // No keys -> the bounds condition is vacuously satisfied.
+        assert!(file_execution_with_keys(&[], 5).is_some());
+    }
+
+    #[test]
+    fn out_of_bounds_scope_refuses_construction() {
+        // A scope with open_line 0 violates the checkers' scope-bounds
+        // precondition. `build_scope_tree` never produces one; the constructor
+        // checks anyway instead of trusting that provenance.
+        let classifications: Arc<Vec<Option<LineClass>>> = Arc::new(vec![None; 5]);
+        let scopes = Arc::new(vec![Scope {
+            open_line: 0,
+            close_line: 5,
+            parent: None,
+            children: vec![],
+        }]);
+        assert!(FileExecution::new(classifications, scopes, &[], 5).is_none());
+    }
+}

--- a/duvet-coverage/src/lib.rs
+++ b/duvet-coverage/src/lib.rs
@@ -68,6 +68,7 @@ pub mod annotation_execution;
 pub mod classify_postpass;
 pub mod degraded;
 pub mod execution_propagation;
+pub mod file_execution;
 pub mod predicates;
 pub mod proofs;
 pub mod scopes;

--- a/duvet-coverage/src/lib.rs
+++ b/duvet-coverage/src/lib.rs
@@ -6,6 +6,44 @@
 //! This crate contains the pure-function coverage model from the
 //! [coverage model spec](../design/query/coverage-model-spec.md).
 //! When compiled with Verus, the correctness properties are machine-checked.
+//!
+//! # Residual trusted base
+//!
+//! Everything else in this crate is machine-checked. What follows is the
+//! complete list of what a consumer trusts *without* a proof, beyond Verus,
+//! rustc, and the platform:
+//!
+//! 1. **Rust field privacy** — no code outside its module can construct a
+//!    [`file_execution::FileExecution`] or mutate its fields, so the type
+//!    invariant proven at construction holds for every reachable value.
+//! 2. **Absence of interior mutability** in `FileExecution`'s field types
+//!    (`Arc<Vec<_>>`, `BTreeMap`, `BTreeSet`, `u64`) — nothing can change a
+//!    field behind a shared reference after construction.
+//! 3. **`collect_hit_lines`** (`execution_propagation.rs`) — `external_body`
+//!    leaf; its ensures semantically *define* "directly executed". Guarded by
+//!    the `collect_hit_lines_matches_hit_oracle` property test.
+//! 4. **`vec_from_btreeset`** (`execution_propagation.rs`) — `external_body`
+//!    leaf with a membership-only spec.
+//! 5. **`coverage_status_at`** (`degraded.rs`) — `external_body` leaf.
+//!
+//! (The `LineProperty` discriminant order, re-specified by hand for the
+//! proofs, is guarded by `discriminant_matches_derived_ord` in `types.rs`.)
+//!
+//! # Why the exec-set optimization cannot change a verdict
+//!
+//! Callers scoring many annotations against one (file, report) share a
+//! precomputed execution set via [`file_execution::FileExecution`] instead of
+//! recomputing the whole-file fixpoint per annotation. This is proven
+//! verdict-preserving, not argued: the self-contained
+//! [`annotation_execution::is_annotation_executed`] and the sharing
+//! [`file_execution::FileExecution::annotation_status`] each carry an
+//! `ensures` proving their result equals the *same* pure spec function,
+//! `execution_status_of`. Two implementations proven equal to the same
+//! function are proven equal to each other — on every build, by Verus. The
+//! set/inputs pairing the sharing path depends on is a machine-checked type
+//! invariant of `FileExecution` (trusting only items 1 and 2 above), never a
+//! caller discipline; the raw entry points that would require such discipline
+//! are `pub(crate)`.
 
 // Verus generates code patterns that trigger these warnings under normal rustc.
 // The verus_keep_ghost cfg, unused proof variables, double-paren casts, and

--- a/duvet/src/query/checks/coverage.rs
+++ b/duvet/src/query/checks/coverage.rs
@@ -231,18 +231,14 @@ pub async fn build_execution_data(
         let mut entries_for_source: FxHashMap<usize, Vec<&str>> = FxHashMap::default();
 
         for (coverage_path, file_coverage) in &generic.files {
-            let indices = match_memo
-                .entry(coverage_path.clone())
-                .or_insert_with(|| {
-                    duvet_sources
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, (_, absolute))| {
-                            coverage_path_matches(absolute, coverage_path)
-                        })
-                        .map(|(idx, _)| idx)
-                        .collect()
-                });
+            let indices = match_memo.entry(coverage_path.clone()).or_insert_with(|| {
+                duvet_sources
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, (_, absolute))| coverage_path_matches(absolute, coverage_path))
+                    .map(|(idx, _)| idx)
+                    .collect()
+            });
 
             // The mirror ambiguity: one report entry claimed by more than one
             // source file.
@@ -412,8 +408,7 @@ fn file_execution_data_for_report(
             // verified verdict is trustworthy for this file+report, so the
             // execution set is left empty and `executed_status_for` reports
             // `Unknown` without consulting it.
-            let coverage_keys_in_bounds =
-                coverage_keys_in_bounds(&coverage, classifications.len());
+            let coverage_keys_in_bounds = coverage_keys_in_bounds(&coverage, classifications.len());
             let exec_set = if coverage_keys_in_bounds {
                 execution_set(classifications, scopes, &coverage)
             } else {
@@ -469,9 +464,11 @@ async fn build_file_base(duvet_path: &Path, annotations: &AnnotationSet) -> Resu
 
     // Tree-sitter classification is pure CPU; run it off the (single-threaded)
     // async runtime so files classify in parallel.
-    tokio::task::spawn_blocking(move || build_file_base_sync(&duvet_path, &file_content, &annotations))
-        .await
-        .map_err(|e| duvet_core::error!("Task join error: {}", e))
+    tokio::task::spawn_blocking(move || {
+        build_file_base_sync(&duvet_path, &file_content, &annotations)
+    })
+    .await
+    .map_err(|e| duvet_core::error!("Task join error: {}", e))
 }
 
 fn build_file_base_sync(

--- a/duvet/src/query/checks/coverage.rs
+++ b/duvet/src/query/checks/coverage.rs
@@ -15,17 +15,18 @@ use crate::{
     Result,
 };
 use duvet_coverage::{
-    annotation_execution::is_annotation_executed,
+    annotation_execution::is_annotation_executed_with_exec_set,
     degraded::degraded_execution_status,
+    execution_propagation::execution_set,
     scopes::{build_scope_tree, scope_imbalance_site},
     types::{
         AnnotationSpan, CoverageReport as CoverageReportMap, ExecutionStatus, LineClass,
         LineProperty, Scope,
     },
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, BTreeSet, HashSet},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -39,11 +40,34 @@ pub enum CoverageFormat {
 /// Coverage model data for a file with a tree-sitter classifier.
 /// Contains the classified line properties, scope tree, and coverage data
 /// in the format expected by the verified `duvet-coverage` algorithms.
+///
+/// The report-independent parts (`classifications`, `scopes`) are shared via
+/// `Arc` across every coverage report — they are a function of the source file
+/// and its annotations only. The per-report parts are the `coverage` map, the
+/// precomputed `exec_set`, and the `coverage_keys_in_bounds` witness.
 #[derive(Debug, Clone)]
 pub struct ClassifiedFileData {
-    pub classifications: Vec<Option<LineClass>>,
-    pub scopes: Vec<Scope>,
+    pub classifications: Arc<Vec<Option<LineClass>>>,
+    pub scopes: Arc<Vec<Scope>>,
     pub coverage: CoverageReportMap,
+    /// The verified execution set for exactly (`classifications`, `scopes`,
+    /// `coverage`), computed ONCE per (file, report) by
+    /// [`duvet_coverage::execution_propagation::execution_set`].
+    ///
+    /// TRUSTED-BASE ASSUMPTION (unverified glue, same shape as the `scopes`
+    /// note in `build_file_base`): `is_annotation_executed_with_exec_set`
+    /// `requires` that this set be the execution set of the sibling fields, and
+    /// that holds *because* the sole producer
+    /// ([`file_execution_data_for_report`]) computes it from those very fields
+    /// with the verified function. Nothing at the type level enforces the
+    /// pairing; do not mutate these fields independently.
+    pub exec_set: BTreeSet<u64>,
+    /// Whether every coverage key maps to a valid classification index —
+    /// `is_annotation_executed_with_exec_set`'s runtime-checkable coverage
+    /// precondition, evaluated once per (file, report) instead of once per
+    /// annotation. When false, the file's annotations are reported `Unknown`
+    /// (the conservative status) without ever calling the verified model.
+    pub coverage_keys_in_bounds: bool,
     pub file_length: u64,
 }
 
@@ -52,9 +76,10 @@ pub struct ClassifiedFileData {
 /// → `None`, annotation lines stamped by the caller) plus coverage and length.
 /// Fed to the verified degraded path, which needs no scope tree because it does
 /// not propagate — it reads coverage directly on the resolved target line.
+/// `classifications` is shared via `Arc` across reports.
 #[derive(Debug, Clone)]
 pub struct DegradedFileData {
-    pub classifications: Vec<Option<LineClass>>,
+    pub classifications: Arc<Vec<Option<LineClass>>>,
     pub coverage: CoverageReportMap,
     pub file_length: u64,
 }
@@ -90,18 +115,77 @@ pub enum FileExecutionData {
 /// Map from file path to execution data.
 pub type ExecutionDataMap = FxHashMap<PathBuf, FileExecutionData>;
 
-/// Build execution data for all source files that have coverage. Each covered
-/// file is routed to the verified two-phase model when a tree-sitter classifier
-/// exists for its language ([`FileExecutionData::Classified`]), or to the
-/// verified degraded path otherwise ([`FileExecutionData::Degraded`]). Both are
-/// verified; neither is the old unverified forward-walk.
+/// Everything `execute_coverage_check` needs about execution, for ALL coverage
+/// reports at once: one [`ExecutionDataMap`] per report, plus the per-file
+/// model-routing summary (which files were scored by which verified model, and
+/// which files' classifications were defeated) aggregated across reports.
+///
+/// Built by [`build_execution_data`]. The summary fields are derived from the
+/// per-file bases (computed once per file), NOT by re-scanning the per-report
+/// maps — the maps only carry entries for files that actually hold annotations,
+/// while the summary covers every file matched by any report.
+#[derive(Debug)]
+pub struct ExecutionData {
+    /// One map per coverage report, in the same order as the input reports.
+    /// Contains entries only for files that carry at least one annotation:
+    /// [`executed_status_for`] is only ever asked about an annotation's source
+    /// file, so execution data for annotation-free files would never be read.
+    pub maps: Vec<ExecutionDataMap>,
+    /// Covered files scored by the language-aware two-phase model (verified).
+    pub classified_files: BTreeSet<PathBuf>,
+    /// Covered files scored by the degraded path — no classifier (verified).
+    pub degraded_files: BTreeSet<PathBuf>,
+    /// Files whose classification was defeated (spec §1.5), each with its
+    /// located issues — once per file, regardless of how many reports cover it.
+    pub defeated: BTreeMap<PathBuf, Vec<ClassifierIssue>>,
+}
+
+/// Report-independent classification base for one source file, computed ONCE
+/// and shared across every coverage report via `Arc`. Everything here is a
+/// function of the file's content and duvet's parsed annotations only —
+/// tree-sitter classification, the scope tree, and annotation stamping are
+/// exactly the expensive work that must not be repeated per report.
+#[derive(Debug)]
+enum FileBase {
+    /// A tree-sitter classifier exists: pristine-then-stamped classifications
+    /// plus the CST-derived scope tree (see `build_file_base` for the ordering
+    /// contract between the two).
+    Classified {
+        classifications: Arc<Vec<Option<LineClass>>>,
+        scopes: Arc<Vec<Scope>>,
+        file_length: u64,
+    },
+    /// No classifier: the minimal universal classification, stamped.
+    Degraded {
+        classifications: Arc<Vec<Option<LineClass>>>,
+        file_length: u64,
+    },
+    /// Defeated commitment (spec §1.5): parse errors or an unbalanced scope
+    /// stream. No trustworthy classification exists; see
+    /// [`FileExecutionData::DefeatedClassification`].
+    Defeated { issues: Vec<ClassifierIssue> },
+}
+
+/// Build execution data for all source files that have coverage, across ALL
+/// coverage reports. Each covered file is routed to the verified two-phase
+/// model when a tree-sitter classifier exists for its language
+/// ([`FileExecutionData::Classified`]), or to the verified degraded path
+/// otherwise ([`FileExecutionData::Degraded`]). Both are verified; neither is
+/// the old unverified forward-walk.
+///
+/// Cost model (why this takes all reports at once): a JaCoCo-style corpus is
+/// often one report per test method — hundreds of ~identical file sets. The
+/// report-independent work (absolutizing source paths, suffix-matching report
+/// entries, tree-sitter classification, scope trees, annotation stamping) is
+/// therefore hoisted and done once per file / once per distinct report path,
+/// and only the genuinely per-report work (the coverage map and its execution
+/// set) is done per (file, report) — in parallel on the blocking pool, since
+/// duvet's runtime is single-threaded and this is pure CPU.
 pub async fn build_execution_data(
     annotations: &AnnotationSet,
-    coverage_data: &CoverageData,
+    coverage_data: &[CoverageData],
     project_sources: &HashSet<SourceFile>,
-) -> Result<ExecutionDataMap> {
-    let generic = coverage_data.as_generic();
-
+) -> Result<ExecutionData> {
     // Resolve each duvet source file to its absolute path once. The absolute
     // path carries the file's full on-disk directory context, which is exactly
     // what lets a report's file path be matched regardless of where duvet was
@@ -123,7 +207,7 @@ pub async fn build_execution_data(
         duvet_sources.push((duvet_path, absolute.to_string_lossy().into_owned()));
     }
 
-    // Match every duvet source against every report entry by the suffix rule,
+    // Match every report entry against every duvet source by the suffix rule,
     // collecting ALL matches in both directions so a genuine ambiguity is caught
     // rather than silently resolved to whichever entry iterated first (the old
     // `.find()` did the latter — verified-looking, but potentially wrong).
@@ -133,99 +217,273 @@ pub async fn build_execution_data(
     // and `moduleB/…/com/example/Foo.java` against a report that only says
     // `com/example/Foo.java`), are both unresolvable from the paths alone. We
     // refuse rather than guess.
-    let mut matches_for_file: Vec<(&Path, &FileCoverage)> = Vec::new();
-    let mut files_for_coverage: FxHashMap<&str, Vec<&Path>> = FxHashMap::default();
+    //
+    // The match itself depends only on (report path, source set), never on
+    // which report the path came from — so it is memoized across reports.
+    let mut match_memo: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    // Per report: the matched (source index, file coverage) pairs.
+    let mut per_report_matches: Vec<Vec<(usize, &FileCoverage)>> =
+        Vec::with_capacity(coverage_data.len());
 
-    for (duvet_path, absolute) in &duvet_sources {
-        let mut matched: Vec<(&str, &FileCoverage)> = Vec::new();
+    for cover in coverage_data {
+        let generic = cover.as_generic();
+        let mut matches: Vec<(usize, &FileCoverage)> = Vec::new();
+        let mut entries_for_source: FxHashMap<usize, Vec<&str>> = FxHashMap::default();
+
         for (coverage_path, file_coverage) in &generic.files {
-            if coverage_path_matches(absolute, coverage_path) {
-                matched.push((coverage_path.as_str(), file_coverage));
-                files_for_coverage
-                    .entry(coverage_path.as_str())
+            let indices = match_memo
+                .entry(coverage_path.clone())
+                .or_insert_with(|| {
+                    duvet_sources
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, (_, absolute))| {
+                            coverage_path_matches(absolute, coverage_path)
+                        })
+                        .map(|(idx, _)| idx)
+                        .collect()
+                });
+
+            // The mirror ambiguity: one report entry claimed by more than one
+            // source file.
+            if indices.len() > 1 {
+                // `project_sources` is a `HashSet`, so iteration order is not
+                // stable; sort the reported names for a deterministic message.
+                let mut names = indices
+                    .iter()
+                    .map(|&idx| duvet_sources[idx].0.display().to_string())
+                    .collect::<Vec<_>>();
+                names.sort();
+                let names = names.join(", ");
+                return Err(duvet_core::error!(
+                    "coverage report entry '{}' is ambiguous: it matches multiple \
+                     source files ({}). duvet cannot tell which file the report \
+                     refers to.",
+                    coverage_path,
+                    names
+                ));
+            }
+
+            if let Some(&idx) = indices.first() {
+                entries_for_source
+                    .entry(idx)
                     .or_default()
-                    .push(duvet_path);
+                    .push(coverage_path.as_str());
+                matches.push((idx, file_coverage));
             }
         }
 
-        if matched.len() > 1 {
-            // `generic.files` is a hash map, so match order is not stable; sort
-            // the reported entries for a deterministic message.
-            let mut entries = matched.iter().map(|(path, _)| *path).collect::<Vec<_>>();
-            entries.sort_unstable();
-            let entries = entries.join(", ");
-            return Err(duvet_core::error!(
-                "coverage is ambiguous for {}: its path matches multiple report \
-                 entries ({}). duvet cannot tell which entry refers to this file.",
-                duvet_path.display(),
-                entries
-            ));
+        // A single duvet file matching two entries within one report.
+        for (idx, entries) in &entries_for_source {
+            if entries.len() > 1 {
+                // `generic.files` is a hash map, so match order is not stable;
+                // sort the reported entries for a deterministic message.
+                let mut entries = entries.to_vec();
+                entries.sort_unstable();
+                let entries = entries.join(", ");
+                return Err(duvet_core::error!(
+                    "coverage is ambiguous for {}: its path matches multiple report \
+                     entries ({}). duvet cannot tell which entry refers to this file.",
+                    duvet_sources[*idx].0.display(),
+                    entries
+                ));
+            }
         }
 
-        if let Some((_, file_coverage)) = matched.first() {
-            matches_for_file.push((*duvet_path, *file_coverage));
-        }
+        per_report_matches.push(matches);
     }
 
-    // The mirror ambiguity: one report entry claimed by more than one source file.
-    for (coverage_path, files) in &files_for_coverage {
-        if files.len() > 1 {
-            // `project_sources` is a `HashSet`, so iteration order is not stable;
-            // sort the reported names for a deterministic message.
-            let mut names = files
-                .iter()
-                .map(|path| path.display().to_string())
-                .collect::<Vec<_>>();
-            names.sort();
-            let names = names.join(", ");
-            return Err(duvet_core::error!(
-                "coverage report entry '{}' is ambiguous: it matches multiple \
-                 source files ({}). duvet cannot tell which file the report \
-                 refers to.",
-                coverage_path,
-                names
-            ));
-        }
-    }
+    // Classify each matched file ONCE (union across reports), in parallel on
+    // the blocking pool — tree-sitter parsing is pure CPU and duvet's runtime
+    // is single-threaded, so plain async concurrency would serialize it. A
+    // covered file without a language classifier is not refused: it is routed
+    // to the verified degraded path (forward-nearest governance over the
+    // minimal universal classification). Both paths are verified.
+    let matched_indices: BTreeSet<usize> = per_report_matches
+        .iter()
+        .flatten()
+        .map(|(idx, _)| *idx)
+        .collect();
 
-    let mut file_futures = Vec::new();
-    for (duvet_path, file_coverage) in matches_for_file {
-        // A covered file without a language classifier is no longer refused: it
-        // is routed to the verified degraded path in `build_file_execution_data`
-        // (forward-nearest governance over the minimal universal classification).
-        // Both the classified and degraded paths are verified in duvet-coverage.
-        let duvet_path = duvet_path.to_path_buf();
+    let mut base_futures = Vec::with_capacity(matched_indices.len());
+    for &idx in &matched_indices {
+        let duvet_path = duvet_sources[idx].0.to_path_buf();
         let annotations = annotations.clone();
-        let file_coverage = file_coverage.clone();
+        base_futures.push(async move {
+            let base = build_file_base(&duvet_path, &annotations).await?;
+            Result::<_, crate::Error>::Ok((idx, Arc::new(base)))
+        });
+    }
+    let bases: FxHashMap<usize, Arc<FileBase>> = futures::future::try_join_all(base_futures)
+        .await?
+        .into_iter()
+        .collect();
 
-        let future = async move {
-            let data = build_file_execution_data(&duvet_path, &annotations, &file_coverage).await?;
-            Result::<_, crate::Error>::Ok((duvet_path.clone(), data))
-        };
-
-        file_futures.push(future);
+    // Model-routing summary, from the bases: once per file, however many
+    // reports cover it.
+    let mut classified_files = BTreeSet::new();
+    let mut degraded_files = BTreeSet::new();
+    let mut defeated = BTreeMap::new();
+    for (&idx, base) in &bases {
+        let path = duvet_sources[idx].0.to_path_buf();
+        match &**base {
+            FileBase::Classified { .. } => {
+                classified_files.insert(path);
+            }
+            FileBase::Degraded { .. } => {
+                degraded_files.insert(path);
+            }
+            FileBase::Defeated { issues } => {
+                defeated.insert(path, issues.clone());
+            }
+        }
     }
 
-    let results = futures::future::try_join_all(file_futures).await?;
-    Ok(results.into_iter().collect())
+    // Only files that hold at least one annotation can ever be queried
+    // (`executed_status_for` looks up the annotation's own source file), so
+    // per-report execution data is built for exactly those.
+    let annotated_files: FxHashSet<PathBuf> = annotations
+        .iter()
+        .map(|annotation| annotation.source.to_path_buf())
+        .collect();
+
+    // Per (report, file): the coverage map and its verified execution set.
+    // This is the only per-report work left, parallelized per report on the
+    // blocking pool.
+    let mut map_futures = Vec::with_capacity(per_report_matches.len());
+    for matches in per_report_matches {
+        // Move owned copies of the (cheap) per-report inputs into the task:
+        // Arc'd bases and the per-file coverage maps.
+        let inputs: Vec<(PathBuf, Arc<FileBase>, FileCoverage)> = matches
+            .into_iter()
+            .filter_map(|(idx, file_coverage)| {
+                let path = duvet_sources[idx].0.to_path_buf();
+                if !annotated_files.contains(&path) {
+                    return None;
+                }
+                let base = bases.get(&idx)?.clone();
+                Some((path, base, file_coverage.clone()))
+            })
+            .collect();
+
+        map_futures.push(async move {
+            tokio::task::spawn_blocking(move || {
+                let mut map = ExecutionDataMap::default();
+                for (path, base, file_coverage) in inputs {
+                    map.insert(path, file_execution_data_for_report(&base, &file_coverage));
+                }
+                map
+            })
+            .await
+            .map_err(|e| duvet_core::error!("Task join error: {}", e))
+        });
+    }
+
+    let maps: Vec<ExecutionDataMap> = futures::future::try_join_all(map_futures).await?;
+
+    Ok(ExecutionData {
+        maps,
+        classified_files,
+        degraded_files,
+        defeated,
+    })
 }
 
-/// Build execution data for a single covered file. Uses the verified two-phase
-/// model when a tree-sitter classifier exists for the language, otherwise the
-/// verified degraded path over the minimal universal classification.
+/// Project a file's report-independent base onto one coverage report: build the
+/// verified-model coverage map, check the coverage-key precondition once, and
+/// precompute the verified execution set (see the trust note on
+/// [`ClassifiedFileData::exec_set`]). This is the only work that is genuinely
+/// per (file, report).
+fn file_execution_data_for_report(
+    base: &FileBase,
+    file_coverage: &FileCoverage,
+) -> FileExecutionData {
+    match base {
+        FileBase::Classified {
+            classifications,
+            scopes,
+            file_length,
+        } => {
+            let coverage = file_coverage.to_coverage_report();
+            // `execution_set`'s (and the per-annotation checker's) coverage
+            // precondition, checked once per (file, report): every JaCoCo
+            // `<line nr=...>` key must map to a valid classification index.
+            // Source/coverage drift or an `nr` past EOF violates it; then no
+            // verified verdict is trustworthy for this file+report, so the
+            // execution set is left empty and `executed_status_for` reports
+            // `Unknown` without consulting it.
+            let coverage_keys_in_bounds =
+                coverage_keys_in_bounds(&coverage, classifications.len());
+            let exec_set = if coverage_keys_in_bounds {
+                execution_set(classifications, scopes, &coverage)
+            } else {
+                BTreeSet::new()
+            };
+            FileExecutionData::Classified(ClassifiedFileData {
+                classifications: classifications.clone(),
+                scopes: scopes.clone(),
+                coverage,
+                exec_set,
+                coverage_keys_in_bounds,
+                file_length: *file_length,
+            })
+        }
+        FileBase::Degraded {
+            classifications,
+            file_length,
+        } => FileExecutionData::Degraded(DegradedFileData {
+            classifications: classifications.clone(),
+            coverage: file_coverage.to_coverage_report(),
+            file_length: *file_length,
+        }),
+        FileBase::Defeated { issues } => FileExecutionData::DefeatedClassification {
+            issues: issues.clone(),
+        },
+    }
+}
+
+/// Build execution data for a single covered file against a single report.
+/// Composition of [`build_file_base`] (the once-per-file work) and
+/// [`file_execution_data_for_report`] (the per-report projection); kept as the
+/// single-file entry point for tests.
+#[cfg(test)]
 async fn build_file_execution_data(
     duvet_path: &Path,
     annotations: &AnnotationSet,
     file_coverage: &FileCoverage,
 ) -> Result<FileExecutionData> {
+    let base = build_file_base(duvet_path, annotations).await?;
+    Ok(file_execution_data_for_report(&base, file_coverage))
+}
+
+/// Build the report-independent base for a single file: read it, classify it
+/// (verified two-phase model when a tree-sitter classifier exists for the
+/// language, otherwise the minimal universal classification for the verified
+/// degraded path), build the scope tree, and stamp annotation lines. The
+/// CPU-bound part runs on the blocking pool.
+async fn build_file_base(duvet_path: &Path, annotations: &AnnotationSet) -> Result<FileBase> {
     let source_file = duvet_core::vfs::read_string(duvet_path).await?;
     let file_content = source_file.to_string();
+    let duvet_path = duvet_path.to_path_buf();
+    let annotations = annotations.clone();
+
+    // Tree-sitter classification is pure CPU; run it off the (single-threaded)
+    // async runtime so files classify in parallel.
+    tokio::task::spawn_blocking(move || build_file_base_sync(&duvet_path, &file_content, &annotations))
+        .await
+        .map_err(|e| duvet_core::error!("Task join error: {}", e))
+}
+
+fn build_file_base_sync(
+    duvet_path: &Path,
+    file_content: &str,
+    annotations: &AnnotationSet,
+) -> FileBase {
     let line_count = file_content.lines().count() as u64;
-    let coverage = file_coverage.to_coverage_report();
 
     if let Some(classifier) = classifier_for_path(duvet_path) {
         // Classified path: tree-sitter classification + verified two-phase model.
-        let mut classifications = match classifier.classify(&file_content) {
+        let mut classifications = match classifier.classify(file_content) {
             Classification::Classified(c) => c,
             // Defeated commitment (spec §1.5): the classifier could not parse the
             // file and reported located parse errors. Escalate rather than build
@@ -235,7 +493,7 @@ async fn build_file_execution_data(
                 let mut issues = Vec::with_capacity(rest.len() + 1);
                 issues.push(first);
                 issues.extend(rest);
-                return Ok(FileExecutionData::DefeatedClassification { issues });
+                return FileBase::Defeated { issues };
             }
         };
 
@@ -270,14 +528,14 @@ async fn build_file_execution_data(
         // brace-balanced file now passes the gate. On a genuine imbalance we
         // still refuse to score against `build_scope_tree`'s collapsed whole-file
         // scope (spec §1.5) and escalate to a located `Unknown`.
-        let scope_events = classifier.scope_events(&file_content);
+        let scope_events = classifier.scope_events(file_content);
         if let Some(witness_line) = scope_imbalance_site(&scope_events) {
-            return Ok(FileExecutionData::DefeatedClassification {
+            return FileBase::Defeated {
                 issues: vec![ClassifierIssue {
                     reason: ClassifierFailure::UnbalancedScopes,
                     line: witness_line,
                 }],
-            });
+            };
         }
 
         // Discharge `build_scope_tree`'s event-stream preconditions at this
@@ -297,29 +555,28 @@ async fn build_file_execution_data(
         apply_annotation_override(&mut classifications, annotations, duvet_path);
 
         // TRUSTED-BASE ASSUMPTION (unverified glue): the `scopes` stored here
-        // satisfy `is_annotation_executed`'s scope-bound preconditions
+        // satisfy the verified checkers' scope-bound preconditions
         // (open_line >= 1, close_line < u64::MAX) *because* they came from
         // `build_scope_tree`, whose contract now states those bounds. Nothing at
         // the type level enforces that this field only ever holds a
-        // `build_scope_tree` result — `scopes: Vec<Scope>` is a plain public
+        // `build_scope_tree` result — `scopes` is a plain public
         // field. Today this is the sole producer, so the assumption holds by
         // construction. TODO(VerifiedScopeTree): replace `Vec<Scope>` with an
         // opaque newtype whose only constructor is `build_scope_tree` and whose
         // Verus type invariant carries the bounds, so the query-side consumer
         // discharges those `requires` from the type instead of this comment.
-        Ok(FileExecutionData::Classified(ClassifiedFileData {
-            classifications,
-            scopes,
-            coverage,
+        FileBase::Classified {
+            classifications: Arc::new(classifications),
+            scopes: Arc::new(scopes),
             file_length: line_count,
-        }))
+        }
     } else {
         // Degraded path: no language classifier for this file. Build the minimal
         // universal classification (blank → Whitespace, else None), stamp
         // annotation lines, and let the verified `degraded_execution_status`
         // resolve the target and read coverage directly. No scope tree is built:
         // the degraded model does not propagate, so none is needed.
-        let mut classifications = match DefaultClassifier.classify(&file_content) {
+        let mut classifications = match DefaultClassifier.classify(file_content) {
             Classification::Classified(c) => c,
             // DefaultClassifier is total (blank-line detection cannot fail), so
             // it never reports Unclassifiable. This arm is unreachable.
@@ -328,11 +585,10 @@ async fn build_file_execution_data(
             }
         };
         apply_annotation_override(&mut classifications, annotations, duvet_path);
-        Ok(FileExecutionData::Degraded(DegradedFileData {
-            classifications,
-            coverage,
+        FileBase::Degraded {
+            classifications: Arc::new(classifications),
             file_length: line_count,
-        }))
+        }
     }
 }
 
@@ -462,7 +718,7 @@ pub fn executed_status_for(
                 end_line,
             };
 
-            // Enforce `is_annotation_executed`'s `requires` at this trust
+            // Enforce the verified checker's `requires` at this trust
             // boundary. Verus checks those clauses statically against the
             // *proof*, but they compile away in release builds, so nothing stops
             // ill-formed runtime inputs from reaching the verified algorithm and
@@ -475,22 +731,28 @@ pub fn executed_status_for(
             // fall back to `Unknown` (the conservative status) instead of calling
             // the verified fn on inputs it never reasoned about.
             //
-            // requires: annotation.end_line < u64::MAX
+            // requires: annotation.end_line < u64::MAX  (checked here, per annotation)
             // requires: every coverage key K has (K - 1) < classifications.len()
-            let precondition_holds =
-                classified_preconditions_hold(end_line, &data.coverage, data.classifications.len());
+            //           (annotation-independent — checked once per (file, report)
+            //           when the execution data was built; see
+            //           `ClassifiedFileData::coverage_keys_in_bounds`)
+            // requires: exec_set == execution_set(classifications, scopes, coverage)
+            //           (by construction — see the trust note on
+            //           `ClassifiedFileData::exec_set`)
+            let precondition_holds = end_line < u64::MAX && data.coverage_keys_in_bounds;
 
             if !precondition_holds {
                 ExecutionStatus::Unknown {
                     line_number: start_line,
                 }
             } else {
-                is_annotation_executed(
+                is_annotation_executed_with_exec_set(
                     &ann_span,
                     &data.classifications,
                     &data.scopes,
                     &data.coverage,
                     data.file_length,
+                    &data.exec_set,
                 )
             }
         }
@@ -531,18 +793,31 @@ pub fn executed_status_for(
     }
 }
 
-/// Whether the classified inputs satisfy `is_annotation_executed`'s `requires`
+/// Whether every coverage key `K` maps to a valid 0-based classification
+/// index: `1 <= K` and `K - 1 < classifications_len`. This is the
+/// annotation-independent half of the verified checker's runtime-checkable
+/// preconditions, evaluated once per (file, report) when execution data is
+/// built (see [`ClassifiedFileData::coverage_keys_in_bounds`]).
+fn coverage_keys_in_bounds(coverage: &CoverageReportMap, classifications_len: usize) -> bool {
+    coverage
+        .keys()
+        .all(|&k| k >= 1 && (k as usize - 1) < classifications_len)
+}
+
+/// Whether the classified inputs satisfy the verified checker's `requires`
 /// clauses. Pure so it can be tested without constructing a full `Annotation`.
 /// Mirrors, exactly, the two runtime-checkable preconditions:
 ///   - `annotation.end_line < u64::MAX`
 ///   - every coverage key `K` maps to a valid 0-based index: `1 <= K` and
-///     `K - 1 < classifications_len`
+///     `K - 1 < classifications_len` (see [`coverage_keys_in_bounds`], which
+///     the production path evaluates once per (file, report) rather than per
+///     annotation)
 ///
 /// (The scope-bounds invariants in the third/fourth `requires` are guaranteed
 /// by `build_scope_tree`'s postcondition and need no runtime check here.
 ///
 /// Property 2's `scopes_match_classifications` hypothesis is *not* a
-/// `requires` of `is_annotation_executed` and is likewise not checked here —
+/// `requires` of the verified checker and is likewise not checked here —
 /// but not because of `build_scope_tree`: that postcondition governs the
 /// scope *tree*, while propagation reads the per-line classification *set*,
 /// and their silent disagreement was a real bug (a `} // comment` line lost
@@ -551,15 +826,13 @@ pub fn executed_status_for(
 /// the verified post-pass (`classify_postpass::clean_classifications`) proves
 /// `ScopeOpen`/`ScopeClose` are never stripped, and the classifier property
 /// test proves boundary lines carry them in the first place.)
+#[cfg(test)]
 fn classified_preconditions_hold(
     end_line: u64,
     coverage: &CoverageReportMap,
     classifications_len: usize,
 ) -> bool {
-    end_line < u64::MAX
-        && coverage
-            .keys()
-            .all(|&k| k >= 1 && (k as usize - 1) < classifications_len)
+    end_line < u64::MAX && coverage_keys_in_bounds(coverage, classifications_len)
 }
 
 #[cfg(test)]

--- a/duvet/src/query/checks/coverage.rs
+++ b/duvet/src/query/checks/coverage.rs
@@ -220,18 +220,20 @@ pub async fn build_execution_data(
     //
     // The match itself depends only on (report path, source set), never on
     // which report the path came from — so it is memoized across reports.
-    let mut match_memo: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    // Keyed by paths borrowed from `coverage_data`, so no hit or miss ever
+    // allocates a key.
+    let mut match_memo: FxHashMap<&str, Vec<usize>> = FxHashMap::default();
     // Per report: the matched (source index, file coverage) pairs.
-    let mut per_report_matches: Vec<Vec<(usize, &FileCoverage)>> =
+    let mut per_report_matches: Vec<Vec<(usize, Arc<FileCoverage>)>> =
         Vec::with_capacity(coverage_data.len());
 
     for cover in coverage_data {
         let generic = cover.as_generic();
-        let mut matches: Vec<(usize, &FileCoverage)> = Vec::new();
+        let mut matches: Vec<(usize, Arc<FileCoverage>)> = Vec::new();
         let mut entries_for_source: FxHashMap<usize, Vec<&str>> = FxHashMap::default();
 
         for (coverage_path, file_coverage) in &generic.files {
-            let indices = match_memo.entry(coverage_path.clone()).or_insert_with(|| {
+            let indices = match_memo.entry(coverage_path.as_str()).or_insert_with(|| {
                 duvet_sources
                     .iter()
                     .enumerate()
@@ -265,7 +267,7 @@ pub async fn build_execution_data(
                     .entry(idx)
                     .or_default()
                     .push(coverage_path.as_str());
-                matches.push((idx, file_coverage));
+                matches.push((idx, file_coverage.clone()));
             }
         }
 
@@ -349,8 +351,8 @@ pub async fn build_execution_data(
     let mut map_futures = Vec::with_capacity(per_report_matches.len());
     for matches in per_report_matches {
         // Move owned copies of the (cheap) per-report inputs into the task:
-        // Arc'd bases and the per-file coverage maps.
-        let inputs: Vec<(PathBuf, Arc<FileBase>, FileCoverage)> = matches
+        // Arc'd bases and Arc'd per-file coverage maps.
+        let inputs: Vec<(PathBuf, Arc<FileBase>, Arc<FileCoverage>)> = matches
             .into_iter()
             .filter_map(|(idx, file_coverage)| {
                 let path = duvet_sources[idx].0.to_path_buf();
@@ -358,7 +360,7 @@ pub async fn build_execution_data(
                     return None;
                 }
                 let base = bases.get(&idx)?.clone();
-                Some((path, base, file_coverage.clone()))
+                Some((path, base, file_coverage))
             })
             .collect();
 

--- a/duvet/src/query/checks/coverage.rs
+++ b/duvet/src/query/checks/coverage.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use duvet_coverage::{
     degraded::degraded_execution_status,
+    file_execution::FileExecution,
     scopes::{build_scope_tree, scope_imbalance_site},
     types::{
         AnnotationSpan, CoverageReport as CoverageReportMap, ExecutionStatus, LineClass,
@@ -35,137 +36,6 @@ pub enum CoverageFormat {
     // Future: Lcov, Clover
 }
 
-/// Sealed home of [`ClassifiedFileData`]. The module boundary is what makes
-/// the exec-set pairing a compiler-enforced fact rather than a discipline:
-/// every field is private to this module, so the constructor below is the
-/// only code in the crate that can produce (or recombine) a value. Code
-/// outside this module — including the rest of this file — can only obtain a
-/// `ClassifiedFileData` whose `exec_set` and `coverage_keys_in_bounds` were
-/// computed from its own sibling fields.
-mod sealed {
-    use super::{coverage_keys_in_bounds, CoverageReportMap};
-    use duvet_coverage::{
-        annotation_execution::is_annotation_executed_with_exec_set,
-        execution_propagation::execution_set,
-        types::{AnnotationSpan, ExecutionStatus, LineClass, Scope},
-    };
-    use std::{collections::BTreeSet, sync::Arc};
-
-    /// Coverage model data for a file with a tree-sitter classifier.
-    /// Contains the classified line properties, scope tree, and coverage data
-    /// in the format expected by the verified `duvet-coverage` algorithms.
-    ///
-    /// The report-independent parts (`classifications`, `scopes`) are shared
-    /// via `Arc` across every coverage report — they are a function of the
-    /// source file and its annotations only. The per-report parts are the
-    /// `coverage` map, the precomputed `exec_set`, and the
-    /// `coverage_keys_in_bounds` witness.
-    ///
-    /// TRUSTED-BASE ASSUMPTION (unverified glue, same shape as the `scopes`
-    /// note in `build_file_base`, but narrowed by sealing):
-    /// `is_annotation_executed_with_exec_set` `requires` that `exec_set` be
-    /// the execution set of the sibling fields. That pairing holds because
-    /// [`ClassifiedFileData::new`] — the only constructor, and the only code
-    /// with field access — computes `exec_set` and `coverage_keys_in_bounds`
-    /// from the very fields it stores, with the verified functions. The
-    /// residual assumption is only that values are not mutated after
-    /// construction: privacy plus the absence of `&mut` accessors and of
-    /// interior mutability enforces that. `Clone` is pairing-preserving (it
-    /// copies all fields together).
-    #[derive(Debug, Clone)]
-    pub struct ClassifiedFileData {
-        classifications: Arc<Vec<Option<LineClass>>>,
-        scopes: Arc<Vec<Scope>>,
-        coverage: CoverageReportMap,
-        /// The verified execution set for exactly (`classifications`,
-        /// `scopes`, `coverage`), computed ONCE per (file, report) by
-        /// [`duvet_coverage::execution_propagation::execution_set`].
-        exec_set: BTreeSet<u64>,
-        /// Whether every coverage key maps to a valid classification index —
-        /// `is_annotation_executed_with_exec_set`'s runtime-checkable coverage
-        /// precondition, evaluated once per (file, report) instead of once per
-        /// annotation. When false, the file's annotations are reported
-        /// `Unknown` (the conservative status) without ever calling the
-        /// verified model.
-        coverage_keys_in_bounds: bool,
-        file_length: u64,
-    }
-
-    impl ClassifiedFileData {
-        /// Sole producer. Checks `execution_set`'s (and the per-annotation
-        /// checker's) coverage precondition once per (file, report) — every
-        /// JaCoCo `<line nr=...>` key must map to a valid classification
-        /// index. Source/coverage drift or an `nr` past EOF violates it; then
-        /// no verified verdict is trustworthy for this file+report, so the
-        /// execution set is left empty and [`Self::annotation_status`] reports
-        /// `Unknown` without consulting it.
-        pub(super) fn new(
-            classifications: Arc<Vec<Option<LineClass>>>,
-            scopes: Arc<Vec<Scope>>,
-            coverage: CoverageReportMap,
-            file_length: u64,
-        ) -> Self {
-            let coverage_keys_in_bounds = coverage_keys_in_bounds(&coverage, classifications.len());
-            let exec_set = if coverage_keys_in_bounds {
-                execution_set(&classifications, &scopes, &coverage)
-            } else {
-                BTreeSet::new()
-            };
-            Self {
-                classifications,
-                scopes,
-                coverage,
-                exec_set,
-                coverage_keys_in_bounds,
-                file_length,
-            }
-        }
-
-        /// The verified verdict for one annotation span, with the verified
-        /// checker's `requires` enforced at this trust boundary. Verus checks
-        /// those clauses statically against the *proof*, but they compile away
-        /// in release builds, so nothing stops ill-formed runtime inputs from
-        /// reaching the verified algorithm and making its guarantees vacuous.
-        /// The inputs here are not proof-clean: `file_length`/
-        /// `classifications` come from the tree-sitter classifier while
-        /// `coverage` keys are JaCoCo `<line nr=...>` values from a
-        /// separately-produced XML. When a precondition fails we cannot
-        /// soundly trust the model's verdict, so fall back to `Unknown` (the
-        /// conservative status) instead of calling the verified fn on inputs
-        /// it never reasoned about.
-        ///
-        /// requires: annotation.end_line < u64::MAX  (checked here, per annotation)
-        /// requires: every coverage key K has (K - 1) < classifications.len()
-        ///           (annotation-independent — checked once per (file, report)
-        ///           by [`Self::new`]; see `coverage_keys_in_bounds`)
-        /// requires: exec_set == execution_set(classifications, scopes, coverage)
-        ///           (by construction — see the trust note on this type)
-        pub(super) fn annotation_status(&self, start_line: u64, end_line: u64) -> ExecutionStatus {
-            let precondition_holds = end_line < u64::MAX && self.coverage_keys_in_bounds;
-
-            if !precondition_holds {
-                ExecutionStatus::Unknown {
-                    line_number: start_line,
-                }
-            } else {
-                is_annotation_executed_with_exec_set(
-                    &AnnotationSpan {
-                        start_line,
-                        end_line,
-                    },
-                    &self.classifications,
-                    &self.scopes,
-                    &self.coverage,
-                    self.file_length,
-                    &self.exec_set,
-                )
-            }
-        }
-    }
-}
-
-pub use sealed::ClassifiedFileData;
-
 /// Coverage model data for a file with **no** tree-sitter classifier: the
 /// minimal universal classification (blank lines → `Whitespace`, everything else
 /// → `None`, annotation lines stamped by the caller) plus coverage and length.
@@ -184,11 +54,19 @@ pub struct DegradedFileData {
 /// one uses the verified degraded path ([`FileExecutionData::Degraded`]). Both
 /// paths are verified in `duvet-coverage`; they differ only in fidelity
 /// (scope-based governance vs. forward-nearest governance).
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum FileExecutionData {
     /// File has a tree-sitter classifier — uses the two-phase coverage model
-    /// (target resolution + execution propagation) from duvet-coverage.
-    Classified(ClassifiedFileData),
+    /// (target resolution + execution propagation) from duvet-coverage,
+    /// packaged as a [`FileExecution`]: a verified type whose invariant
+    /// carries the exec-set pairing, so this glue holds no paired fields to
+    /// keep in sync. `None` records that construction failed the
+    /// runtime-checked model preconditions (a coverage key out of the
+    /// classification's bounds — source/coverage drift or a JaCoCo
+    /// `<line nr=...>` past EOF); every annotation in the file is then
+    /// reported `Unknown` (the conservative status) without consulting the
+    /// model.
+    Classified(Option<FileExecution>),
     /// File has no tree-sitter classifier — uses the verified degraded path
     /// ([`duvet_coverage::degraded::degraded_execution_status`]): the same
     /// forward target walk, deciding status by reading coverage directly on the
@@ -480,11 +358,11 @@ pub async fn build_execution_data(
     })
 }
 
-/// Project a file's report-independent base onto one coverage report: build the
-/// verified-model coverage map, check the coverage-key precondition once, and
-/// precompute the verified execution set (see the trust note on
-/// [`ClassifiedFileData::exec_set`]). This is the only work that is genuinely
-/// per (file, report).
+/// Project a file's report-independent base onto one coverage report. For the
+/// classified path this hands the merged coverage pairs to the verified
+/// [`FileExecution::new`], which checks the model's preconditions and computes
+/// the execution set. This is the only work that is genuinely per
+/// (file, report).
 fn file_execution_data_for_report(
     base: &FileBase,
     file_coverage: &FileCoverage,
@@ -495,15 +373,19 @@ fn file_execution_data_for_report(
             scopes,
             file_length,
         } => {
-            let coverage = file_coverage.to_coverage_report();
-            // The coverage-keys precondition check and the verified
-            // `execution_set` computation both live inside the sealed
-            // constructor — the only code that can pair those values with the
-            // fields they were computed from.
-            FileExecutionData::Classified(ClassifiedFileData::new(
+            // The Hit-priority merge across line/branch records stays here
+            // (it is coverage-format policy, not model logic); the verified
+            // constructor takes the merged pairs, runtime-checks the model's
+            // preconditions, and computes the execution set from the very
+            // data it seals — the pairing is its type invariant, not a glue
+            // assumption. `None` means a coverage key fell outside the
+            // classification's bounds; see [`FileExecutionData::Classified`].
+            let coverage_pairs: Vec<(u64, duvet_coverage::types::CoverageStatus)> =
+                file_coverage.to_coverage_report().into_iter().collect();
+            FileExecutionData::Classified(FileExecution::new(
                 classifications.clone(),
                 scopes.clone(),
-                coverage,
+                &coverage_pairs,
                 *file_length,
             ))
         }
@@ -635,17 +517,16 @@ fn build_file_base_sync(
 
         apply_annotation_override(&mut classifications, annotations, duvet_path);
 
-        // TRUSTED-BASE ASSUMPTION (unverified glue): the `scopes` stored here
-        // satisfy the verified checkers' scope-bound preconditions
-        // (open_line >= 1, close_line < u64::MAX) *because* they came from
-        // `build_scope_tree`, whose contract now states those bounds. Nothing at
-        // the type level enforces that this field only ever holds a
-        // `build_scope_tree` result — `scopes` is a plain public
-        // field. Today this is the sole producer, so the assumption holds by
-        // construction. TODO(VerifiedScopeTree): replace `Vec<Scope>` with an
-        // opaque newtype whose only constructor is `build_scope_tree` and whose
-        // Verus type invariant carries the bounds, so the query-side consumer
-        // discharges those `requires` from the type instead of this comment.
+        // The verified checkers' scope-bound preconditions (open_line >= 1,
+        // close_line < u64::MAX) are guaranteed here by `build_scope_tree`'s
+        // contract — and, since the pairing moved into the verified crate, no
+        // longer *trusted* downstream: [`FileExecution::new`] runtime-checks
+        // them instead of assuming this provenance, so a future producer that
+        // violated them would be refused (conservative `Unknown`), not
+        // silently scored. TODO(VerifiedScopeTree): a `Vec<Scope>` newtype
+        // whose only constructor is `build_scope_tree` would still be worth
+        // it, to carry the richer well-formedness postconditions (proper
+        // nesting) into the type system rather than just the bounds.
         FileBase::Classified {
             classifications: Arc::new(classifications),
             scopes: Arc::new(scopes),
@@ -792,12 +673,29 @@ pub fn executed_status_for(
     let file_path = annotation.source.to_path_buf();
 
     match execution_data_map.get(&file_path) {
-        Some(FileExecutionData::Classified(data)) => {
+        Some(FileExecutionData::Classified(execution)) => {
             let (start_line, end_line) = annotation.line_range();
-            // The verified checker's `requires` are enforced inside the sealed
-            // [`ClassifiedFileData::annotation_status`], next to the fields
-            // they constrain — see the trust note on that type.
-            data.annotation_status(start_line, end_line)
+            // The exec-set and coverage-bounds `requires` of the verified
+            // checker are carried by `FileExecution`'s type invariant and its
+            // constructor's runtime checks; the one per-annotation
+            // precondition left at this trust boundary is
+            // `end_line < u64::MAX` (physically unfalsifiable for a real line
+            // number, but Verus's `requires` compile away in release builds,
+            // so guard rather than risk overflow — mirroring the degraded
+            // guard below). A `None` execution means construction failed the
+            // coverage-bounds check; both cases report the conservative
+            // `Unknown`.
+            match execution {
+                Some(execution) if end_line < u64::MAX => {
+                    execution.annotation_status(&AnnotationSpan {
+                        start_line,
+                        end_line,
+                    })
+                }
+                _ => ExecutionStatus::Unknown {
+                    line_number: start_line,
+                },
+            }
         }
         Some(FileExecutionData::Degraded(data)) => {
             let (start_line, end_line) = annotation.line_range();
@@ -836,57 +734,22 @@ pub fn executed_status_for(
     }
 }
 
-/// Whether every coverage key `K` maps to a valid 0-based classification
-/// index: `1 <= K` and `K - 1 < classifications_len`. This is the
-/// annotation-independent half of the verified checker's runtime-checkable
-/// preconditions, evaluated once per (file, report) when execution data is
-/// built (see [`ClassifiedFileData::coverage_keys_in_bounds`]).
-fn coverage_keys_in_bounds(coverage: &CoverageReportMap, classifications_len: usize) -> bool {
-    coverage
-        .keys()
-        .all(|&k| k >= 1 && (k as usize - 1) < classifications_len)
-}
-
-/// Whether the classified inputs satisfy the verified checker's `requires`
-/// clauses. Pure so it can be tested without constructing a full `Annotation`.
-/// Mirrors, exactly, the two runtime-checkable preconditions:
-///   - `annotation.end_line < u64::MAX`
-///   - every coverage key `K` maps to a valid 0-based index: `1 <= K` and
-///     `K - 1 < classifications_len` (see [`coverage_keys_in_bounds`], which
-///     the production path evaluates once per (file, report) rather than per
-///     annotation)
-///
-/// (The scope-bounds invariants in the third/fourth `requires` are guaranteed
-/// by `build_scope_tree`'s postcondition and need no runtime check here.
-///
-/// Property 2's `scopes_match_classifications` hypothesis is *not* a
-/// `requires` of the verified checker and is likewise not checked here —
-/// but not because of `build_scope_tree`: that postcondition governs the
-/// scope *tree*, while propagation reads the per-line classification *set*,
-/// and their silent disagreement was a real bug (a `} // comment` line lost
-/// `ScopeClose` to the mutual-exclusivity post-pass, letting backward
-/// propagation cross the brace). It is discharged upstream by construction:
-/// the verified post-pass (`classify_postpass::clean_classifications`) proves
-/// `ScopeOpen`/`ScopeClose` are never stripped, and the classifier property
-/// test proves boundary lines carry them in the first place.)
-#[cfg(test)]
-fn classified_preconditions_hold(
-    end_line: u64,
-    coverage: &CoverageReportMap,
-    classifications_len: usize,
-) -> bool {
-    end_line < u64::MAX && coverage_keys_in_bounds(coverage, classifications_len)
-}
+// (The coverage-keys and scope-bounds precondition checks that used to live
+// here as unverified glue are now runtime checks *inside*
+// [`FileExecution::new`], in the verified crate — see the tests below, which
+// pin the accept/reject behavior at that boundary. Property 2's
+// `scopes_match_classifications` hypothesis is not a `requires` of the
+// verified checker and is likewise not checked at this boundary — it is
+// discharged upstream by construction: the verified post-pass
+// (`classify_postpass::clean_classifications`) proves `ScopeOpen`/`ScopeClose`
+// are never stripped, and the classifier property test proves boundary lines
+// carry them in the first place.)
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::query::classify::{java::JavaClassifier, Classification, LineClassifier};
     use duvet_coverage::types::{CoverageStatus, LineProperty};
-
-    fn coverage_with_keys(keys: &[u64]) -> CoverageReportMap {
-        keys.iter().map(|&k| (k, CoverageStatus::Hit)).collect()
-    }
 
     fn count_scope_opens(classifications: &[Option<LineClass>]) -> usize {
         classifications
@@ -955,40 +818,62 @@ public class Two {
         );
     }
 
-    #[test]
-    fn preconditions_hold_for_in_bounds_coverage() {
-        // 5 classified lines; coverage keys 1..=5 all map to valid indices.
-        let coverage = coverage_with_keys(&[1, 3, 5]);
-        assert!(classified_preconditions_hold(4, &coverage, 5));
+    // --- FileExecution::new precondition boundary ---
+    //
+    // The verified constructor runtime-checks the model's coverage-keys and
+    // scope-bounds preconditions and refuses (returns `None`) rather than
+    // compute against inputs the proofs never reasoned about. These pin the
+    // accept/reject line exactly where the old glue-side checks pinned it.
+
+    /// Build a FileExecution over `len` unclassified lines with the given
+    /// coverage keys (all Hit) and no scopes.
+    fn file_execution_with_keys(keys: &[u64], len: usize) -> Option<FileExecution> {
+        let classifications: Arc<Vec<Option<LineClass>>> = Arc::new(vec![None; len]);
+        let scopes: Arc<Vec<duvet_coverage::types::Scope>> = Arc::new(vec![]);
+        let pairs: Vec<(u64, CoverageStatus)> =
+            keys.iter().map(|&k| (k, CoverageStatus::Hit)).collect();
+        FileExecution::new(classifications, scopes, &pairs, len as u64)
     }
 
     #[test]
-    fn coverage_key_past_eof_violates_precondition() {
+    fn in_bounds_coverage_constructs() {
+        // 5 classified lines; coverage keys 1..=5 all map to valid indices.
+        assert!(file_execution_with_keys(&[1, 3, 5], 5).is_some());
+    }
+
+    #[test]
+    fn coverage_key_past_eof_refuses_construction() {
         // Key 6 -> index 5, out of range for 5 classified lines. This is the
         // JaCoCo-nr-past-EOF / source-coverage-drift case that would otherwise
         // reach the verified fn with an input it never reasoned about.
-        let coverage = coverage_with_keys(&[1, 6]);
-        assert!(!classified_preconditions_hold(4, &coverage, 5));
+        assert!(file_execution_with_keys(&[1, 6], 5).is_none());
     }
 
     #[test]
-    fn zero_coverage_key_violates_precondition() {
+    fn zero_coverage_key_refuses_construction() {
         // Line numbers are 1-based; key 0 has no valid 0-based index.
-        let coverage = coverage_with_keys(&[0, 1]);
-        assert!(!classified_preconditions_hold(4, &coverage, 5));
+        assert!(file_execution_with_keys(&[0, 1], 5).is_none());
     }
 
     #[test]
-    fn end_line_at_u64_max_violates_precondition() {
-        let coverage = coverage_with_keys(&[1]);
-        assert!(!classified_preconditions_hold(u64::MAX, &coverage, 5));
+    fn empty_coverage_constructs() {
+        // No keys -> the bounds condition is vacuously satisfied.
+        assert!(file_execution_with_keys(&[], 5).is_some());
     }
 
     #[test]
-    fn empty_coverage_holds() {
-        // No keys -> the forall is vacuously satisfied.
-        let coverage = coverage_with_keys(&[]);
-        assert!(classified_preconditions_hold(4, &coverage, 5));
+    fn out_of_bounds_scope_refuses_construction() {
+        // A scope with open_line 0 violates the checkers' scope-bounds
+        // precondition. `build_scope_tree` never produces one; the constructor
+        // checks anyway instead of trusting that provenance.
+        let classifications: Arc<Vec<Option<LineClass>>> = Arc::new(vec![None; 5]);
+        let scopes = Arc::new(vec![duvet_coverage::types::Scope {
+            open_line: 0,
+            close_line: 5,
+            parent: None,
+            children: vec![],
+        }]);
+        assert!(FileExecution::new(classifications, scopes, &[], 5).is_none());
     }
 
     // --- coverage_path_matches ---

--- a/duvet/src/query/checks/coverage.rs
+++ b/duvet/src/query/checks/coverage.rs
@@ -770,7 +770,7 @@ pub fn executed_status_for(
 mod tests {
     use super::*;
     use crate::query::classify::{java::JavaClassifier, Classification, LineClassifier};
-    use duvet_coverage::types::{CoverageStatus, LineProperty};
+    use duvet_coverage::types::LineProperty;
 
     fn count_scope_opens(classifications: &[Option<LineClass>]) -> usize {
         classifications
@@ -839,63 +839,11 @@ public class Two {
         );
     }
 
-    // --- FileExecution::new precondition boundary ---
-    //
-    // The verified constructor runtime-checks the model's coverage-keys and
-    // scope-bounds preconditions and refuses (returns `None`) rather than
-    // compute against inputs the proofs never reasoned about. These pin the
-    // accept/reject line exactly where the old glue-side checks pinned it.
-
-    /// Build a FileExecution over `len` unclassified lines with the given
-    /// coverage keys (all Hit) and no scopes.
-    fn file_execution_with_keys(keys: &[u64], len: usize) -> Option<FileExecution> {
-        let classifications: Arc<Vec<Option<LineClass>>> = Arc::new(vec![None; len]);
-        let scopes: Arc<Vec<duvet_coverage::types::Scope>> = Arc::new(vec![]);
-        let pairs: Vec<(u64, CoverageStatus)> =
-            keys.iter().map(|&k| (k, CoverageStatus::Hit)).collect();
-        FileExecution::new(classifications, scopes, &pairs, len as u64)
-    }
-
-    #[test]
-    fn in_bounds_coverage_constructs() {
-        // 5 classified lines; coverage keys 1..=5 all map to valid indices.
-        assert!(file_execution_with_keys(&[1, 3, 5], 5).is_some());
-    }
-
-    #[test]
-    fn coverage_key_past_eof_refuses_construction() {
-        // Key 6 -> index 5, out of range for 5 classified lines. This is the
-        // JaCoCo-nr-past-EOF / source-coverage-drift case that would otherwise
-        // reach the verified fn with an input it never reasoned about.
-        assert!(file_execution_with_keys(&[1, 6], 5).is_none());
-    }
-
-    #[test]
-    fn zero_coverage_key_refuses_construction() {
-        // Line numbers are 1-based; key 0 has no valid 0-based index.
-        assert!(file_execution_with_keys(&[0, 1], 5).is_none());
-    }
-
-    #[test]
-    fn empty_coverage_constructs() {
-        // No keys -> the bounds condition is vacuously satisfied.
-        assert!(file_execution_with_keys(&[], 5).is_some());
-    }
-
-    #[test]
-    fn out_of_bounds_scope_refuses_construction() {
-        // A scope with open_line 0 violates the checkers' scope-bounds
-        // precondition. `build_scope_tree` never produces one; the constructor
-        // checks anyway instead of trusting that provenance.
-        let classifications: Arc<Vec<Option<LineClass>>> = Arc::new(vec![None; 5]);
-        let scopes = Arc::new(vec![duvet_coverage::types::Scope {
-            open_line: 0,
-            close_line: 5,
-            parent: None,
-            children: vec![],
-        }]);
-        assert!(FileExecution::new(classifications, scopes, &[], 5).is_none());
-    }
+    // (The `FileExecution::new` precondition-boundary tests moved to
+    // `duvet-coverage/src/file_execution.rs`, beside the constructor, where
+    // they carry Duvet `type=test` citations to the spec's Drift requirement —
+    // this file is excluded from annotation scanning as a fixture carrier;
+    // see `.duvet/config.toml` and issue #226.)
 
     // --- coverage_path_matches ---
     //

--- a/duvet/src/query/checks/coverage.rs
+++ b/duvet/src/query/checks/coverage.rs
@@ -23,6 +23,7 @@ use duvet_coverage::{
         LineProperty, Scope,
     },
 };
+use futures::{StreamExt as _, TryStreamExt as _};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
@@ -276,6 +277,14 @@ pub async fn build_execution_data(
         .map(|(idx, _)| *idx)
         .collect();
 
+    // Bound the in-flight `spawn_blocking` fan-out to the machine's
+    // parallelism. The work is pure CPU, so tasks beyond core count cannot
+    // run concurrently anyway — unbounded submission would only queue
+    // hundreds of CPU-bound tasks onto tokio's blocking pool (sized, and
+    // capped at 512 threads, for blocking *I/O*), oversubscribing cores and
+    // paying a thread stack per task on large corpora.
+    let concurrency = std::thread::available_parallelism().map_or(4, |n| n.get());
+
     let mut base_futures = Vec::with_capacity(matched_indices.len());
     for &idx in &matched_indices {
         let duvet_path = duvet_sources[idx].0.to_path_buf();
@@ -285,7 +294,11 @@ pub async fn build_execution_data(
             Result::<_, crate::Error>::Ok((idx, Arc::new(base)))
         });
     }
-    let bases: FxHashMap<usize, Arc<FileBase>> = futures::future::try_join_all(base_futures)
+    // Completion order is irrelevant here: results land in a map keyed by
+    // source index.
+    let bases: FxHashMap<usize, Arc<FileBase>> = futures::stream::iter(base_futures)
+        .buffer_unordered(concurrency)
+        .try_collect::<Vec<_>>()
         .await?
         .into_iter()
         .collect();
@@ -350,7 +363,13 @@ pub async fn build_execution_data(
         });
     }
 
-    let maps: Vec<ExecutionDataMap> = futures::future::try_join_all(map_futures).await?;
+    // `buffered`, not `buffer_unordered`: [`ExecutionData::maps`] promises
+    // one map per report *in input order*, and `buffered` yields results in
+    // stream order while still running up to `concurrency` tasks at once.
+    let maps: Vec<ExecutionDataMap> = futures::stream::iter(map_futures)
+        .buffered(concurrency)
+        .try_collect()
+        .await?;
 
     Ok(ExecutionData {
         maps,

--- a/duvet/src/query/checks/coverage.rs
+++ b/duvet/src/query/checks/coverage.rs
@@ -15,9 +15,7 @@ use crate::{
     Result,
 };
 use duvet_coverage::{
-    annotation_execution::is_annotation_executed_with_exec_set,
     degraded::degraded_execution_status,
-    execution_propagation::execution_set,
     scopes::{build_scope_tree, scope_imbalance_site},
     types::{
         AnnotationSpan, CoverageReport as CoverageReportMap, ExecutionStatus, LineClass,
@@ -37,39 +35,136 @@ pub enum CoverageFormat {
     // Future: Lcov, Clover
 }
 
-/// Coverage model data for a file with a tree-sitter classifier.
-/// Contains the classified line properties, scope tree, and coverage data
-/// in the format expected by the verified `duvet-coverage` algorithms.
-///
-/// The report-independent parts (`classifications`, `scopes`) are shared via
-/// `Arc` across every coverage report — they are a function of the source file
-/// and its annotations only. The per-report parts are the `coverage` map, the
-/// precomputed `exec_set`, and the `coverage_keys_in_bounds` witness.
-#[derive(Debug, Clone)]
-pub struct ClassifiedFileData {
-    pub classifications: Arc<Vec<Option<LineClass>>>,
-    pub scopes: Arc<Vec<Scope>>,
-    pub coverage: CoverageReportMap,
-    /// The verified execution set for exactly (`classifications`, `scopes`,
-    /// `coverage`), computed ONCE per (file, report) by
-    /// [`duvet_coverage::execution_propagation::execution_set`].
+/// Sealed home of [`ClassifiedFileData`]. The module boundary is what makes
+/// the exec-set pairing a compiler-enforced fact rather than a discipline:
+/// every field is private to this module, so the constructor below is the
+/// only code in the crate that can produce (or recombine) a value. Code
+/// outside this module — including the rest of this file — can only obtain a
+/// `ClassifiedFileData` whose `exec_set` and `coverage_keys_in_bounds` were
+/// computed from its own sibling fields.
+mod sealed {
+    use super::{coverage_keys_in_bounds, CoverageReportMap};
+    use duvet_coverage::{
+        annotation_execution::is_annotation_executed_with_exec_set,
+        execution_propagation::execution_set,
+        types::{AnnotationSpan, ExecutionStatus, LineClass, Scope},
+    };
+    use std::{collections::BTreeSet, sync::Arc};
+
+    /// Coverage model data for a file with a tree-sitter classifier.
+    /// Contains the classified line properties, scope tree, and coverage data
+    /// in the format expected by the verified `duvet-coverage` algorithms.
+    ///
+    /// The report-independent parts (`classifications`, `scopes`) are shared
+    /// via `Arc` across every coverage report — they are a function of the
+    /// source file and its annotations only. The per-report parts are the
+    /// `coverage` map, the precomputed `exec_set`, and the
+    /// `coverage_keys_in_bounds` witness.
     ///
     /// TRUSTED-BASE ASSUMPTION (unverified glue, same shape as the `scopes`
-    /// note in `build_file_base`): `is_annotation_executed_with_exec_set`
-    /// `requires` that this set be the execution set of the sibling fields, and
-    /// that holds *because* the sole producer
-    /// ([`file_execution_data_for_report`]) computes it from those very fields
-    /// with the verified function. Nothing at the type level enforces the
-    /// pairing; do not mutate these fields independently.
-    pub exec_set: BTreeSet<u64>,
-    /// Whether every coverage key maps to a valid classification index —
-    /// `is_annotation_executed_with_exec_set`'s runtime-checkable coverage
-    /// precondition, evaluated once per (file, report) instead of once per
-    /// annotation. When false, the file's annotations are reported `Unknown`
-    /// (the conservative status) without ever calling the verified model.
-    pub coverage_keys_in_bounds: bool,
-    pub file_length: u64,
+    /// note in `build_file_base`, but narrowed by sealing):
+    /// `is_annotation_executed_with_exec_set` `requires` that `exec_set` be
+    /// the execution set of the sibling fields. That pairing holds because
+    /// [`ClassifiedFileData::new`] — the only constructor, and the only code
+    /// with field access — computes `exec_set` and `coverage_keys_in_bounds`
+    /// from the very fields it stores, with the verified functions. The
+    /// residual assumption is only that values are not mutated after
+    /// construction: privacy plus the absence of `&mut` accessors and of
+    /// interior mutability enforces that. `Clone` is pairing-preserving (it
+    /// copies all fields together).
+    #[derive(Debug, Clone)]
+    pub struct ClassifiedFileData {
+        classifications: Arc<Vec<Option<LineClass>>>,
+        scopes: Arc<Vec<Scope>>,
+        coverage: CoverageReportMap,
+        /// The verified execution set for exactly (`classifications`,
+        /// `scopes`, `coverage`), computed ONCE per (file, report) by
+        /// [`duvet_coverage::execution_propagation::execution_set`].
+        exec_set: BTreeSet<u64>,
+        /// Whether every coverage key maps to a valid classification index —
+        /// `is_annotation_executed_with_exec_set`'s runtime-checkable coverage
+        /// precondition, evaluated once per (file, report) instead of once per
+        /// annotation. When false, the file's annotations are reported
+        /// `Unknown` (the conservative status) without ever calling the
+        /// verified model.
+        coverage_keys_in_bounds: bool,
+        file_length: u64,
+    }
+
+    impl ClassifiedFileData {
+        /// Sole producer. Checks `execution_set`'s (and the per-annotation
+        /// checker's) coverage precondition once per (file, report) — every
+        /// JaCoCo `<line nr=...>` key must map to a valid classification
+        /// index. Source/coverage drift or an `nr` past EOF violates it; then
+        /// no verified verdict is trustworthy for this file+report, so the
+        /// execution set is left empty and [`Self::annotation_status`] reports
+        /// `Unknown` without consulting it.
+        pub(super) fn new(
+            classifications: Arc<Vec<Option<LineClass>>>,
+            scopes: Arc<Vec<Scope>>,
+            coverage: CoverageReportMap,
+            file_length: u64,
+        ) -> Self {
+            let coverage_keys_in_bounds = coverage_keys_in_bounds(&coverage, classifications.len());
+            let exec_set = if coverage_keys_in_bounds {
+                execution_set(&classifications, &scopes, &coverage)
+            } else {
+                BTreeSet::new()
+            };
+            Self {
+                classifications,
+                scopes,
+                coverage,
+                exec_set,
+                coverage_keys_in_bounds,
+                file_length,
+            }
+        }
+
+        /// The verified verdict for one annotation span, with the verified
+        /// checker's `requires` enforced at this trust boundary. Verus checks
+        /// those clauses statically against the *proof*, but they compile away
+        /// in release builds, so nothing stops ill-formed runtime inputs from
+        /// reaching the verified algorithm and making its guarantees vacuous.
+        /// The inputs here are not proof-clean: `file_length`/
+        /// `classifications` come from the tree-sitter classifier while
+        /// `coverage` keys are JaCoCo `<line nr=...>` values from a
+        /// separately-produced XML. When a precondition fails we cannot
+        /// soundly trust the model's verdict, so fall back to `Unknown` (the
+        /// conservative status) instead of calling the verified fn on inputs
+        /// it never reasoned about.
+        ///
+        /// requires: annotation.end_line < u64::MAX  (checked here, per annotation)
+        /// requires: every coverage key K has (K - 1) < classifications.len()
+        ///           (annotation-independent — checked once per (file, report)
+        ///           by [`Self::new`]; see `coverage_keys_in_bounds`)
+        /// requires: exec_set == execution_set(classifications, scopes, coverage)
+        ///           (by construction — see the trust note on this type)
+        pub(super) fn annotation_status(&self, start_line: u64, end_line: u64) -> ExecutionStatus {
+            let precondition_holds = end_line < u64::MAX && self.coverage_keys_in_bounds;
+
+            if !precondition_holds {
+                ExecutionStatus::Unknown {
+                    line_number: start_line,
+                }
+            } else {
+                is_annotation_executed_with_exec_set(
+                    &AnnotationSpan {
+                        start_line,
+                        end_line,
+                    },
+                    &self.classifications,
+                    &self.scopes,
+                    &self.coverage,
+                    self.file_length,
+                    &self.exec_set,
+                )
+            }
+        }
+    }
 }
+
+pub use sealed::ClassifiedFileData;
 
 /// Coverage model data for a file with **no** tree-sitter classifier: the
 /// minimal universal classification (blank lines → `Whitespace`, everything else
@@ -231,18 +326,14 @@ pub async fn build_execution_data(
         let mut entries_for_source: FxHashMap<usize, Vec<&str>> = FxHashMap::default();
 
         for (coverage_path, file_coverage) in &generic.files {
-            let indices = match_memo
-                .entry(coverage_path.clone())
-                .or_insert_with(|| {
-                    duvet_sources
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, (_, absolute))| {
-                            coverage_path_matches(absolute, coverage_path)
-                        })
-                        .map(|(idx, _)| idx)
-                        .collect()
-                });
+            let indices = match_memo.entry(coverage_path.clone()).or_insert_with(|| {
+                duvet_sources
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, (_, absolute))| coverage_path_matches(absolute, coverage_path))
+                    .map(|(idx, _)| idx)
+                    .collect()
+            });
 
             // The mirror ambiguity: one report entry claimed by more than one
             // source file.
@@ -405,28 +496,16 @@ fn file_execution_data_for_report(
             file_length,
         } => {
             let coverage = file_coverage.to_coverage_report();
-            // `execution_set`'s (and the per-annotation checker's) coverage
-            // precondition, checked once per (file, report): every JaCoCo
-            // `<line nr=...>` key must map to a valid classification index.
-            // Source/coverage drift or an `nr` past EOF violates it; then no
-            // verified verdict is trustworthy for this file+report, so the
-            // execution set is left empty and `executed_status_for` reports
-            // `Unknown` without consulting it.
-            let coverage_keys_in_bounds =
-                coverage_keys_in_bounds(&coverage, classifications.len());
-            let exec_set = if coverage_keys_in_bounds {
-                execution_set(classifications, scopes, &coverage)
-            } else {
-                BTreeSet::new()
-            };
-            FileExecutionData::Classified(ClassifiedFileData {
-                classifications: classifications.clone(),
-                scopes: scopes.clone(),
+            // The coverage-keys precondition check and the verified
+            // `execution_set` computation both live inside the sealed
+            // constructor — the only code that can pair those values with the
+            // fields they were computed from.
+            FileExecutionData::Classified(ClassifiedFileData::new(
+                classifications.clone(),
+                scopes.clone(),
                 coverage,
-                exec_set,
-                coverage_keys_in_bounds,
-                file_length: *file_length,
-            })
+                *file_length,
+            ))
         }
         FileBase::Degraded {
             classifications,
@@ -469,9 +548,11 @@ async fn build_file_base(duvet_path: &Path, annotations: &AnnotationSet) -> Resu
 
     // Tree-sitter classification is pure CPU; run it off the (single-threaded)
     // async runtime so files classify in parallel.
-    tokio::task::spawn_blocking(move || build_file_base_sync(&duvet_path, &file_content, &annotations))
-        .await
-        .map_err(|e| duvet_core::error!("Task join error: {}", e))
+    tokio::task::spawn_blocking(move || {
+        build_file_base_sync(&duvet_path, &file_content, &annotations)
+    })
+    .await
+    .map_err(|e| duvet_core::error!("Task join error: {}", e))
 }
 
 fn build_file_base_sync(
@@ -713,48 +794,10 @@ pub fn executed_status_for(
     match execution_data_map.get(&file_path) {
         Some(FileExecutionData::Classified(data)) => {
             let (start_line, end_line) = annotation.line_range();
-            let ann_span = AnnotationSpan {
-                start_line,
-                end_line,
-            };
-
-            // Enforce the verified checker's `requires` at this trust
-            // boundary. Verus checks those clauses statically against the
-            // *proof*, but they compile away in release builds, so nothing stops
-            // ill-formed runtime inputs from reaching the verified algorithm and
-            // making its guarantees vacuous. The inputs here are not proof-clean:
-            // `file_length`/`classifications` come from the tree-sitter
-            // classifier while `coverage` keys are JaCoCo `<line nr=...>` values
-            // from a separately-produced XML, so source/coverage drift, a
-            // trailing newline, or `nr` past EOF can violate the preconditions.
-            // When that happens we cannot soundly trust the model's verdict, so
-            // fall back to `Unknown` (the conservative status) instead of calling
-            // the verified fn on inputs it never reasoned about.
-            //
-            // requires: annotation.end_line < u64::MAX  (checked here, per annotation)
-            // requires: every coverage key K has (K - 1) < classifications.len()
-            //           (annotation-independent — checked once per (file, report)
-            //           when the execution data was built; see
-            //           `ClassifiedFileData::coverage_keys_in_bounds`)
-            // requires: exec_set == execution_set(classifications, scopes, coverage)
-            //           (by construction — see the trust note on
-            //           `ClassifiedFileData::exec_set`)
-            let precondition_holds = end_line < u64::MAX && data.coverage_keys_in_bounds;
-
-            if !precondition_holds {
-                ExecutionStatus::Unknown {
-                    line_number: start_line,
-                }
-            } else {
-                is_annotation_executed_with_exec_set(
-                    &ann_span,
-                    &data.classifications,
-                    &data.scopes,
-                    &data.coverage,
-                    data.file_length,
-                    &data.exec_set,
-                )
-            }
+            // The verified checker's `requires` are enforced inside the sealed
+            // [`ClassifiedFileData::annotation_status`], next to the fields
+            // they constrain — see the trust note on that type.
+            data.annotation_status(start_line, end_line)
         }
         Some(FileExecutionData::Degraded(data)) => {
             let (start_line, end_line) = annotation.line_range();

--- a/duvet/src/query/coverage.rs
+++ b/duvet/src/query/coverage.rs
@@ -3,7 +3,7 @@
 
 use crate::Result;
 use rustc_hash::FxHashMap;
-use std::{collections::BTreeMap, path::Path};
+use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 /// Coverage data abstraction
 #[derive(Clone, Debug)]
@@ -20,9 +20,13 @@ impl CoverageData {
 }
 
 /// Generic (aggregate) coverage data
+///
+/// Per-file coverage is held behind `Arc` so consumers that need an owned
+/// handle (e.g. to move into `spawn_blocking`) get one with a refcount bump
+/// instead of a deep copy of the line/branch maps.
 #[derive(Clone, Debug)]
 pub struct GenericCoverageData {
-    pub files: FxHashMap<String, FileCoverage>,
+    pub files: FxHashMap<String, Arc<FileCoverage>>,
 }
 
 impl GenericCoverageData {

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -957,10 +957,10 @@ mod tests {
                 lines.insert(1u32, 1u64);
                 generic.files.insert(
                     name.to_string(),
-                    FileCoverage {
+                    Arc::new(FileCoverage {
                         lines,
                         branches: std::collections::BTreeMap::new(),
-                    },
+                    }),
                 );
             }
             CoverageData::Generic(generic)

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -761,17 +761,16 @@ fn fold_execution_status<'a>(
     let mut folded = ExecutionStatus::NotExecuted;
     for exec_data in execution_data_maps {
         let status = executed_status_for(annotation, exec_data);
-        match status {
-            // Executed wins outright — no later report can override it.
-            ExecutionStatus::Executed => return ExecutionStatus::Executed,
-            // Prefer Unknown over any previously-seen non-executed status.
-            ExecutionStatus::Unknown { .. } => folded = status,
-            // Structural / NotExecuted: only take it if we have nothing better.
-            _ => {
-                if matches!(folded, ExecutionStatus::NotExecuted) {
-                    folded = status;
-                }
-            }
+        // The decision step is verified (duvet-coverage): its `ensures` prove
+        // OR/absorption on `Executed`, that the fold never invents a status
+        // neither report produced, and the full Unknown > Structural >
+        // NotExecuted preference (`fold_step_spec`). This loop only supplies
+        // iteration.
+        folded = duvet_coverage::annotation_execution::fold_execution_status_step(folded, status);
+        if matches!(folded, ExecutionStatus::Executed) {
+            // Absorbing (per the step's ensures): no later report can
+            // override it, so skip scoring the remaining reports.
+            return folded;
         }
     }
     folded
@@ -1009,5 +1008,195 @@ mod tests {
         // file must carry exactly the same located issues as one report —
         // none duplicated (the old per-map re-scan doubled them), none lost.
         assert_eq!(execution_data.defeated, single.defeated);
+    }
+
+    /// End-to-end over the multi-report entry point with a REAL annotated
+    /// file — the path the escalation test (empty annotation set, empty maps)
+    /// deliberately does not exercise. One valid Java file carries an
+    /// annotation targeting a statement; two reports disagree about that
+    /// statement (Hit vs. Miss). Pins, in one pass through
+    /// `build_execution_data`:
+    ///
+    /// 1. the annotated-files filter — the annotation's file gets per-report
+    ///    execution data, and a covered file with no annotation gets none
+    ///    (though it still appears in the model-routing summary);
+    /// 2. report-order preservation — `maps[i]` corresponds to
+    ///    `coverage_data[i]` (load-bearing for witness semantics, and for the
+    ///    order-preserving `buffered` in the bounded fan-out);
+    /// 3. the per-report verified verdicts — Executed under the Hit report,
+    ///    NotExecuted under the Miss report, through `FileExecution`'s
+    ///    type-invariant-carried exec set;
+    /// 4. the OR-fold (design/query/design.md §5.2) — any one report proving
+    ///    execution decides the folded status, via the verified
+    ///    `fold_execution_status_step`.
+    #[tokio::test]
+    async fn multi_report_annotated_file_or_folds_across_reports() {
+        use crate::{
+            annotation::AnnotationLevel,
+            query::{
+                checks::coverage::build_execution_data,
+                coverage::{CoverageData, FileCoverage, GenericCoverageData},
+            },
+            source::SourceFile,
+        };
+        use duvet_core::file::SourceFile as CoreSourceFile;
+        use std::{collections::HashSet, io::Write};
+
+        let dir = std::env::temp_dir().join(format!(
+            "duvet_or_fold_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        struct DirGuard(std::path::PathBuf);
+        impl Drop for DirGuard {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        let _guard = DirGuard(dir.clone());
+        let write = |name: &str, contents: &str| {
+            let path = dir.join(name);
+            std::fs::File::create(&path)
+                .unwrap()
+                .write_all(contents.as_bytes())
+                .unwrap();
+            path
+        };
+
+        // The annotated file. Line 3 is a plain comment on disk; the
+        // authoritative annotation stamping comes from the parsed
+        // `AnnotationSet` below, so the fixture needs no `//=` literal (which
+        // this scanned file must not contain anyway — see `annotation()`).
+        // The annotation's target resolves forward from line 4: a statement.
+        let annotated = write(
+            "annotated.java",
+            "class T {\n    void run() {\n        // anno\n        work();\n    }\n}\n",
+        );
+        // Covered by both reports, carries no annotation: must be classified
+        // (for the summary) but get NO per-report execution data.
+        let plain = write("plain.java", "class U {\n}\n");
+
+        let mut project_sources: HashSet<SourceFile> = HashSet::new();
+        for path in [&annotated, &plain] {
+            project_sources.insert(SourceFile::Text {
+                pattern: crate::comment::Pattern::default(),
+                default_type: AnnotationType::Citation,
+                path: path.as_path().into(),
+                blob_link: None,
+            });
+        }
+
+        // The annotation: anno_line 3, single original_text line => spans
+        // (3, 3); target resolution walks to line 4 (`work();`). The virtual
+        // contents exist only to carve substr ranges; execution scoring reads
+        // the real file from disk and `line_range()` from `anno_line`.
+        let source = CoreSourceFile::new(
+            annotated.to_string_lossy().into_owned(),
+            "//= spec#s\ncode();\n",
+        )
+        .unwrap();
+        let ann = Arc::new(Annotation {
+            source: source.path().clone(),
+            anno_line: 3,
+            original_target: source.substr_range(4..10).unwrap(),
+            original_text: source.substr_range(0..10).unwrap(),
+            original_quote: source.substr_range(11..18).unwrap(),
+            anno: AnnotationType::Citation,
+            target: "spec#s".to_string(),
+            quote: String::new(),
+            comment: String::new(),
+            manifest_dir: source.path().clone(),
+            level: AnnotationLevel::Auto,
+            format: crate::specification::Format::Auto,
+            tracking_issue: String::new(),
+            feature: String::new(),
+            tags: Default::default(),
+            blob_link: None,
+        });
+        let annotations: AnnotationSet = Arc::new(std::collections::BTreeSet::from([ann.clone()]));
+
+        // Two reports over the same files, disagreeing on the target line:
+        // report 0 proves execution of line 4, report 1 saw it not run.
+        let report = |line4_count: u64| {
+            let mut generic = GenericCoverageData::new();
+            let mut lines = std::collections::BTreeMap::new();
+            lines.insert(4u32, line4_count);
+            generic.files.insert(
+                "annotated.java".to_string(),
+                Arc::new(FileCoverage {
+                    lines,
+                    branches: std::collections::BTreeMap::new(),
+                }),
+            );
+            let mut plain_lines = std::collections::BTreeMap::new();
+            plain_lines.insert(1u32, 1u64);
+            generic.files.insert(
+                "plain.java".to_string(),
+                Arc::new(FileCoverage {
+                    lines: plain_lines,
+                    branches: std::collections::BTreeMap::new(),
+                }),
+            );
+            CoverageData::Generic(generic)
+        };
+        let coverage_data = vec![report(1), report(0)];
+
+        let execution_data = build_execution_data(&annotations, &coverage_data, &project_sources)
+            .await
+            .expect("build must succeed");
+
+        // (2) One map per report, in input order.
+        assert_eq!(execution_data.maps.len(), 2);
+
+        // (1) The annotated-files filter: only the annotation's file gets
+        // execution data; the covered-but-unannotated file is summarized as
+        // classified yet carries no per-report entry.
+        for map in &execution_data.maps {
+            assert!(
+                map.contains_key(annotated.as_path()),
+                "annotated file must have execution data in every covering report"
+            );
+            assert!(
+                !map.contains_key(plain.as_path()),
+                "covered file with no annotation must not get execution data"
+            );
+        }
+        assert!(execution_data.classified_files.contains(&annotated));
+        assert!(
+            execution_data.classified_files.contains(&plain),
+            "the model-routing summary covers every matched file, annotated or not"
+        );
+        assert!(execution_data.degraded_files.is_empty());
+        assert!(execution_data.defeated.is_empty());
+
+        // (3) Per-report verified verdicts, in report order: Hit report says
+        // Executed, Miss report says NotExecuted.
+        assert_eq!(
+            executed_status_for(&ann, &execution_data.maps[0]),
+            ExecutionStatus::Executed,
+            "report 0 (Hit on the target line) must prove execution"
+        );
+        assert_eq!(
+            executed_status_for(&ann, &execution_data.maps[1]),
+            ExecutionStatus::NotExecuted,
+            "report 1 (Miss on the target line) must not"
+        );
+
+        // (4) The OR-fold: one proving report decides the folded status —
+        // in either order.
+        assert_eq!(
+            fold_execution_status(&ann, &execution_data.maps),
+            ExecutionStatus::Executed
+        );
+        let reversed: Vec<&ExecutionDataMap> = execution_data.maps.iter().rev().collect();
+        assert_eq!(
+            fold_execution_status(&ann, reversed),
+            ExecutionStatus::Executed,
+            "OR semantics cannot depend on report order"
+        );
     }
 }

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -905,11 +905,14 @@ mod tests {
     /// reaches it exactly once per file.
     #[tokio::test]
     async fn escalation_reports_each_located_issue() {
-        use crate::query::checks::coverage::build_execution_data;
-        use crate::query::coverage::{CoverageData, FileCoverage, GenericCoverageData};
-        use crate::source::SourceFile;
-        use std::collections::HashSet;
-        use std::io::Write;
+        use crate::{
+            query::{
+                checks::coverage::build_execution_data,
+                coverage::{CoverageData, FileCoverage, GenericCoverageData},
+            },
+            source::SourceFile,
+        };
+        use std::{collections::HashSet, io::Write};
 
         // Two Java files whose scope streams cannot be trusted: a bare
         // close-brace and a bare open-brace. Whether the classifier reports

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -927,6 +927,14 @@ mod tests {
                 .as_nanos()
         ));
         std::fs::create_dir_all(&dir).unwrap();
+        // Remove the temp dir even when an expect/assert below panics first.
+        struct DirGuard(std::path::PathBuf);
+        impl Drop for DirGuard {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        let _guard = DirGuard(dir.clone());
         let write = |name: &str, contents: &str| {
             let path = dir.join(name);
             std::fs::File::create(&path)

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -358,22 +358,19 @@ async fn execute_coverage_check(
         progress!("Running test execution correlation check...");
     }
 
-    // Build execution data for each coverage report in parallel.
-    // Each report produces an ExecutionDataMap (one entry per source file with coverage).
-    let build_futures: Vec<_> = coverage_data
-        .iter()
-        .map(|cover| {
-            build_execution_data(
-                &project_data.annotations,
-                cover,
-                &project_data.project_sources,
-            )
-        })
-        .collect();
-
-    let execution_data_maps: Vec<ExecutionDataMap> =
-        futures::future::try_join_all(build_futures).await?;
-    let report_count = execution_data_maps.len();
+    // Build execution data for ALL coverage reports in one pass. The
+    // report-independent work (path matching, tree-sitter classification,
+    // scope trees, annotation stamping) is done once per file and shared;
+    // only the per-report coverage maps and their verified execution sets are
+    // built per report (in parallel). Each report still produces its own
+    // ExecutionDataMap (one entry per annotated source file with coverage).
+    let execution_data = build_execution_data(
+        &project_data.annotations,
+        coverage_data,
+        &project_data.project_sources,
+    )
+    .await?;
+    let report_count = execution_data.maps.len();
 
     // Loud, non-verbose: files whose selected classifier could not produce a
     // trustworthy classification — a parse error, or an unbalanced scope stream
@@ -396,8 +393,7 @@ async fn execute_coverage_check(
     //# the collapsed scope tree; it MUST escalate, reporting each located issue.
     {
         use crate::query::classify::{ClassifierFailure, ClassifierIssue};
-        let defeated = collect_defeated_issues(&execution_data_maps);
-        for (path, issues) in &defeated {
+        for (path, issues) in &execution_data.defeated {
             let (parse, unbalanced): (Vec<&ClassifierIssue>, Vec<&ClassifierIssue>) = issues
                 .iter()
                 .partition(|i| matches!(i.reason, ClassifierFailure::ParseError));
@@ -428,35 +424,19 @@ async fn execute_coverage_check(
         // Tell the user which coverage path each covered file uses: the
         // language-aware two-phase model (classifier present) or the verified
         // degraded path (no classifier). Both are verified; the degraded path is
-        // lower-fidelity (forward-nearest governance). Aggregate across reports.
-        let mut classified_files: BTreeSet<&std::path::Path> = BTreeSet::new();
-        let mut degraded_files: BTreeSet<&std::path::Path> = BTreeSet::new();
-        for map in &execution_data_maps {
-            for (path, data) in map {
-                match data {
-                    crate::query::checks::coverage::FileExecutionData::Classified(_) => {
-                        classified_files.insert(path.as_path());
-                    }
-                    crate::query::checks::coverage::FileExecutionData::Degraded(_) => {
-                        degraded_files.insert(path.as_path());
-                    }
-                    crate::query::checks::coverage::FileExecutionData::DefeatedClassification {
-                        ..
-                    } => {
-                        // Reported unconditionally above (loud, not verbose-gated).
-                    }
-                }
-            }
-        }
+        // lower-fidelity (forward-nearest governance). Aggregated across reports
+        // (defeated files are reported unconditionally above, not verbose-gated).
         progress!(
             "Coverage model: {} file(s) language-aware (verified), {} file(s) degraded — no classifier (verified)",
-            classified_files.len(),
-            degraded_files.len()
+            execution_data.classified_files.len(),
+            execution_data.degraded_files.len()
         );
-        for path in &degraded_files {
+        for path in &execution_data.degraded_files {
             progress!("  degraded (no classifier, verified): {}", path.display());
         }
     }
+
+    let execution_data_maps: Vec<ExecutionDataMap> = execution_data.maps;
 
     let mut test_annotations: Vec<_> = Vec::new();
     let mut implementation_annotations: Vec<_> = Vec::new();
@@ -797,31 +777,6 @@ fn fold_execution_status<'a>(
     folded
 }
 
-/// Aggregate every located issue from files whose classification was defeated,
-/// across all reports — the escalation's input. Extracted so a unit test can
-/// pin that each located issue reaches the escalation surface (none dropped,
-/// none merged away); the loud per-file report in `execute_coverage_check`
-/// iterates exactly this.
-fn collect_defeated_issues(
-    execution_data_maps: &[ExecutionDataMap],
-) -> std::collections::BTreeMap<std::path::PathBuf, Vec<crate::query::classify::ClassifierIssue>> {
-    let mut defeated: std::collections::BTreeMap<
-        std::path::PathBuf,
-        Vec<crate::query::classify::ClassifierIssue>,
-    > = std::collections::BTreeMap::new();
-    for map in execution_data_maps {
-        for (path, data) in map {
-            if let crate::query::checks::coverage::FileExecutionData::DefeatedClassification {
-                issues,
-            } = data
-            {
-                defeated.entry(path.clone()).or_default().extend(issues);
-            }
-        }
-    }
-    defeated
-}
-
 fn deduplicate_annotation_coverage(
     coverage_list: Vec<AnnotationCoverage>,
 ) -> Vec<AnnotationCoverage> {
@@ -942,51 +897,106 @@ mod tests {
 
     /// Escalation carries every located issue: the aggregation feeding the
     /// loud per-file report (the escalation surface) preserves each located
-    /// issue from every defeated file across all reports — none dropped,
-    /// none merged away. The printing itself is presentation glue; what is
-    /// pinned here is that each located issue reaches it.
-    #[test]
-    fn escalation_reports_each_located_issue() {
-        let unbalanced = |line| ClassifierIssue {
-            reason: ClassifierFailure::UnbalancedScopes,
-            line,
+    /// issue from every defeated file — none dropped, and (now that the
+    /// aggregation is derived from the once-per-file classification bases
+    /// rather than by re-scanning every report's map) none duplicated when
+    /// many reports cover the same defeated file. The printing itself is
+    /// presentation glue; what is pinned here is that each located issue
+    /// reaches it exactly once per file.
+    #[tokio::test]
+    async fn escalation_reports_each_located_issue() {
+        use crate::query::checks::coverage::build_execution_data;
+        use crate::query::coverage::{CoverageData, FileCoverage, GenericCoverageData};
+        use crate::source::SourceFile;
+        use std::collections::HashSet;
+        use std::io::Write;
+
+        // Two Java files whose scope streams cannot be trusted: a bare
+        // close-brace and a bare open-brace. Whether the classifier reports
+        // them as parse errors or the verified balance check reports the
+        // imbalance witness, both must surface as defeated classifications.
+        let dir = std::env::temp_dir().join(format!(
+            "duvet_escalation_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let write = |name: &str, contents: &str| {
+            let path = dir.join(name);
+            std::fs::File::create(&path)
+                .unwrap()
+                .write_all(contents.as_bytes())
+                .unwrap();
+            path
         };
-        let parse = |line| ClassifierIssue {
-            reason: ClassifierFailure::ParseError,
-            line,
+        let broken_a = write("broken_a.java", "}\n");
+        let broken_b = write("broken_b.java", "class B {\n");
+
+        let mut project_sources: HashSet<SourceFile> = HashSet::new();
+        for path in [&broken_a, &broken_b] {
+            project_sources.insert(SourceFile::Text {
+                pattern: crate::comment::Pattern::default(),
+                default_type: AnnotationType::Citation,
+                path: path.as_path().into(),
+                blob_link: None,
+            });
+        }
+
+        // Two reports covering the same two files: the defeated aggregation
+        // must not duplicate issues per report.
+        let report = || {
+            let mut generic = GenericCoverageData::new();
+            for name in ["broken_a.java", "broken_b.java"] {
+                let mut lines = std::collections::BTreeMap::new();
+                lines.insert(1u32, 1u64);
+                generic.files.insert(
+                    name.to_string(),
+                    FileCoverage {
+                        lines,
+                        branches: std::collections::BTreeMap::new(),
+                    },
+                );
+            }
+            CoverageData::Generic(generic)
         };
-        let mut map_a = ExecutionDataMap::default();
-        map_a.insert(
-            std::path::PathBuf::from("a/broken.rs"),
-            FileExecutionData::DefeatedClassification {
-                issues: vec![unbalanced(7), parse(2)],
-            },
-        );
-        let mut map_b = ExecutionDataMap::default();
-        map_b.insert(
-            std::path::PathBuf::from("b/also_broken.rs"),
-            FileExecutionData::DefeatedClassification {
-                issues: vec![unbalanced(11)],
-            },
-        );
-        let defeated = collect_defeated_issues(&[map_a, map_b]);
+        let coverage_data = vec![report(), report()];
+
+        let annotations: AnnotationSet = Arc::new(std::collections::BTreeSet::new());
+        let execution_data = build_execution_data(&annotations, &coverage_data, &project_sources)
+            .await
+            .expect("defeated files must not error the build");
+        // Single-report baseline for the no-duplication assertion below
+        // (built before the temp files are removed).
+        let single_report = vec![report()];
+        let single = build_execution_data(&annotations, &single_report, &project_sources)
+            .await
+            .expect("single-report build");
+
+        let _ = std::fs::remove_dir_all(&dir);
+
         //= design/query/coverage-model-spec.md#trust-taxonomy
         //= type=test
         //# it MUST escalate, reporting each located issue.
-        assert_eq!(defeated.len(), 2);
         assert_eq!(
-            defeated[std::path::Path::new("a/broken.rs")]
-                .iter()
-                .map(|i| i.line)
-                .collect::<Vec<_>>(),
-            [7, 2]
+            execution_data.defeated.len(),
+            2,
+            "both defeated files must reach the escalation surface: {:?}",
+            execution_data.defeated
         );
-        assert_eq!(
-            defeated[std::path::Path::new("b/also_broken.rs")]
-                .iter()
-                .map(|i| i.line)
-                .collect::<Vec<_>>(),
-            [11]
-        );
+        for (path, issues) in &execution_data.defeated {
+            assert!(
+                !issues.is_empty(),
+                "every defeated file carries at least one located issue: {}",
+                path.display()
+            );
+        }
+
+        // Aggregated once per file: two reports covering the same defeated
+        // file must carry exactly the same located issues as one report —
+        // none duplicated (the old per-map re-scan doubled them), none lost.
+        assert_eq!(execution_data.defeated, single.defeated);
     }
 }

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -391,6 +391,15 @@ async fn execute_coverage_check(
     //= type=implementation
     //# duvet MUST NOT silently substitute the coarse model or score against
     //# the collapsed scope tree; it MUST escalate, reporting each located issue.
+    //
+    // Once-per-file is carried by the shape of the data: `defeated` is a map
+    // keyed by file, derived from the once-per-file classification bases
+    // (never by re-scanning the per-report maps), and this loop is its only
+    // reporting surface.
+    //= design/query/coverage-model-spec.md#escalation
+    //= type=implementation
+    //# Each located issue MUST be reported exactly once per file, regardless of how
+    //# many coverage reports cover the file.
     {
         use crate::query::classify::{ClassifierFailure, ClassifierIssue};
         for (path, issues) in &execution_data.defeated {
@@ -1007,6 +1016,10 @@ mod tests {
         // Aggregated once per file: two reports covering the same defeated
         // file must carry exactly the same located issues as one report —
         // none duplicated (the old per-map re-scan doubled them), none lost.
+        //= design/query/coverage-model-spec.md#escalation
+        //= type=test
+        //# Each located issue MUST be reported exactly once per file, regardless of how
+        //# many coverage reports cover the file.
         assert_eq!(execution_data.defeated, single.defeated);
     }
 

--- a/duvet/src/query/parsers/jacoco.rs
+++ b/duvet/src/query/parsers/jacoco.rs
@@ -10,6 +10,7 @@ use std::{
     collections::BTreeMap,
     io::{BufRead, Cursor},
     path::Path,
+    sync::Arc,
 };
 
 use super::super::coverage::{
@@ -58,7 +59,9 @@ pub fn parse_jacoco_xml_report<T: BufRead>(
 
                 // Merge package results into coverage data
                 for (file_path, file_coverage) in package_results {
-                    coverage_data.files.insert(file_path, file_coverage);
+                    coverage_data
+                        .files
+                        .insert(file_path, Arc::new(file_coverage));
                 }
             }
             Ok(Event::Eof) => break,

--- a/duvet/src/query/parsers/jacoco.rs
+++ b/duvet/src/query/parsers/jacoco.rs
@@ -83,30 +83,28 @@ fn parse_jacoco_report_package<T: BufRead>(
 
     loop {
         match parser.read_event_into(buf) {
-            Ok(Event::Start(ref e)) => {
-                // Per-line coverage lives only in <sourcefile>; <class>/<method>
-                // carry no line data, so we skip everything else here (the loop's
-                // outer `_ => {}` steps over their events until </package>). If
-                // JaCoCo method boundaries are ever needed, reintroduce exactly
-                // the parsing that consumer requires.
-                if e.local_name().into_inner() == b"sourcefile" {
-                    let file = get_xml_attribute(parser, e, "name")?;
-                    let source_file_data = parse_jacoco_report_sourcefile(parser, buf)?;
+            // Per-line coverage lives only in <sourcefile>; <class>/<method>
+            // carry no line data, so we skip everything else here (the loop's
+            // outer `_ => {}` steps over their events until </package>). If
+            // JaCoCo method boundaries are ever needed, reintroduce exactly
+            // the parsing that consumer requires.
+            Ok(Event::Start(ref e)) if e.local_name().into_inner() == b"sourcefile" => {
+                let file = get_xml_attribute(parser, e, "name")?;
+                let source_file_data = parse_jacoco_report_sourcefile(parser, buf)?;
 
-                    match results_map.get_mut(&file) {
-                        Some(file_coverage) => {
-                            file_coverage.lines = source_file_data.lines;
-                            file_coverage.branches = source_file_data.branches;
-                        }
-                        None => {
-                            results_map.insert(
-                                file.clone(),
-                                FileCoverage {
-                                    lines: source_file_data.lines,
-                                    branches: source_file_data.branches,
-                                },
-                            );
-                        }
+                match results_map.get_mut(&file) {
+                    Some(file_coverage) => {
+                        file_coverage.lines = source_file_data.lines;
+                        file_coverage.branches = source_file_data.branches;
+                    }
+                    None => {
+                        results_map.insert(
+                            file.clone(),
+                            FileCoverage {
+                                lines: source_file_data.lines,
+                                branches: source_file_data.branches,
+                            },
+                        );
                     }
                 }
             }


### PR DESCRIPTION
A JaCoCo-style corpus often carries one XML report per test method: hundreds of reports describing the same handful of source files. The coverage check built its execution data once per report, so every piece of report-independent work — path absolutization and suffix matching, tree-sitter classification, scope-tree construction, and annotation stamping — was repeated for every (file, report) pair instead of once per file. Profiling a large corpus showed tree-sitter parsing dominating the multi-minute runtime. Separately, the verified `is_annotation_executed` recomputed the whole-file `execution_set` fixpoint on every call, i.e. per (annotation, report), even though the set depends only on the file-level inputs.

*Description of changes:*

In duvet-coverage (the verified crate):

- Make `execution_set` public so a caller can compute it once per (file, report) and share it across every annotation in the file.
- Split `is_annotation_executed` into a verified wrapper plus `is_annotation_executed_with_exec_set`, whose exec-set `requires` are, verbatim, `execution_set`'s `ensures` — piping one into the other preserves the verified contract by construction. All existing `ensures` (spec-twin equivalence, Property 6a/6b) are unchanged, and the crate still verifies with zero errors.

In duvet (the unverified glue):

- `build_execution_data` now takes ALL coverage reports at once: per-file classification bases (classify + scope tree + stamping) are built once and shared via Arc; report-path matching is memoized per distinct path (per-report ambiguity checks preserved); only the genuinely per-report work — the coverage map, its bounds check, and its verified execution set — is done per (file, report), in parallel on the blocking pool (duvet's runtime is single-threaded).
- Build execution data only for files that carry annotations; `executed_status_for` is only ever asked about an annotation's own source file, so data for annotation-free files was never read.
- Check the coverage-key precondition once per (file, report) instead of once per annotation; `executed_status_for` consults the cached witness and the precomputed execution set.
- Derive the defeated-classification and verbose model-routing summaries from the once-per-file bases instead of re-scanning every report's map — which also fixes the escalation message duplicating each defeated file's issue list once per covering report.

The check now does strictly less work — the report-independent steps run once per file instead of once per (file, report), and the execution-set fixpoint once per (file, report) instead of once per (annotation, report) — with byte-identical output — except the escalation message, whose per-report duplication of each defeated file's issue list is a bug this restructuring fixes (each issue is now listed once per file; see the changelog's Bug Fixes entry). All unit and integration tests pass; the escalation unit test was rewritten end-to-end against the new aggregation and now also pins the no-duplication property.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


