### PR TITLE
feat(cli): add --version / -V flag

### DIFF
--- a/duvet/build.rs
+++ b/duvet/build.rs
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Stamp a git commit + dirty suffix into `DUVET_VERSION_SUFFIX` so
+// `duvet --version` can distinguish a released build from a local one.
+// When git isn't available (e.g. crate built from the crates.io tarball),
+// the suffix is empty and --version prints just the semver.
+
+use std::process::Command;
+
+fn main() {
+    // Re-run when HEAD moves or the index changes.
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/index");
+
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+
+    let suffix = match hash {
+        Some(h) => {
+            let dirty = Command::new("git")
+                .args(["status", "--porcelain"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| !o.stdout.is_empty())
+                .unwrap_or(false);
+            let tag = if dirty { "-dirty" } else { "" };
+            format!(" ({h}{tag})")
+        }
+        None => String::new(),
+    };
+
+    println!("cargo:rustc-env=DUVET_VERSION_SUFFIX={suffix}");
+}

--- a/duvet/src/lib.rs
+++ b/duvet/src/lib.rs
@@ -24,6 +24,7 @@ pub use duvet_core::{diagnostic::Error, Result};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Parser)]
+#[command(version = concat!(env!("CARGO_PKG_VERSION"), env!("DUVET_VERSION_SUFFIX")))]
 pub enum Arguments {
     /// Initializes a duvet project
     Init(init::Init),


### PR DESCRIPTION
resolves: https://github.com/awslabs/duvet/issues/250

## Summary
Adds a `--version` / `-V` flag to the top-level `duvet` CLI. Distinguishes released builds from source-checkout builds, with a `-dirty` marker on uncommitted trees.

## Output matrix

| Build source | Output |
|---|---|
| `cargo install duvet` (crates.io tarball, no .git) | `duvet 0.4.3` |
| Source checkout, clean tree | `duvet 0.4.3 (abc123f)` |
| Source checkout, uncommitted edits | `duvet 0.4.3 (abc123f-dirty)` |

Follows the ripgrep/bat/fd convention for released binaries (no parenthetical when git isn't available), while giving source-build users a signal.

## Changes
- `duvet/build.rs` (new) — stamps a git suffix into the `DUVET_VERSION_SUFFIX` env var at compile time. Empty string when git isn't available.
- `duvet/src/lib.rs` — one-line clap attribute: `#[command(version = concat!(env!("CARGO_PKG_VERSION"), env!("DUVET_VERSION_SUFFIX")))]` on the `Arguments` enum.

## Motivation
While investigating why the aws-lc `third_party/vectors/` Duvet setup produced a blank HTML report, there was no way to tell which duvet build was on the machine. `duvet` with no args prints usage but not a version; `duvet --version` errored. This makes the "which duvet am I running?" question a one-command answer.

## Test
- [ ] CI: full `cargo xtask test` (integration snapshots do not include `--version` output)