### PR TITLE
PR 256 follow-ups: 

### DIFF
--- a/.duvet/config.toml
+++ b/.duvet/config.toml
@@ -11,6 +11,30 @@
 [[source]]
 pattern = "duvet-coverage/**/*.rs"
 
+# The CI verify step is the artifact that enforces "These properties MUST be
+# proven with Verus" — the annotation lives on the step, not on a file header
+# (position must discriminate; design/duplicates/spec.md §3). The #=/#% style
+# keeps ordinary yaml comments from ever being ingested as quote lines.
+[[source]]
+pattern = ".github/workflows/ci.yml"
+comment-style = { meta = "#=", content = "#%" }
+
+# Duplicates policy (design/duplicates/spec.md §4). Every value here was
+# settled by running the check on this tree and challenging each collision:
+#
+# - implementation = 2: each proven property carries exactly two
+#   machine-checked artifacts — the core lemma and the composed end-to-end
+#   lemma over the public API. Two evidence artifacts structurally force two
+#   annotations; three would be spray.
+# - targets.count = 1: every fan-in site on this tree dissolved under more
+#   targeted placement (D1/D2 onto their enforcing lines, the Verus-proving
+#   claim onto the CI step that runs the prover). One target, one annotation.
+[duplicates.claims]
+implementation = 2
+
+[duplicates.targets]
+count = 1
+
 [[specification]]
 source = "design/query/coverage-model-spec.md"
 

--- a/.duvet/config.toml
+++ b/.duvet/config.toml
@@ -1,15 +1,48 @@
 '$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
 
 # Only `duvet-coverage` carries real requirement annotations (the coverage
-# model proofs). `duvet/**` is intentionally NOT scanned for now: duvet's
+# model proofs). `duvet/**` is intentionally NOT scanned wholesale: duvet's
 # annotation parser also reads string literals, so example annotations in
 # duvet's own test fixtures and help strings (e.g. `//= spec.md#...`,
 # `//= https://.../rfc2324...`) would be picked up as real citations. Once
 # that parser issue is fixed, `duvet/**` can be scanned safely.
 # See https://github.com/awslabs/duvet/issues/226
+#
+# The three files below are scanned as explicit exceptions: each was
+# inspected for string literals whose lines begin with the `//=` meta
+# prefix (the tokenizer matches only at trimmed line start —
+# duvet/src/comment/tokenizer.rs) and carries none. Re-inspect before
+# widening any of these patterns.
 
 [[source]]
 pattern = "duvet-coverage/**/*.rs"
+
+[[source]]
+pattern = "duvet/src/query/checks/duplicates.rs"
+
+[[source]]
+pattern = "duvet/src/config.rs"
+
+[[source]]
+pattern = "duvet/src/config/schema/v0_4_0.rs"
+
+[[source]]
+pattern = "duvet/src/query/result.rs"
+
+# The duplicates fixtures carry `#=`-style test citations against
+# design/duplicates/spec.md: each fixture is the test artifact that pins the
+# rule it cites. The `#=`/`#%` style means the Rust-style `//=` annotation
+# text embedded in fixture `contents` strings is never ingested.
+[[source]]
+pattern = "integration/*.toml"
+comment-style = { meta = "#=", content = "#%" }
+
+# This config file is scanned so deferrals can be recorded as reviewed
+# `exception` annotations right where the policy lives (see the end of
+# this file).
+[[source]]
+pattern = ".duvet/config.toml"
+comment-style = { meta = "#=", content = "#%" }
 
 # The CI verify step is the artifact that enforces "These properties MUST be
 # proven with Verus" — the annotation lives on the step, not on a file header
@@ -38,6 +71,9 @@ count = 1
 [[specification]]
 source = "design/query/coverage-model-spec.md"
 
+[[specification]]
+source = "design/duplicates/spec.md"
+
 [report.html]
 enabled = true
 issue-link = "https://github.com/awslabs/duvet/issues"
@@ -48,3 +84,30 @@ enabled = true
 
 [report.snapshot]
 enabled = true
+
+# ---------------------------------------------------------------------------
+# DEFERRALS — reviewed waivers for spec MUSTs with no honest artifact on this
+# branch. Each is an `exception` annotation: visible in the report, gone the
+# day the artifact lands. Do not add implications here — an implication
+# claims the requirement holds by construction, which is exactly the
+# type-shopping §2.4 polices.
+#
+# 1. spec §5's fixture-pinning meta-MUST: the fixture suite exists and CI
+#    runs it, but nothing on this branch audits that EVERY property is
+#    pinned. Deferred until a property-to-fixture traceability check exists.
+#
+#= design/duplicates/spec.md#properties
+#= type=exception
+#% Each property MUST be pinned by an integration fixture, except
+#% where noted.
+
+# 2. spec §4.5 scoped overrides: designed and deferred (Decision 13). The
+#    feature does not exist in this version, so its conditional MUSTs have
+#    no implementation to cite. The exception dissolves when scoped
+#    overrides ship.
+#
+#= design/duplicates/spec.md#scoped-overrides
+#= type=exception
+#% If scoped overrides ship,
+#% they MUST satisfy resolution determinism, unconfigured
+#% equivalence, and shadowing monotonicity as stated there.

--- a/.duvet/requirements/design/duplicates/spec/annotation-model.toml
+++ b/.duvet/requirements/design/duplicates/spec/annotation-model.toml
@@ -1,0 +1,37 @@
+target = "design/duplicates/spec.md#annotation-model"
+
+# 1.1 Annotation model
+#
+# An annotation is a triple **(τ, q, t)**:
+# 
+# - **τ** — the claim form: one of `test`, `implementation`,
+#   `implication`, `exception`, `todo`, `spec`.
+# - **q** — the claim ([§1.2](#claims)).
+# - **t** — the resolved target ([§1.4](#targets)).
+# 
+# Naming ([Decision 10](decisions.md#decision-10)):
+# `implementation` is the canonical user-facing name of the claim
+# form the codebase calls `Citation`. Every user-facing surface this
+# specification defines — configuration keys, report sections,
+# failure messages — MUST emit the name `implementation` and MUST
+# NOT emit the name `citation`. Wherever a claim form is read as
+# input, `citation` MUST be accepted as an alias for
+# `implementation`.
+
+[[spec]]
+level = "MUST"
+quote = '''
+Every user-facing surface this
+specification defines — configuration keys, report sections,
+failure messages — MUST emit the name `implementation` and MUST
+NOT emit the name `citation`.
+'''
+
+[[spec]]
+level = "MUST"
+quote = '''
+Wherever a claim form is read as
+input, `citation` MUST be accepted as an alias for
+`implementation`.
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/caps.toml
+++ b/.duvet/requirements/design/duplicates/spec/caps.toml
@@ -1,0 +1,53 @@
+target = "design/duplicates/spec.md#caps"
+
+# 2.2 Multiplicity caps
+#
+# Each claim form has a **cap**: a positive integer, default 1
+# ([§4.3](#defaults)).
+# 
+# A duplicate set whose size exceeds its form's cap MUST fail the
+# duplicates check.
+# ([Decision 1](decisions.md#decision-1))
+# 
+# Caps MUST be configurable only for the priced forms. The caps of
+# `spec`, `todo`, `exception`, and `implication` are fixed at 1 and
+# MUST NOT be configurable.
+# ([Decision 3](decisions.md#decision-3);
+# [P-D2](#property-p-d2))
+# 
+# A duplicate set within its cap MUST pass this check
+# ([Decision 5](decisions.md#decision-5)), and when its size exceeds
+# one it MUST be reported with its size and every member's location,
+# so multiplicity is always surfaced, never silent.
+# ([Decision 1](decisions.md#decision-1))
+
+[[spec]]
+level = "MUST"
+quote = '''
+A duplicate set whose size exceeds its form's cap MUST fail the
+duplicates check.
+'''
+
+[[spec]]
+level = "MUST"
+quote = '''
+Caps MUST be configurable only for the priced forms.
+'''
+
+[[spec]]
+level = "MUST"
+quote = '''
+The caps of
+`spec`, `todo`, `exception`, and `implication` are fixed at 1 and
+MUST NOT be configurable.
+'''
+
+[[spec]]
+level = "MUST"
+quote = '''
+A duplicate set within its cap MUST pass this check
+([Decision 5](decisions.md#decision-5)), and when its size exceeds
+one it MUST be reported with its size and every member's location,
+so multiplicity is always surfaced, never silent.
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/duplicates-verdict.toml
+++ b/.duvet/requirements/design/duplicates/spec/duplicates-verdict.toml
@@ -1,0 +1,27 @@
+target = "design/duplicates/spec.md#duplicates-verdict"
+
+# 2.6 Verdict
+#
+# The duplicates check MUST fail if and only if at least one rule of
+# [§2.1](#same-claim-same-target)–[§2.4](#exclusivity) or of the
+# target axis ([§3.2](#fan-in-bounds)–[§3.3](#type-combinations))
+# fires.
+# 
+# Run alone, a passing verdict claims structure only. Evidence
+# billing of every copy is the coverage check's contract, enforced
+# whether or not this check runs ([Decision 5](decisions.md#decision-5)).
+# The `executed-coverage` mode carries no duplicate guarantees; it
+# is deliberately partial for everything, and duplicates inherit
+# that partiality ([Decision 7](decisions.md#decision-7)).
+# 
+# ---
+
+[[spec]]
+level = "MUST"
+quote = '''
+The duplicates check MUST fail if and only if at least one rule of
+[§2.1](#same-claim-same-target)–[§2.4](#exclusivity) or of the
+target axis ([§3.2](#fan-in-bounds)–[§3.3](#type-combinations))
+fires.
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/exclusivity.toml
+++ b/.duvet/requirements/design/duplicates/spec/exclusivity.toml
@@ -1,0 +1,54 @@
+target = "design/duplicates/spec.md#exclusivity"
+
+# 2.4 Claim-form family
+#
+# A claim class whose non-`spec` members bear two or more distinct
+# claim forms MUST fail the duplicates check unless the set of
+# non-`spec` claim forms is admitted by the configured claim-form
+# family ([§4.2](#schema-claims)). A claim class whose non-`spec`
+# members bear a single claim form MUST NOT fail this rule: copies
+# of one form are the caps' business ([§2.2](#caps)).
+# ([Decision 4](decisions.md#decision-4);
+# [P-D5](#property-p-d5))
+# 
+# The default claim-form family admits exactly the form sets
+# containing no free form ([§4.3](#defaults)) — any combination of
+# `test` and `implementation` members may share a claim, each billed
+# on its own; a free form never shares a claim with another form.
+# An empty family (`types = []`) admits no multi-form set: it
+# forbids all multi-form claim sharing, `test` + `implementation`
+# included. Derived verdicts under the default family, for the
+# record:
+# 
+# | Coexistence (same claim) | Verdict |
+# |---|---|
+# | `exception` + `test` | fail — contradiction |
+# | `exception` + `implementation` | fail — contradiction |
+# | `implication` + `implementation` | fail — silent unbilling |
+# | `implication` + `test` | fail — incompatible claims about R's nature |
+# | `todo` + `implementation` | fail — the todo is replaced, not joined |
+# | `test` + `implementation` (different targets) | pass — the system itself |
+# 
+# This rule is a deliberate tightening of released behavior
+# ([Decision 14](decisions.md#decision-14)): cross-form coexistence
+# on one requirement silently passes the historical check. The
+# restoration path is a configuration line ([§4.2](#schema-claims)),
+# never a comment.
+
+[[spec]]
+level = "MUST"
+quote = '''
+A claim class whose non-`spec` members bear two or more distinct
+claim forms MUST fail the duplicates check unless the set of
+non-`spec` claim forms is admitted by the configured claim-form
+family ([§4.2](#schema-claims)).
+'''
+
+[[spec]]
+level = "MUST"
+quote = '''
+A claim class whose non-`spec`
+members bear a single claim form MUST NOT fail this rule: copies
+of one form are the caps' business ([§2.2](#caps)).
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/fan-in-bounds.toml
+++ b/.duvet/requirements/design/duplicates/spec/fan-in-bounds.toml
@@ -1,0 +1,26 @@
+target = "design/duplicates/spec.md#fan-in-bounds"
+
+# 3.2 Fan-in bounds
+#
+# Two opt-in bounds, both unlimited by default
+# ([§4.3](#defaults)):
+# 
+# - `count` — the maximum number of annotations in one target class.
+# - `sections` — the maximum number of distinct sections claimed by
+#   one target class.
+# 
+# When a bound is configured, a target class exceeding it MUST fail
+# the duplicates check. When a bound is not configured, no target
+# class fails it.
+# 
+# These are the only rules in this specification that fail code for
+# a smell rather than a violated evidence property; teams opt into
+# the opinion.
+
+[[spec]]
+level = "MUST"
+quote = '''
+When a bound is configured, a target class exceeding it MUST fail
+the duplicates check.
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/fan-in-listing.toml
+++ b/.duvet/requirements/design/duplicates/spec/fan-in-listing.toml
@@ -1,0 +1,33 @@
+target = "design/duplicates/spec.md#fan-in-listing"
+
+# 3.1 Listing
+#
+# The duplicates check's report MUST include the fan-in listing: it
+# MUST contain a target if and only if two or more annotations
+# resolve to it.
+# ([P-T1](#property-p-t1))
+# 
+# Each listed target MUST report its exact annotation count, its
+# per-form breakdown, and its distinct-section count, and the
+# listing MUST be sorted by annotation count descending.
+# 
+# The distinct-section count is a triage column, not a
+# discriminator: `count=12 sections=1` reads "dense but coherent";
+# `count=12 sections=8` reads "look here first."
+
+[[spec]]
+level = "MUST"
+quote = '''
+The duplicates check's report MUST include the fan-in listing: it
+MUST contain a target if and only if two or more annotations
+resolve to it.
+'''
+
+[[spec]]
+level = "MUST"
+quote = '''
+Each listed target MUST report its exact annotation count, its
+per-form breakdown, and its distinct-section count, and the
+listing MUST be sorted by annotation count descending.
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/partial-overlap.toml
+++ b/.duvet/requirements/design/duplicates/spec/partial-overlap.toml
@@ -1,0 +1,37 @@
+target = "design/duplicates/spec.md#partial-overlap"
+
+# 2.5 Partial overlap
+#
+# Annotations whose quotes overlap without full coverage in either
+# direction (the `some_overlap` population) are outside this
+# specification's model. Three layers, separately stated:
+# 
+# Verdict: a partial overlap MUST NOT fail the duplicates check,
+# matching the historical check.
+# 
+# Content: the check MUST identify every partial-overlap pair in
+# its analysis.
+# 
+# Presentation, non-normative note: display of the analysis
+# population is verbosity-tiered — the default report omits it,
+# `--verbose` shows it; verbosity never changes the verdict
+# ([§4.1](#policy-source)). This is deliberately weaker than
+# [§2.2](#caps)'s unconditional surfacing: an admitted duplicate is
+# a standing liability kept in view at every verbosity
+# ([Decision 1](decisions.md#decision-1)); a partial overlap is a
+# model-boundary disclosure, not a liability the check prices.
+
+[[spec]]
+level = "MUST"
+quote = '''
+Verdict: a partial overlap MUST NOT fail the duplicates check,
+matching the historical check.
+'''
+
+[[spec]]
+level = "MUST"
+quote = '''
+Content: the check MUST identify every partial-overlap pair in
+its analysis.
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/policy-source.toml
+++ b/.duvet/requirements/design/duplicates/spec/policy-source.toml
@@ -1,0 +1,29 @@
+target = "design/duplicates/spec.md#policy-source"
+
+# 4.1 Policy source
+#
+# Every policy value in this specification MUST be read from
+# checked-in configuration. The shipped defaults
+# ([§4.3](#defaults)) apply where configuration is silent.
+# 
+# Command-line options MUST NOT change any verdict: the command line
+# selects which checks run, points at evidence artifacts, and
+# controls verbosity — display, never verdict.
+# ([Decision 9](decisions.md#decision-9);
+# [P-S0](#property-p-s0))
+
+[[spec]]
+level = "MUST"
+quote = '''
+Every policy value in this specification MUST be read from
+checked-in configuration.
+'''
+
+[[spec]]
+level = "MUST"
+quote = '''
+Command-line options MUST NOT change any verdict: the command line
+selects which checks run, points at evidence artifacts, and
+controls verbosity — display, never verdict.
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/properties.toml
+++ b/.duvet/requirements/design/duplicates/spec/properties.toml
@@ -1,0 +1,14 @@
+target = "design/duplicates/spec.md#properties"
+
+# 5. Properties
+#
+# Each property MUST be pinned by an integration fixture, except
+# where noted.
+
+[[spec]]
+level = "MUST"
+quote = '''
+Each property MUST be pinned by an integration fixture, except
+where noted.
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/same-claim-same-target.toml
+++ b/.duvet/requirements/design/duplicates/spec/same-claim-same-target.toml
@@ -1,0 +1,23 @@
+target = "design/duplicates/spec.md#same-claim-same-target"
+
+# 2.1 Same claim, same target
+#
+# Two annotations that share a claim and share a resolved target
+# MUST fail the duplicates check, regardless of their claim forms
+# and regardless of any configured cap.
+# ([Decision 2](decisions.md#decision-2);
+# [P-D1](#property-p-d1))
+# 
+# Same location is defined as same *resolved target*, never same
+# source line: stacked copies above one statement collapse to one
+# target and fail here; copies that resolve to different targets are
+# governed by the cap ([§2.2](#caps)).
+
+[[spec]]
+level = "MUST"
+quote = '''
+Two annotations that share a claim and share a resolved target
+MUST fail the duplicates check, regardless of their claim forms
+and regardless of any configured cap.
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/schema-shared.toml
+++ b/.duvet/requirements/design/duplicates/spec/schema-shared.toml
@@ -1,0 +1,55 @@
+target = "design/duplicates/spec.md#schema-shared"
+
+# 4.2.3 Shared rules
+#
+# Form names in configuration use the canonical vocabulary
+# ([§1.1](#annotation-model)); `citation` MUST be accepted as an
+# alias for `implementation` and MUST NOT appear in any emitted
+# output.
+# 
+# An unrecognized key under `[duplicates.claims]` or
+# `[duplicates.targets]` MUST be a configuration error, so a typo
+# never silently takes a default.
+# 
+# Configuring a cap for a form other than `test` or
+# `implementation` MUST be a configuration error
+# ([§2.2](#caps)).
+# 
+# Example:
+# 
+# ```toml
+# [duplicates.claims]
+# test = 2                        # proof + PBT: two evidence artifacts
+# # implementation defaults to 1
+# # types defaults to the free-form-exclusive family (§4.3)
+# 
+# [duplicates.targets]
+# count = 15                      # opt-in fan-in bound
+# types = ["exception+test"]      # allow this combination on one target
+# ```
+
+[[spec]]
+level = "MUST"
+quote = '''
+Form names in configuration use the canonical vocabulary
+([§1.1](#annotation-model)); `citation` MUST be accepted as an
+alias for `implementation` and MUST NOT appear in any emitted
+output.
+'''
+
+[[spec]]
+level = "MUST"
+quote = '''
+An unrecognized key under `[duplicates.claims]` or
+`[duplicates.targets]` MUST be a configuration error, so a typo
+never silently takes a default.
+'''
+
+[[spec]]
+level = "MUST"
+quote = '''
+Configuring a cap for a form other than `test` or
+`implementation` MUST be a configuration error
+([§2.2](#caps)).
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/scoped-overrides.toml
+++ b/.duvet/requirements/design/duplicates/spec/scoped-overrides.toml
@@ -1,0 +1,19 @@
+target = "design/duplicates/spec.md#scoped-overrides"
+
+# 4.5 Scoped overrides
+#
+# Designed and deferred ([Decision 13](decisions.md#decision-13)).
+# All values in this version are global. If scoped overrides ship,
+# they MUST satisfy resolution determinism, unconfigured
+# equivalence, and shadowing monotonicity as stated there.
+# 
+# ---
+
+[[spec]]
+level = "MUST"
+quote = '''
+If scoped overrides ship,
+they MUST satisfy resolution determinism, unconfigured
+equivalence, and shadowing monotonicity as stated there.
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/subsumption.toml
+++ b/.duvet/requirements/design/duplicates/spec/subsumption.toml
@@ -1,0 +1,27 @@
+target = "design/duplicates/spec.md#subsumption"
+
+# 2.3 Subsumption
+#
+# An annotation whose claim is fully covered
+# ([§1.3](#claim-coverage)) by the claims of same-form annotations
+# outside its own claim class MUST fail the duplicates check,
+# regardless of any configured cap.
+# 
+# Rationale, non-normative: this is the historical check's
+# union-coverage semantics, separated from the cap rule. A fragment
+# copy claims nothing its coverers do not already claim; no cap
+# admits it, because the motivating case for a raised cap (two
+# evidence artifacts for one requirement) is copies of the *same*
+# claim, not fragments of it. Together with [§2.2](#caps) at cap 1,
+# this rule reproduces the historical verdict
+# ([P-D3](#property-p-d3)).
+
+[[spec]]
+level = "MUST"
+quote = '''
+An annotation whose claim is fully covered
+([§1.3](#claim-coverage)) by the claims of same-form annotations
+outside its own claim class MUST fail the duplicates check,
+regardless of any configured cap.
+'''
+

--- a/.duvet/requirements/design/duplicates/spec/type-combinations.toml
+++ b/.duvet/requirements/design/duplicates/spec/type-combinations.toml
@@ -1,0 +1,39 @@
+target = "design/duplicates/spec.md#type-combinations"
+
+# 3.3 Target form combinations
+#
+# Configuration declares a **family of allowed form sets** for
+# target classes ([§4.2](#schema-targets)).
+# 
+# A target class bearing two or more distinct claim forms MUST fail
+# the duplicates check unless its form set is a subset of some
+# member of the family. A target class bearing a single claim form
+# MUST NOT fail this rule.
+# ([Decision 12](decisions.md#decision-12);
+# [P-T2](#property-p-t2))
+# 
+# The default family admits every form set that does not contain
+# both `test` and `implementation`
+# ([Decision 8](decisions.md#decision-8)): a position claimed as
+# test code and implementation code simultaneously fails by default;
+# the meta-requirement case relaxes the default in configuration and
+# owns the decision in review.
+# 
+# An empty family (`types = []`) forbids all form mixing on a
+# target.
+
+[[spec]]
+level = "MUST"
+quote = '''
+A target class bearing two or more distinct claim forms MUST fail
+the duplicates check unless its form set is a subset of some
+member of the family.
+'''
+
+[[spec]]
+level = "MUST"
+quote = '''
+A target class bearing a single claim form
+MUST NOT fail this rule.
+'''
+

--- a/.duvet/snapshot.txt
+++ b/.duvet/snapshot.txt
@@ -1,3 +1,108 @@
+SPECIFICATION: [Duvet Duplicates: Formal Specification](design/duplicates/spec.md)
+  SECTION: [1.1 Annotation model](#annotation-model)
+    TEXT[!MUST,implementation,test]: Every user-facing surface this
+    TEXT[!MUST,implementation,test]: specification defines — configuration keys, report sections,
+    TEXT[!MUST,implementation,test]: failure messages — MUST emit the name `implementation` and MUST
+    TEXT[!MUST,implementation,test]: NOT emit the name `citation`.
+    TEXT[!MUST,implementation,test]: Wherever a claim form is read as
+    TEXT[!MUST,implementation,test]: input, `citation` MUST be accepted as an alias for
+    TEXT[!MUST,implementation,test]: `implementation`.
+
+  SECTION: [2.1 Same claim, same target](#same-claim-same-target)
+    TEXT[!MUST,implementation,test]: Two annotations that share a claim and share a resolved target
+    TEXT[!MUST,implementation,test]: MUST fail the duplicates check, regardless of their claim forms
+    TEXT[!MUST,implementation,test]: and regardless of any configured cap.
+
+  SECTION: [2.2 Multiplicity caps](#caps)
+    TEXT[!MUST,implementation,test]: A duplicate set whose size exceeds its form's cap MUST fail the
+    TEXT[!MUST,implementation,test]: duplicates check.
+    TEXT[!MUST,implementation,test]: Caps MUST be configurable only for the priced forms.
+    TEXT[!MUST,implementation,test]: The caps of
+    TEXT[!MUST,implementation,test]: `spec`, `todo`, `exception`, and `implication` are fixed at 1 and
+    TEXT[!MUST,implementation,test]: MUST NOT be configurable.
+    TEXT[!MUST,implementation,test]: A duplicate set within its cap MUST pass this check
+    TEXT[!MUST,implementation,test]: ([Decision 5](decisions.md#decision-5)), and when its size exceeds
+    TEXT[!MUST,implementation,test]: one it MUST be reported with its size and every member's location,
+    TEXT[!MUST,implementation,test]: so multiplicity is always surfaced, never silent.
+
+  SECTION: [2.3 Subsumption](#subsumption)
+    TEXT[!MUST,implementation,test]: An annotation whose claim is fully covered
+    TEXT[!MUST,implementation,test]: ([§1.3](#claim-coverage)) by the claims of same-form annotations
+    TEXT[!MUST,implementation,test]: outside its own claim class MUST fail the duplicates check,
+    TEXT[!MUST,implementation,test]: regardless of any configured cap.
+
+  SECTION: [2.4 Claim-form family](#exclusivity)
+    TEXT[!MUST,implementation,test]: A claim class whose non-`spec` members bear two or more distinct
+    TEXT[!MUST,implementation,test]: claim forms MUST fail the duplicates check unless the set of
+    TEXT[!MUST,implementation,test]: non-`spec` claim forms is admitted by the configured claim-form
+    TEXT[!MUST,implementation,test]: family ([§4.2](#schema-claims)).
+    TEXT[!MUST,implementation,test]: A claim class whose non-`spec`
+    TEXT[!MUST,implementation,test]: members bear a single claim form MUST NOT fail this rule: copies
+    TEXT[!MUST,implementation,test]: of one form are the caps' business ([§2.2](#caps)).
+    TEXT[implementation,test]: The default claim-form family admits exactly the form sets
+    TEXT[implementation,test]: containing no free form
+
+  SECTION: [2.5 Partial overlap](#partial-overlap)
+    TEXT[!MUST,implementation,test]: Verdict: a partial overlap MUST NOT fail the duplicates check,
+    TEXT[!MUST,implementation,test]: matching the historical check.
+    TEXT[!MUST,implementation,test]: Content: the check MUST identify every partial-overlap pair in
+    TEXT[!MUST,implementation,test]: its analysis.
+
+  SECTION: [2.6 Verdict](#duplicates-verdict)
+    TEXT[!MUST,implementation,test]: The duplicates check MUST fail if and only if at least one rule of
+    TEXT[!MUST,implementation,test]: [§2.1](#same-claim-same-target)–[§2.4](#exclusivity) or of the
+    TEXT[!MUST,implementation,test]: target axis ([§3.2](#fan-in-bounds)–[§3.3](#type-combinations))
+    TEXT[!MUST,implementation,test]: fires.
+
+  SECTION: [3.1 Listing](#fan-in-listing)
+    TEXT[!MUST,implementation,test]: The duplicates check's report MUST include the fan-in listing: it
+    TEXT[!MUST,implementation,test]: MUST contain a target if and only if two or more annotations
+    TEXT[!MUST,implementation,test]: resolve to it.
+    TEXT[!MUST,implementation,test]: Each listed target MUST report its exact annotation count, its
+    TEXT[!MUST,implementation,test]: per-form breakdown, and its distinct-section count, and the
+    TEXT[!MUST,implementation,test]: listing MUST be sorted by annotation count descending.
+
+  SECTION: [3.2 Fan-in bounds](#fan-in-bounds)
+    TEXT[!MUST,implementation,test]: When a bound is configured, a target class exceeding it MUST fail
+    TEXT[!MUST,implementation,test]: the duplicates check.
+
+  SECTION: [3.3 Target form combinations](#type-combinations)
+    TEXT[!MUST,implementation,test]: A target class bearing two or more distinct claim forms MUST fail
+    TEXT[!MUST,implementation,test]: the duplicates check unless its form set is a subset of some
+    TEXT[!MUST,implementation,test]: member of the family.
+    TEXT[!MUST,implementation,test]: A target class bearing a single claim form
+    TEXT[!MUST,implementation,test]: MUST NOT fail this rule.
+    TEXT[implementation,test]: The default family admits every form set that does not contain
+    TEXT[implementation,test]: both `test` and `implementation`
+
+  SECTION: [4.1 Policy source](#policy-source)
+    TEXT[!MUST,implementation,test]: Every policy value in this specification MUST be read from
+    TEXT[!MUST,implementation,test]: checked-in configuration.
+    TEXT[!MUST,implementation,test]: Command-line options MUST NOT change any verdict: the command line
+    TEXT[!MUST,implementation,test]: selects which checks run, points at evidence artifacts, and
+    TEXT[!MUST,implementation,test]: controls verbosity — display, never verdict.
+
+  SECTION: [4.2.3 Shared rules](#schema-shared)
+    TEXT[!MUST,implementation,test]: Form names in configuration use the canonical vocabulary
+    TEXT[!MUST,implementation,test]: ([§1.1](#annotation-model)); `citation` MUST be accepted as an
+    TEXT[!MUST,implementation,test]: alias for `implementation` and MUST NOT appear in any emitted
+    TEXT[!MUST,implementation,test]: output.
+    TEXT[!MUST,implementation,test]: An unrecognized key under `[duplicates.claims]` or
+    TEXT[!MUST,implementation,test]: `[duplicates.targets]` MUST be a configuration error, so a typo
+    TEXT[!MUST,implementation,test]: never silently takes a default.
+    TEXT[!MUST,implementation,test]: Configuring a cap for a form other than `test` or
+    TEXT[!MUST,implementation,test]: `implementation` MUST be a configuration error
+    TEXT[!MUST,implementation,test]: ([§2.2](#caps)).
+
+  SECTION: [4.5 Scoped overrides](#scoped-overrides)
+    TEXT[!MUST,exception]: If scoped overrides ship,
+    TEXT[!MUST,exception]: they MUST satisfy resolution determinism, unconfigured
+    TEXT[!MUST,exception]: equivalence, and shadowing monotonicity as stated there.
+
+  SECTION: [5. Properties](#properties)
+    TEXT[!MUST,exception]: Each property MUST be pinned by an integration fixture, except
+    TEXT[!MUST,exception]: where noted.
+
 SPECIFICATION: [Duvet Coverage Model: Formal Specification](design/query/coverage-model-spec.md)
   SECTION: [1.3 Classification Function and Unknown Lines](#classification-function)
     TEXT[!MUST]: A line classified as `{Annotation}` MUST NOT also have

--- a/.duvet/snapshot.txt
+++ b/.duvet/snapshot.txt
@@ -22,7 +22,7 @@ SPECIFICATION: [Duvet Coverage Model: Formal Specification](design/query/coverag
     TEXT[!MUST]: (see [Classifier Selection and Dispatch](#dispatch)).
 
   SECTION: [5. Correctness Properties](#correctness-properties)
-    TEXT[!MUST,implementation,test]: These properties MUST be proven with Verus.
+    TEXT[!MUST,implementation]: These properties MUST be proven with Verus.
     TEXT[!MUST,implication]: The Verus proof files MUST carry duvet annotations
     TEXT[!MUST,implication]: linking each `proof fn` back to the corresponding property section
     TEXT[!MUST,implication]: in this document.
@@ -46,26 +46,26 @@ SPECIFICATION: [Duvet Coverage Model: Formal Specification](design/query/coverag
     TEXT[implication]:   is unknown (`None`)
 
   SECTION: [Property 2: No Cross-Scope Leakage](#property-2-no-cross-scope-leakage)
-    TEXT[!MUST,implementation,implication,test]: The implementation MUST prove that
-    TEXT[!MUST,implementation,implication,test]: for any two lines A and B
-    TEXT[!MUST,implementation,implication,test]: where A is in scope S1 and B is in scope S2
-    TEXT[!MUST,implementation,implication,test]: and S1 ≠ S2
-    TEXT[!MUST,implementation,implication,test]: and S1 is not a parent of S2
-    TEXT[!MUST,implementation,implication,test]: and S2 is not a parent of S1:
+    TEXT[!MUST,implementation,test]: The implementation MUST prove that
+    TEXT[!MUST,implementation,test]: for any two lines A and B
+    TEXT[!MUST,implementation,test]: where A is in scope S1 and B is in scope S2
+    TEXT[!MUST,implementation,test]: and S1 ≠ S2
+    TEXT[!MUST,implementation,test]: and S1 is not a parent of S2
+    TEXT[!MUST,implementation,test]: and S2 is not a parent of S1:
 
   SECTION: [Property 3: Conservative Fallback](#property-3-conservative-fallback)
-    TEXT[!MUST,implementation,implication,test]: The implementation MUST prove that
-    TEXT[!MUST,implementation,implication,test]: no backward propagation occurs WITHIN a scope
-    TEXT[!MUST,implementation,implication,test]: that contains a `NonLinearControl` line.
-    TEXT[!MAY,implication,test]: If an ancestor scope S contains `NonLinearControl`
-    TEXT[!MAY,implication,test]: but a child scope S' does not,
-    TEXT[!MAY,implication,test]: propagation MAY occur through S'.
+    TEXT[!MUST,implementation,test]: The implementation MUST prove that
+    TEXT[!MUST,implementation,test]: no backward propagation occurs WITHIN a scope
+    TEXT[!MUST,implementation,test]: that contains a `NonLinearControl` line.
+    TEXT[!MAY,implementation,test]: If an ancestor scope S contains `NonLinearControl`
+    TEXT[!MAY,implementation,test]: but a child scope S' does not,
+    TEXT[!MAY,implementation,test]: propagation MAY occur through S'.
 
   SECTION: [Property 4: Monotonicity](#property-4-monotonicity)
-    TEXT[!MUST,implementation,implication,test]: The implementation MUST prove that
-    TEXT[!MUST,implementation,implication,test]: given two coverage reports E1 and E2
-    TEXT[!MUST,implementation,implication,test]: where E1 ⊆ E2
-    TEXT[!MUST,implementation,implication,test]: (E2 reports all the same hits as E1, plus possibly more):
+    TEXT[!MUST,implementation,test]: The implementation MUST prove that
+    TEXT[!MUST,implementation,test]: given two coverage reports E1 and E2
+    TEXT[!MUST,implementation,test]: where E1 ⊆ E2
+    TEXT[!MUST,implementation,test]: (E2 reports all the same hits as E1, plus possibly more):
 
   SECTION: [Property 5: Annotation Stacking Transitivity](#property-5-stacking-transitivity)
     TEXT[!MUST,implementation,test]: The implementation MUST prove that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,14 @@ jobs:
         run: |
           cargo xtask test
 
+      # Dogfood: this tree holds itself to its own duplicates policy
+      # (.duvet/config.toml [duplicates.*]; semantics in
+      # design/duplicates/spec.md). Uses the branch-built binary from the
+      # xtask build above.
+      - name: Self-check duplicates
+        run: |
+          ./target/release-debug/duvet query --check duplicates --check duplicate-targets
+
   verify: # verify the duvet-coverage Verus proofs
     name: Verify duvet-coverage proofs
     runs-on: ubuntu-latest
@@ -188,6 +196,8 @@ jobs:
       - name: Verify duvet-coverage proofs
         # `--features verify` pulls in vstd, which is verification-only and
         # optional so it stays out of the published dependency graph.
+        #= design/query/coverage-model-spec.md#correctness-properties
+        #% These properties MUST be proven with Verus.
         run: cargo verus build -p duvet-coverage --features verify
 
   action: # make sure the action works on a clean machine without building

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       # xtask build above.
       - name: Self-check duplicates
         run: |
-          ./target/release-debug/duvet query --check duplicates --check duplicate-targets
+          ./target/release-debug/duvet query --check duplicates
 
   verify: # verify the duvet-coverage Verus proofs
     name: Verify duvet-coverage proofs

--- a/config/v0.4.0.json
+++ b/config/v0.4.0.json
@@ -11,7 +11,7 @@
       ]
     },
     "duplicates": {
-      "description": "Policy for the duplicates check and the duplicate-targets query\n(design/duplicates/spec.md §4).",
+      "description": "Policy for the duplicates check — both coincidence axes\n(design/duplicates/spec.md §4).",
       "anyOf": [
         {
           "$ref": "#/$defs/DuplicatesSchema"
@@ -71,7 +71,7 @@
       ]
     },
     "DuplicatesClaims": {
-      "description": "`[duplicates.claims]` — predicates over claim classes.\n\n//= design/duplicates/spec.md#caps\n//# Caps MUST be configurable only for the priced forms.",
+      "description": "`[duplicates.claims]` — predicates over claim classes.",
       "type": "object",
       "properties": {
         "implementation": {
@@ -109,7 +109,7 @@
       "additionalProperties": false
     },
     "DuplicatesSchema": {
-      "description": "The `[duplicates]` configuration section (design/duplicates/spec.md §4.2).\nTwo namespaces mirror the two coincidence axes; every setting lives in\nexactly one namespace.\n\n//= design/duplicates/spec.md#schema-shared\n//# An unrecognized key under `[duplicates.claims]` or\n//# `[duplicates.targets]` MUST be a configuration error, so a typo\n//# never silently takes a default.",
+      "description": "The `[duplicates]` configuration section (design/duplicates/spec.md §4.2).\nTwo namespaces mirror the two coincidence axes; every setting lives in\nexactly one namespace.",
       "type": "object",
       "properties": {
         "claims": {

--- a/config/v0.4.0.json
+++ b/config/v0.4.0.json
@@ -10,6 +10,17 @@
         "null"
       ]
     },
+    "duplicates": {
+      "description": "Policy for the duplicates check and the duplicate-targets query\n(design/duplicates/spec.md §4).",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DuplicatesSchema"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "report": {
       "$ref": "#/$defs/Report"
     },
@@ -58,6 +69,109 @@
         "todo",
         "implication"
       ]
+    },
+    "DuplicatesClaims": {
+      "description": "`[duplicates.claims]` — predicates over claim classes.\n\n//= design/duplicates/spec.md#caps\n//# Caps MUST be configurable only for the priced forms.",
+      "type": "object",
+      "properties": {
+        "implementation": {
+          "description": "Cap for `implementation` duplicate sets. Default 1. `citation` is\naccepted as an input alias and never emitted.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "default": null,
+          "minimum": 0
+        },
+        "test": {
+          "description": "Cap for `test` duplicate sets. Default 1.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "default": null,
+          "minimum": 0
+        },
+        "types": {
+          "description": "The claim-form family: allowed coexisting form sets, `+`-joined\n(e.g. `[\"exception+test\"]`). Unset = default family (no free form\nshares a claim).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "DuplicatesSchema": {
+      "description": "The `[duplicates]` configuration section (design/duplicates/spec.md §4.2).\nTwo namespaces mirror the two coincidence axes; every setting lives in\nexactly one namespace.\n\n//= design/duplicates/spec.md#schema-shared\n//# An unrecognized key under `[duplicates.claims]` or\n//# `[duplicates.targets]` MUST be a configuration error, so a typo\n//# never silently takes a default.",
+      "type": "object",
+      "properties": {
+        "claims": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DuplicatesClaims"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "targets": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DuplicatesTargets"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DuplicatesTargets": {
+      "description": "`[duplicates.targets]` — predicates over target classes. Bounds are\nopt-in: unlimited when unset.",
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "Fan-in bound: maximum annotations per target.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "default": null,
+          "minimum": 0
+        },
+        "sections": {
+          "description": "Maximum distinct sections per target.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "default": null,
+          "minimum": 0
+        },
+        "types": {
+          "description": "The target-form family: allowed coexisting form sets, `+`-joined.\nUnset = default family (everything except `test`+`implementation`).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
     },
     "HtmlReport": {
       "type": "object",

--- a/config/v0.4.json
+++ b/config/v0.4.json
@@ -11,7 +11,7 @@
       ]
     },
     "duplicates": {
-      "description": "Policy for the duplicates check and the duplicate-targets query\n(design/duplicates/spec.md §4).",
+      "description": "Policy for the duplicates check — both coincidence axes\n(design/duplicates/spec.md §4).",
       "anyOf": [
         {
           "$ref": "#/$defs/DuplicatesSchema"
@@ -71,7 +71,7 @@
       ]
     },
     "DuplicatesClaims": {
-      "description": "`[duplicates.claims]` — predicates over claim classes.\n\n//= design/duplicates/spec.md#caps\n//# Caps MUST be configurable only for the priced forms.",
+      "description": "`[duplicates.claims]` — predicates over claim classes.",
       "type": "object",
       "properties": {
         "implementation": {
@@ -109,7 +109,7 @@
       "additionalProperties": false
     },
     "DuplicatesSchema": {
-      "description": "The `[duplicates]` configuration section (design/duplicates/spec.md §4.2).\nTwo namespaces mirror the two coincidence axes; every setting lives in\nexactly one namespace.\n\n//= design/duplicates/spec.md#schema-shared\n//# An unrecognized key under `[duplicates.claims]` or\n//# `[duplicates.targets]` MUST be a configuration error, so a typo\n//# never silently takes a default.",
+      "description": "The `[duplicates]` configuration section (design/duplicates/spec.md §4.2).\nTwo namespaces mirror the two coincidence axes; every setting lives in\nexactly one namespace.",
       "type": "object",
       "properties": {
         "claims": {

--- a/config/v0.4.json
+++ b/config/v0.4.json
@@ -10,6 +10,17 @@
         "null"
       ]
     },
+    "duplicates": {
+      "description": "Policy for the duplicates check and the duplicate-targets query\n(design/duplicates/spec.md §4).",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DuplicatesSchema"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "report": {
       "$ref": "#/$defs/Report"
     },
@@ -58,6 +69,109 @@
         "todo",
         "implication"
       ]
+    },
+    "DuplicatesClaims": {
+      "description": "`[duplicates.claims]` — predicates over claim classes.\n\n//= design/duplicates/spec.md#caps\n//# Caps MUST be configurable only for the priced forms.",
+      "type": "object",
+      "properties": {
+        "implementation": {
+          "description": "Cap for `implementation` duplicate sets. Default 1. `citation` is\naccepted as an input alias and never emitted.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "default": null,
+          "minimum": 0
+        },
+        "test": {
+          "description": "Cap for `test` duplicate sets. Default 1.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "default": null,
+          "minimum": 0
+        },
+        "types": {
+          "description": "The claim-form family: allowed coexisting form sets, `+`-joined\n(e.g. `[\"exception+test\"]`). Unset = default family (no free form\nshares a claim).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "DuplicatesSchema": {
+      "description": "The `[duplicates]` configuration section (design/duplicates/spec.md §4.2).\nTwo namespaces mirror the two coincidence axes; every setting lives in\nexactly one namespace.\n\n//= design/duplicates/spec.md#schema-shared\n//# An unrecognized key under `[duplicates.claims]` or\n//# `[duplicates.targets]` MUST be a configuration error, so a typo\n//# never silently takes a default.",
+      "type": "object",
+      "properties": {
+        "claims": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DuplicatesClaims"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "targets": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DuplicatesTargets"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DuplicatesTargets": {
+      "description": "`[duplicates.targets]` — predicates over target classes. Bounds are\nopt-in: unlimited when unset.",
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "Fan-in bound: maximum annotations per target.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "default": null,
+          "minimum": 0
+        },
+        "sections": {
+          "description": "Maximum distinct sections per target.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "default": null,
+          "minimum": 0
+        },
+        "types": {
+          "description": "The target-form family: allowed coexisting form sets, `+`-joined.\nUnset = default family (everything except `test`+`implementation`).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
     },
     "HtmlReport": {
       "type": "object",

--- a/design/duplicates/decisions.md
+++ b/design/duplicates/decisions.md
@@ -27,6 +27,11 @@ spray door — and, once the space is stated formally, it turns out
 "duplicate" names more than one thing, and each gets its own
 answer.
 
+The merged query design reserved this slot: its future-work list
+names "acceptable duplicates" as a mechanism not yet designed
+([§7.4](../query/design.md#future-work)). This document is that
+design.
+
 ## The formal space {#formal-space}
 
 An annotation is a triple **(τ, q, t)**:
@@ -61,7 +66,11 @@ predicate over the two partitions the coincidence relations
 induce:
 
 - **Claim classes** (annotations sharing a requirement):
-  multiplicity caps, evidential distinctness, type coherence.
+  multiplicity caps, type coherence. Whether the *evidence* behind
+  two copies is distinguishable is the correlation check's own
+  territory ([query design
+  §2.4](../query/design.md#check-coverage)), not a predicate of
+  this document.
 - **Target classes** (annotations sharing a position): fan-in
   bounds, mixed-form targets.
 
@@ -155,6 +164,20 @@ size and member locations, so multiplicity is always surfaced,
 never silent. Cap semantics are monotone ([P-D4](#properties)):
 raising N never flips a passing project to failing.
 
+What a raised cap costs, and what recovers it: the static check
+cannot tell two evidence-backed copies from one claim written
+twice — that is not a static question, and it is not answered
+here. It does not need to be, because the correlation check bills
+every copy natively: each is an independent test annotation that
+must execute and discharge against its covering implementations
+([query design §2.4](../query/design.md#check-coverage); witness
+model in [§5.2](../query/design.md#annotation-execution) and
+`design/witness/spec.md`) — whether or not the duplicates check
+ever runs. How correlation treats copies whose evidence is
+identical is correlation's decision to make in its own design.
+The governing principle above states what this document needs
+from it; nothing here legislates how.
+
 ---
 
 ## Decision 2: Same claim, same target — always fails, for every type pair {#decision-2}
@@ -193,10 +216,14 @@ FAIL unconditionally, regardless of cap and regardless of type.
 target**, not same
 source line: stacked copies above one statement collapse to one
 target and die here; copies scattered through a function body
-resolve to different targets and are governed by the cap and by
-the evidential rule stated later — indistinguishability decidable
-only once evidence arrives. This decision is that rule's
-statically decidable fragment.
+resolve to different targets and are governed by the cap, with
+each copy's evidence billed by the correlation check
+([query design §2.4](../query/design.md#check-coverage)) —
+indistinguishability beyond position is decidable only once
+evidence arrives, and deciding it is coverage's job, not this
+check's. This decision is the statically decidable fragment: same
+target implies indistinguishable by construction, before any
+evidence exists.
 
 ---
 
@@ -365,9 +392,10 @@ The duplicates check enforces structure only (Decisions 1–4): run
 alone, a within-cap duplicate set **passes**, with its size and
 members surfaced in the report. The coverage check enforces
 evidence natively and unconditionally — whether or not the
-duplicates check ever runs (the next decision states the
-evidential rule). Run the full report and the composition just
-works; run one check and you get exactly that check's guarantee.
+duplicates check ever runs; its contract is its own design
+([query design §2.4](../query/design.md#check-coverage)). Run the
+full report and the composition just works; run one check and you
+get exactly that check's guarantee.
 
 ### Decision: Option B
 
@@ -376,8 +404,9 @@ its two scoping conditions stated so nobody over-reads it:
 
 1. For **test** duplicates, the full coverage check alone
    dominates: every copy is an independent T — unwitnessed → W6
-   fail; witnessed → per-pair ∀w billing; evidentially identical →
-   the distinctness failure defined next.
+   fail; witnessed → per-pair ∀w billing. Whether correlation
+   additionally compares copies *to each other* is its own design
+   question, owned there.
 2. For **implementation** duplicates, coverage dominates the
    *duplicate-specific* badness only. An implementation annotation
    on a quote no test covers is invisible to coverage — but so is
@@ -390,137 +419,13 @@ duplicates. The report wording points at running both checks.
 
 ---
 
-## Decision 6: Coverage fails evidentially indistinct duplicates (W8) {#decision-6}
-
-**Context:** A project raises `test = 2`, and a requirement now
-carries two test annotations in two places. What the coverage
-check does with them today: it binds each annotation to its
-witness set — the concrete units of evidence, an instrumented
-test run, a proved clause — and verifies each annotation
-independently: witnessed? discharged against every covering
-implementation? Both copies can answer both questions by pointing
-at the same evidence, and both pass, because nothing ever
-compares the copies *to each other*. Per-instance discharge (W6
-plus pair billing) is already enforced for every copy; what no
-existing machinery asks is whether the two copies are two claims
-or one claim written twice.
-
-One question decides it: **do the copies bind the same witness
-set?** Everything duvet can check about a test annotation — in
-this check or any future one — is a function of its witness set.
-If two copies bind exactly equal sets, no check can ever tell
-them apart; the second copy adds no information. The governing
-principle says duplicates are permissible exactly where coverage
-can disambiguate them, and equal witness sets is precisely where
-it cannot.
-
-### Option A: Report the groups, never change the verdict
-
-Surface "these copies are evidentially indistinguishable" as an
-informational grouping — candidates for collapsing, no failure.
-This option was briefly adopted during design, out of sympathy
-for contained multiplicity ("silly but not intrinsically wrong").
-
-- Con: it quietly guts the design's central claim. If
-  indistinguishable copies never fail, coverage resolves only
-  *rot* (unwitnessed, undischarged copies), not *redundancy* —
-  and "the duplicates check can relax because coverage
-  disambiguates the copies" stops being true. The grouping
-  becomes a caption on a pass.
-- Con: the governing principle decides this case directly.
-  Allowing indistinguishable copies is not tolerance; it is the
-  principle's own failure condition.
-
-### Option B: Fail the indistinguishable groups
-
-Within each claim class, group the same-type test members by
-their bound witness set. **Every group of size ≥ 2 fails** —
-those members are mutually indistinguishable. Singleton groups
-pass.
-
-### Decision: Option B
-
-Property **W8 (evidential distinctness):** coverage PASS requires
-that no two same-type mutually-covering test annotations bind the
-same witness set.
-
-**How you hit it in practice.** Three ways:
-
-- Copy-paste: N copies scattered through one test function all
-  bind that test's witnesses identically. Fails; collapse them.
-- One merged suite report: two *genuinely different* tests run as
-  a single instrumented invocation produce one fat witness, and
-  both annotations bind it. Fails — and this is the case that
-  feels like a false positive, because the tests really are
-  different. But the evidence handed to duvet cannot see the
-  difference, and duvet does not guess at distinctions its
-  evidence cannot support. Two exits, both improvements: collapse
-  the copies, or individuate the runs (per-test reports) so the
-  sets differ. Coarser evidence buys fewer allowed duplicates —
-  the monotonicity invariant surfacing as an incentive.
-- Two test annotations inside one Verus discharge unit bind the
-  same clause span. Fails. Copies on two *different* `ensures`
-  clauses of one function pass — the prover artifact records a
-  span per clause, so the sets were never equal. Two separately
-  recorded prover obligations are two units of evidence; edgy,
-  pinned by fixture, reopened if dogfooding says otherwise.
-
-The constructions this admits are the motivating ones: proof +
-PBT (`{w_verus}` vs `{w_jacoco}`), split tests with per-test
-reports.
-
-**There are no false positives in the strict sense.** Equal sets
-are computed from the delivered evidence, not estimated; when the
-rule fires, the indistinguishability is a fact. The unfair
-*feeling* is always the merged-report case — evidence coarser
-than reality — and the remediation message says so.
-
-The formulation carries two deliberate precisions, both
-arm-wrestled:
-
-- **Distinct means unequal, never disjoint.** An earlier
-  "pairwise distinct sets" phrasing invited misreading as
-  disjointness, and disjointness would fail legitimate structure:
-  `{extent, e₁} ≠ {extent, e₂}` passes despite the shared
-  witness.
-- **The verdict attaches to the indistinguishable group, not the
-  class.** If A and B bind identically but C binds differently, A
-  and B fail together and C is untouched. Coverage can prove the
-  group mutually vacuous but cannot pick the canonical member; a
-  human collapses it.
-
-**Consequences:**
-
-- [Decision 2](#decision-2)'s same-target rule is exactly this
-  rule's statically decidable shadow: same target implies
-  identical sets by construction, but not conversely — positions
-  that always execute together are positionally distinct and
-  evidentially identical, and only this rule sees them.
-- **Robust to report duplication:** binding is content-determined
-  (`executed_by` reads the coverage map), so delivering one
-  report twice binds both copies identically for *every*
-  annotation — `{w₁, w₂} = {w₁, w₂}`, still indistinct. Evidence
-  cannot be photocopied into distinctness.
-- Implementation surface is additive: the check already computes
-  `bound_witnesses` per test; the new work is grouping by witness
-  set, one new result bucket, one status conjunct — linear, no
-  pairwise walk. Per the engine-glue requirement, the W8 verdict
-  flows through a verified-layer predicate (set equality over the
-  existing `binds` cells) with an exactness proof: members
-  grouped ⟺ witness sets equal.
-- Implementation-side distinctness (comparing execution profiles
-  of implementation copies) is deferred to a follow-up; tests are
-  where the motivating case lives.
-
----
-
-## Decision 7: Evidence units come from the artifact, never from inference {#decision-7}
+## Decision 6: Evidence units come from the artifact, never from inference {#decision-6}
 
 **Context:** Under one merged runtime report, two genuinely
 different tests carrying the same claim bind identical witness
-sets and fail W8. Could duvet subdivide the report — e.g. by "the
-test function the annotation sits in," using the classifier's
-scope tree — to tell them apart?
+sets — the evidence cannot tell them apart. Could duvet subdivide
+the report — e.g. by "the test function the annotation sits in,"
+using the classifier's scope tree — to tell them apart?
 
 ### Option A: Scope-refined evidence units
 
@@ -552,7 +457,8 @@ artifacts: one instrumented run per test.
 
 ### Decision: Option B. Scope refinement is rejected, not deferred.
 
-**Consequences:** The fat-report W8 failure is designed incentive,
+**Consequences:** The fat-report indistinguishability is designed
+incentive,
 not accident: merged report → indistinguishable duplicates →
 collapse them or individuate your runs. Coarse evidence buys fewer
 allowed duplicates; finer evidence buys more. This is the
@@ -570,7 +476,7 @@ spans) ever subdivides a unit.
 
 ---
 
-## Decision 8: Executed-coverage mode carries no duplicate guarantees {#decision-8}
+## Decision 7: Executed-coverage mode carries no duplicate guarantees {#decision-7}
 
 **Context:** `executed-coverage` skips `NotExecuted` tests by
 design — it is the tight inner loop (run one test in seconds, not
@@ -579,8 +485,8 @@ this invocation are unbilled there.
 
 ### Option A: A narrow tightening for the mode
 
-When some members of a duplicate set executed and grouped
-vacuously, fail the set even in executed mode.
+When some members of a duplicate set executed and their evidence
+is identical, fail the set even in executed mode.
 
 - Con: it designs duplicate machinery into a debug loop. The
   mode's entire purpose is deliberate partiality — run one test in
@@ -601,7 +507,7 @@ positions that resolve to nothing has no refuge here either.
 
 ---
 
-## Decision 9: Duplicate targets — the fan-in axis {#decision-9}
+## Decision 8: Duplicate targets — the fan-in axis {#decision-8}
 
 **Context:** Everything above polices coincidence of **claims**.
 The formal space has a second coordinate, and it collides too:
@@ -612,7 +518,7 @@ LLM sessions. The full matrix:
 
 | | same target | different targets |
 |---|---|---|
-| same claim | dead — [Decision 2](#decision-2) | duplicate set — cap + W8 |
+| same claim | dead — [Decision 2](#decision-2) | duplicate set — cap + evidence billing |
 | different claims | **duplicate target (this decision)** | normal |
 
 This is duplication of the *other* coordinate — not a duplicated
@@ -639,7 +545,7 @@ lines, losing per-claim precision — on the prover side, the
 difference between binding the extent and binding the clause
 unit); rot amplification (a refactor re-homes twelve claims as one
 careless block); and annotation dumping — spray rotated ninety
-degrees. Per [Decision 7](#decision-7), no evidence-side analysis
+degrees. Per [Decision 6](#decision-6), no evidence-side analysis
 can distinguish a well-placed stack from a lazy one within a unit,
 so the tools here are static, and their bounds are policy rather
 than correctness.
@@ -678,7 +584,7 @@ biting default.
 Use the execution data to tell a lazily-stacked function head from
 a precisely-annotated dense function.
 
-- Con: impossible within a unit, per [Decision 7](#decision-7) —
+- Con: impossible within a unit, per [Decision 6](#decision-6) —
   no execution gradient exists. (A related evidence-side idea
   survives as a parked observation at the end of this document.)
 
@@ -734,11 +640,11 @@ is the next decision.
 
 ---
 
-## Decision 10: Policy lives in configuration, not on the command line {#decision-10}
+## Decision 9: Policy lives in configuration, not on the command line {#decision-9}
 
 **Context:** The decisions above accumulate policy values — caps
 (Decision 1), coherence cells (Decision 4), fan-in bounds and the
-mixed-form default (Decision 9). Where do they live?
+mixed-form default (Decision 8). Where do they live?
 
 ### Option A: CLI flags, possibly mirrored in config
 
@@ -782,7 +688,7 @@ controls verbosity — display, never verdict.
 
 ---
 
-## Decision 11: User-facing vocabulary — `implementation`, not `citation` {#decision-11}
+## Decision 10: User-facing vocabulary — `implementation`, not `citation` {#decision-10}
 
 **Context:** The code names the default annotation type
 `citation`. Every user-facing surface the preceding decisions add
@@ -821,9 +727,9 @@ own change.
 
 ---
 
-## Decision 12: One config namespace per coincidence axis {#decision-12}
+## Decision 11: One config namespace per coincidence axis {#decision-11}
 
-**Context:** [Decision 10](#decision-10) settled where policy
+**Context:** [Decision 9](#decision-9) settled where policy
 lives; its sketch wrote the keys flat. This settles the vocabulary
 the policy is written in.
 
@@ -857,7 +763,7 @@ implementation = 1
 # coherence-cell overrides (Decision 4)
 
 [duplicates.targets]       # predicates over target classes (D_T)
-count = 3                  # fan-in bound (Decision 9)
+count = 3                  # fan-in bound (Decision 8)
 sections = 2               # distinct sections per target
 # allowed type combinations: next decision
 ```
@@ -878,9 +784,9 @@ unaffected: those are not caps, and remain unique always
 
 ---
 
-## Decision 13: Target type combinations are an allowed-set family {#decision-13}
+## Decision 12: Target type combinations are an allowed-set family {#decision-12}
 
-**Context:** [Decision 9](#decision-9) named a `types` bound (max
+**Context:** [Decision 8](#decision-8) named a `types` bound (max
 distinct claim forms per target) and a mixed-form default
 (`test`+`implementation` on one target fails). Stated as a number,
 the bound is expressive only at 1.
@@ -945,11 +851,11 @@ one never flips failing to passing. Exactness is
 
 ---
 
-## Decision 14: Scoped policy overrides — designed, deferred {#decision-14}
+## Decision 13: Scoped policy overrides — designed, deferred {#decision-13}
 
 **Context:** Every policy value so far is global — one value per
 setting per project. The legitimate-density population from
-[Decision 9](#decision-9) invites finer grain: the packet-format
+[Decision 8](#decision-8) invites finer grain: the packet-format
 section genuinely hosts twelve MUSTs; the parser file genuinely
 hosts fan-in. Today the only relief is loosening the global bound,
 which surrenders the check everywhere to accommodate one place. Is
@@ -1043,19 +949,15 @@ inside its scope; nothing outside leaks).
 
 ---
 
-## Decision 15: Release posture {#decision-15}
+## Decision 14: Release posture {#decision-14}
 
-**Context:** Executed (runtime) coverage has shipped; proof
-coverage has not. Two behavior changes are on the table: W8
-([Decision 6](#decision-6)) changes the coverage verdict on inputs
-containing indistinct duplicate pairs, and type coherence
-([Decision 4](#decision-4)) makes the duplicates check fail
-cross-type coexistences that silently pass today.
+**Context:** One behavior change ships from this document: type
+coherence ([Decision 4](#decision-4)) makes the duplicates check
+fail cross-type coexistences that silently pass today.
 
 ### Option A: A compatibility flag
 
-Ship the new semantics behind `--no-distinctness` /
-`--legacy-coherence` switches.
+Ship the new semantics behind a `--legacy-coherence` switch.
 
 - Con: a waiver-by-declaration, rejected on the same grounds as
   every other waiver in this document — and a permanent escape
@@ -1066,29 +968,19 @@ Ship the new semantics behind `--no-distinctness` /
 - Pro: nobody gets ambushed; the warning release lists the exact
   collapse/split remediation.
 - Con: unnecessary given the facts. It was designed under the
-  assumption of a broad executed-coverage install base; the actual
-  base is effectively one user, and proof coverage has not shipped
-  at all.
+  assumption of a broad install base; the actual base is
+  effectively one user.
 
-### Option C: Ship strict with proof coverage; tightened defaults are pinnable
+### Option C: Ship the tightened default, pinnable
 
-W8 ships **in the same release as proof coverage** — the check
-simply always had these semantics; no lenient version ever
-existed to be compatible with. Type coherence ships as a
-tightened default with its cells pinnable per
-[Decision 10](#decision-10) — the release notes name the cell
-that restores prior behavior.
+Type coherence ships as a tightened default with its cells
+pinnable per [Decision 9](#decision-9) — the release notes name
+the cell that restores prior behavior.
 
 ### Decision: Option C
 
-**Consequences:** Enforcement invariance is stated honestly as
-**P-C1′**: the new coverage verdict equals the old on every input
-containing no indistinct duplicate pair; on inputs that do, new
-coverage fails where old passed — and that delta is precisely the
-defect class this feature defines. Both exits from the new failure
-are improvements: collapse the copies (the report lists them) or
-individuate the evidence. Legacy equivalence for the duplicates
-check ([P-D3](#properties)) is likewise scoped: caps at 1 *and*
+**Consequences:** Legacy equivalence for the duplicates check
+([P-D3](#properties)) is scoped honestly: caps at 1 *and*
 coherence cells at their pre-existing effective values reproduce
 the historical verdict; the shipped coherence defaults are a
 deliberate tightening.
@@ -1153,7 +1045,7 @@ fan-in view and pair billing.
 
 **Parked, not adopted:** the transpose cannot serve the placement
 question that motivated it — within one evidence unit there is no
-execution gradient ([Decision 7](#decision-7)), so a constant
+execution gradient ([Decision 6](#decision-6)), so a constant
 column cannot distinguish a lazily-placed annotation from a
 precisely-placed one on a genuinely hot path (a requirement really
 enforced on the universal request path legitimately executes under
@@ -1167,8 +1059,7 @@ coverage already computes.
 
 ## Properties {#properties}
 
-Pinned by fixture unless noted; W8's predicate and exactness proof
-live in the verified layer.
+Pinned by fixture unless noted.
 
 - **P-D1 (stacked-spam soundness).** duplicates PASS ⟹ no
   mutually-covering pair — any types — shares a resolved target.
@@ -1194,25 +1085,18 @@ live in the verified layer.
   set; single-type targets never fail it. Adding an allowed set
   never flips a passing project to failing; removing one never
   flips failing to passing (the family form of P-D4).
-- **P-C1′ (scoped enforcement invariance).** New coverage verdict
-  ≡ old on every input with no indistinct duplicate pair.
 - **P-C2 (per-instance billing).** coverage PASS ⟹ every in-scope
   test annotation, duplicate or not, is witnessed and discharges
   against every covering implementation. (Already true — W6 plus
   the per-test aggregation; stated so independence is visibly
   safe.)
-- **W8 (evidential distinctness).** coverage PASS ⟹ within every
-  claim class, no witness-set group of same-type test members has
-  size ≥ 2. Verified-layer predicate; exactness: grouped ⟺ sets
-  equal. Distinct means unequal, not disjoint.
 - **P-S0 (verdict determinism).** For a fixed set of checks and
   evidence inputs, the verdict is a function of the checked-in
   tree (source + config). Verbosity never changes a verdict.
 - **P-S1 (no pass without evidence).** duplicates PASS ∧ coverage
   PASS ⟹ every duplicate copy resolves to a distinct target, every
-  set is within cap, every claim class is type-coherent, every
-  copy is individually billed, and every pair is evidentially
-  distinct.
+  set is within cap, every claim class is type-coherent, and every
+  copy is individually billed.
 
 ## Follow-ups
 
@@ -1221,13 +1105,8 @@ live in the verified layer.
   and test checks), so P-D5's fixture set covers the real paths;
   and that exact/full mutual coverage is transitive, so claim
   classes are well-defined.
-- Integration fixtures: same-test-fn pair (fail W8); split-test
-  pair with per-test reports (pass); fat-report distinct-tests
-  pair (fail W8); duplicated-report pair (fail W8); Verus
-  same-ensures pair (fail) and cross-ensures pair (pass);
-  specificity-boundary binding (annotation on fn header vs inside
-  clause spans); cap fixtures at N=1 (legacy parity) and N=2;
-  coherence fixtures per row of the Decision 4 table; fan-in
+- Integration fixtures: cap fixtures at N=1 (legacy parity) and
+  N=2; coherence fixtures per row of the Decision 4 table; fan-in
   listing exactness; mixed-form target default.
 - Config schema (`[duplicates.claims]` / `[duplicates.targets]`):
   caps, fan-in bounds, the type-set family, coherence cells,
@@ -1235,15 +1114,13 @@ live in the verified layer.
   parse boundary, never emitted.
 - Survey the public duvet corpus (s2n-quic, s2n-tls, the AWS
   crypto tooling) for actual target fan-in frequency — settles
-  Decision 9's open `count` default (unlimited vs 1).
-- Scoped overrides (Decision 14), if demand arrives: glob keys for
+  Decision 8's open `count` default (unlimited vs 1).
+- Scoped overrides (Decision 13), if demand arrives: glob keys for
   target scope and their overlap-precedence rule; whether spec
   scope without section scope is worth having; fixtures for the
   three scoping properties.
 - `duplicate-targets` query, then snapshot inclusion once the
   format stabilizes.
-- Implementation-side distinctness (execution profiles) — own
-  follow-up.
 - Implication duplicates — rider on self-discharging implications.
 - Impl-dump diagnostic locality (pointing failures at the dumped
   annotation rather than the innocent tests) — revisit with the

--- a/design/duplicates/decisions.md
+++ b/design/duplicates/decisions.md
@@ -303,22 +303,29 @@ an `implementation`? Today the duplicates check is same-type-only
 and never sees these coexistences.
 
 The engine fact from [the formal space](#formal-space) makes this
-urgent rather than cosmetic: an `exception` or `implication`
-exempts its requirement from the test obligation. So a free form
-added *next to* an existing priced form silently deflates the
-priced form's obligations — an LLM (or a tired human) that learns
-"tests need witnesses and implementations must execute" also
-learns that `implication` requires nothing. Type-shopping is the
-gate-evasion strategy the pricing table predicts, and the free
-forms are its escape valve. A per-target rule cannot catch it: an
+urgent rather than cosmetic: the free forms are satisfied coverers
+everywhere the checks look for implementations — they cover
+requirements in the implementation check and cover tests in the
+coverage check — while the test check ranges over `implementation`
+annotations only. A free form written *in place of* a priced form
+therefore satisfies implementation coverage while creating no test
+obligation at all — an LLM (or a tired human) that learns "tests
+need witnesses and implementations must execute" also learns that
+`implication` requires nothing. (A free form added *next to* an
+intact priced form deflates nothing — the priced form keeps its
+obligations; what that coexistence signals is incoherent claims
+about the requirement's nature.) Type-shopping is the gate-evasion
+strategy the pricing table predicts, and the free forms are its
+escape valve. A per-target rule cannot catch the coexistence: an
 `exception`'s position is incidental, so it evades any co-location
 check by sitting anywhere else.
 
 ### Option A: Leave it alone (today's behavior)
 
-- Con: the exploit is live. Adding an `implication` next to an
-  existing `implementation` annotation silently deflates the
-  requirement's obligations, and nothing reports the coexistence.
+- Con: the exploit is live. An `implication` written where an
+  `implementation` belongs satisfies the implementation check and
+  carries no test obligation, and nothing reports a free form
+  coexisting with priced claims on one requirement.
 
 ### Option B: A pairwise contradiction matrix
 
@@ -1119,11 +1126,6 @@ Pinned by fixture unless noted.
 
 ## Follow-ups
 
-- Verify against the engine: the exact control flow by which
-  exception/implication exempt the test obligation (implementation
-  and test checks), so P-D5's fixture set covers the real paths;
-  and that exact/full mutual coverage is transitive, so claim
-  classes are well-defined.
 - Integration fixtures: cap fixtures at N=1 (legacy parity) and
   N=2; coherence fixtures per row of the Decision 4 table; fan-in
   listing exactness; mixed-form target default.

--- a/design/duplicates/decisions.md
+++ b/design/duplicates/decisions.md
@@ -694,17 +694,10 @@ mixed-form default (Decision 9). Where do they live?
 
 All policy is checked-in configuration. The shipped defaults
 encode this document's verdicts; a project overrides individual
-cells; omitted cells take the defaults.
-
-```toml
-[duplicates]
-max-duplicates = { test = 2 }          # Decision 1; default: all 1
-# max-target   = { count = 5, sections = 3, types = 1 }   # Decision 9; default: unlimited
-# policy cells (Decision 4, Decision 9), shipped defaults shown:
-# "exception+test.same-claim"          = "fail"
-# "implication+implementation.same-claim" = "fail"
-# "test+implementation.same-target"    = "fail"
-```
+cells; omitted cells take the defaults. (The key vocabulary the
+policy is written in — what the settings are named and how the
+file is structured — is left open here and settled two decisions
+below, once the naming question is also on the table.)
 
 ### Decision: Option B
 
@@ -731,7 +724,254 @@ controls verbosity — display, never verdict.
 
 ---
 
-## Decision 11: Release posture {#decision-11}
+## Decision 11: User-facing vocabulary — `implementation`, not `citation` {#decision-11}
+
+**Context:** The code names the default annotation type
+`citation`. Every user-facing surface the preceding decisions add
+— config keys, report sections, failure messages — needs one name
+for it, and this document has already been using `implementation`
+throughout. Which name is canonical, and what happens to the
+other?
+
+### Option A: `citation` everywhere
+
+- Con: it names the mechanics (the annotation quotes the spec),
+  not the claim ("R is implemented here"). Every rule in this
+  document prices the claim; the pricing table's rows read
+  strangely against a name that describes quoting.
+
+### Option B: Rename the code
+
+- Con: eviscerates the codebase for a naming preference — every
+  touched line is review burden with zero behavior change.
+
+### Option C: Canonical user-facing name, alias at the parse boundary
+
+`implementation` is the one name emitted anywhere a user reads:
+config keys, reports, messages. `citation` remains accepted on
+input — existing annotations keep parsing, forever — and is never
+emitted. Internal code keeps its vocabulary.
+
+### Decision: Option C
+
+**Consequences:** One canonical output name prevents the drift
+that two-names-for-one-thing invites. The rename never touches the
+enum.
+
+---
+
+## Decision 12: One config namespace per coincidence axis {#decision-12}
+
+**Context:** [Decision 10](#decision-10) settled where policy
+lives; its sketch wrote the keys flat. This settles the vocabulary
+the policy is written in.
+
+### Option A: Flat keys
+
+`test`, `count`, `sections` side by side under `[duplicates]`.
+
+- Con: `count` is ambiguous between the two partitions — "how many
+  annotations may share a claim" versus "how many may share a
+  target" — and the ambiguity is not hypothetical: it was
+  committed during this design, in a draft that wrote `count`
+  meaning fan-in where a reader had every reason to read
+  multiplicity.
+
+### Option B: Disambiguating key prefixes
+
+`max-duplicates.test`, `max-target.count`.
+
+- Pro: unambiguous.
+- Con: a naming convention carries the structure instead of the
+  structure carrying it. The formal space has exactly two
+  partitions; the config file can mirror the model instead of
+  encoding it into hyphenated names.
+
+### Option C: Two namespaces mirroring the two partitions
+
+```toml
+[duplicates.claims]        # predicates over claim classes (D_Q)
+test = 2                   # per-type multiplicity caps (Decision 1)
+implementation = 1
+# coherence-cell overrides (Decision 4)
+
+[duplicates.targets]       # predicates over target classes (D_T)
+count = 3                  # fan-in bound (Decision 9)
+sections = 2               # distinct sections per target
+# allowed type combinations: next decision
+```
+
+Every setting lives in exactly one namespace; no setting name
+appears in both. "What does this key constrain" is answered by
+position in the file.
+
+### Decision: Option C
+
+**Consequences:** Both priced types sit on equal footing under
+`claims` — `implementation` caps are as configurable as `test`
+caps, with no privileged case. Whether a team wants duplicate
+implementations is the team's call, made in review by writing the
+number. [Decision 3](#decision-3)'s verdicts on the free forms are
+unaffected: those are not caps, and remain unique always
+([P-D2](#properties)).
+
+---
+
+## Decision 13: Target type combinations are an allowed-set family {#decision-13}
+
+**Context:** [Decision 9](#decision-9) named a `types` bound (max
+distinct claim forms per target) and a mixed-form default
+(`test`+`implementation` on one target fails). Stated as a number,
+the bound is expressive only at 1.
+
+### Option A: Numeric bound
+
+- Con: `types = 2` says "any two forms may share a target" — it
+  permits exactly the combination the mixed-form default forbids,
+  and cannot say "exception+test is fine, test+implementation is
+  not." The one distinction the axis exists to draw is the one a
+  count cannot express, so the mixed-form default would survive as
+  special-case machinery beside the bound.
+
+### Option B: Pairwise cells
+
+A verdict per type pair, like [Decision 4](#decision-4) Option B.
+
+- Con: rejected there for the same reasons that apply here —
+  per-cell metaphysics, invitation to relitigate, and every new
+  annotation type multiplies the cells.
+
+### Option C: A family of allowed type-sets
+
+Config declares which combinations may share a target. A target
+class G passes iff `types(G) ⊆ S` for some configured set S:
+
+```toml
+[duplicates.targets]
+types = ["implementation", "test", "exception+test"]
+```
+
+- Pro: downward-closed by construction — a subset of an allowed
+  combination is always allowed, so permitting a combination never
+  forbids its parts.
+- Pro: subsumes the numeric form — `types = 1` is the family of
+  singletons. One primitive instead of two.
+- Pro: the mixed-form default stops being special-case machinery:
+  the shipped default family is every combination **not**
+  containing both `test` and `implementation`. The Appendix-A team
+  adds one set to the family and owns it in review.
+- Pro: it is [Decision 4](#decision-4)'s shape — allowed type
+  combinations — transplanted to the other partition. The model's
+  symmetry, showing up in the config.
+
+### Decision: Option C
+
+**Consequences:** [P-D4](#properties) extends to families: adding
+an allowed set never flips a passing project to failing; removing
+one never flips failing to passing. Exactness is
+[P-T2](#properties).
+
+---
+
+## Decision 14: Scoped policy overrides — designed, deferred {#decision-14}
+
+**Context:** Every policy value so far is global — one value per
+setting per project. The legitimate-density population from
+[Decision 9](#decision-9) invites finer grain: the packet-format
+section genuinely hosts twelve MUSTs; the parser file genuinely
+hosts fan-in. Today the only relief is loosening the global bound,
+which surrenders the check everywhere to accommodate one place. Is
+there a scoping scheme that stays policy — a rule about a class —
+without becoming the per-instance waiver this document rejected at
+the outset?
+
+### Option A: Section scoping for everything
+
+Overrides keyed by `spec.md#section-id`, applying to every
+predicate.
+
+- Con: ill-typed for target predicates. A claim class has exactly
+  one section (its quote's); a target class has none — it may host
+  annotations from eight sections and two specs. This was
+  committed during design: a draft override scoped `count`
+  (fan-in) under a section key, the precise coordinate a target
+  class lacks.
+- Con: the `sections` bound becomes circular under section scoping
+  — bounding distinct-sections-per-target with a bound that itself
+  varies by section.
+
+### Option B: Strictest applicable bound
+
+Where a target hosts annotations from several sections, the
+strictest configured bound governs.
+
+- Con: action-at-a-distance. Importing one quote from a stricter
+  section onto an existing stack silently changes which bound
+  governs the whole target — the effective bound moves under
+  exactly the mutations pull requests contain.
+
+### Option C: Most-permissive applicable bound
+
+- Con: laundering. Route one annotation from the loose section
+  onto any target and its bound rises — type-shopping in scope
+  clothing. Rejected outright.
+
+### Option D: Axis-matched scoping
+
+Each predicate family scopes by the coordinate system its
+equivalence classes live in; most-specific wins; unset scopes
+inherit:
+
+- Claim predicates: global → spec → section, keyed in the same
+  `spec.md#section-id` form annotations use — same resolver, and a
+  key naming a nonexistent section fails like a bad annotation
+  reference.
+- Target predicates: global → file path, keyed by the target's
+  own address.
+
+```toml
+[duplicates.claims."rfc9000.md#packet-format"]
+test = 3
+
+[duplicates.targets."src/parser.rs"]
+count = 15
+```
+
+- Pro: each override names its blast radius in its own key.
+- Pro: bounds are stable under annotation arrival — a target's
+  bound is a function of its address, and no arriving annotation
+  from any section can change which bound applies.
+- Pro: still rule-level. A section or a file is a class; the
+  override is an audited statement about it, not an excuse for an
+  instance. The waiver door stays closed. The granularity ladder
+  is global → spec → section → per-annotation (rejected), and
+  scope stops at the finest grain that is still a rule.
+- Pro: the dense parser is bounded at its own address; the global
+  stays tight.
+
+### Decision: Option D is the design; shipping it is deferred
+
+Two reasons to wait, recorded so the deferral is a decision and
+not a drift. First, target-side scoping will immediately be asked
+to take globs — one file is rarely the real class, `src/parser/**`
+is — and glob keys need an overlap-precedence rule
+(`src/parser.rs` vs `src/**`) that is real, unresolved design
+surface. Second, no demonstrated need yet: global bounds plus the
+discovery loop may be enough, and adding scope resolution to the
+policy model before a user asks buys complexity without a
+customer.
+
+If it ships, it owes three properties, stated now so the future
+decision inherits them: **resolution determinism** (the effective
+value is a pure function of config plus the class's coordinates —
+no key-order dependence), **unconfigured equivalence** (a config
+with no scoped keys behaves identically to global-only), and
+**shadowing monotonicity** (a scoped key changes verdicts only
+inside its scope; nothing outside leaks).
+
+---
+
+## Decision 15: Release posture {#decision-15}
 
 **Context:** Executed (runtime) coverage has shipped; proof
 coverage has not. Two behavior changes are on the table: W8
@@ -876,6 +1116,11 @@ live in the verified layer.
 - **P-T1 (fan-in exactness).** The duplicate-targets listing
   contains a target iff ≥ 2 annotations resolve to it; counts,
   type breakdowns, and section counts are exact.
+- **P-T2 (type-family exactness).** With a configured family, a
+  target class fails the type-combination rule iff its type set is
+  a subset of no allowed set. Adding an allowed set never flips a
+  passing project to failing; removing one never flips failing to
+  passing (the family form of P-D4).
 - **P-C1′ (scoped enforcement invariance).** New coverage verdict
   ≡ old on every input with no indistinct duplicate pair.
 - **P-C2 (per-instance billing).** coverage PASS ⟹ every in-scope
@@ -911,8 +1156,14 @@ live in the verified layer.
   clause spans); cap fixtures at N=1 (legacy parity) and N=2;
   coherence fixtures per row of the Decision 4 table; fan-in
   listing exactness; mixed-form target default.
-- Config schema (`[duplicates]` section): caps, fan-in bounds,
-  policy cells, shipped defaults.
+- Config schema (`[duplicates.claims]` / `[duplicates.targets]`):
+  caps, fan-in bounds, the type-set family, coherence cells,
+  shipped defaults; `citation` → `implementation` alias at the
+  parse boundary, never emitted.
+- Scoped overrides (Decision 14), if demand arrives: glob keys for
+  target scope and their overlap-precedence rule; whether spec
+  scope without section scope is worth having; fixtures for the
+  three scoping properties.
 - `duplicate-targets` query, then snapshot inclusion once the
   format stabilizes.
 - Implementation-side distinctness (execution profiles) — own

--- a/design/duplicates/decisions.md
+++ b/design/duplicates/decisions.md
@@ -1,9 +1,5 @@
 # Duplicate Annotations — Decisions
 
-**Status:** Decisions 1–8 proposed, not yet implemented.
-References to `design/witness/` are forward references to the
-witness-coverage work (in flight, not yet on `main`).
-
 ## Context
 
 The duplicates check today classifies each annotation type against
@@ -27,19 +23,72 @@ artifacts structurally force two annotations, and the duplicates
 check punishes exactly the behavior we want to encourage.
 
 This document decides how to admit that case without opening the
-spray door.
+spray door — and, once the space is stated formally, it turns out
+"duplicate" names more than one thing, and each gets its own
+answer.
+
+## The formal space {#formal-space}
+
+An annotation is a triple **(τ, q, t)**:
+
+- **τ** — the claim form (type): `test`, `implementation`,
+  `implication`, `exception`, `todo`, `spec`.
+- **q** — the claim: a section plus quoted requirement text.
+- **t** — the resolved target: the position the annotation
+  resolves to (`resolve_target_line`), which is what binding
+  scores.
+
+There are exactly two coincidence relations — the two coordinates
+on which annotations can collide:
+
+- **Same claim** (D_Q): quotes mutually cover on the same section.
+- **Same target** (D_T): same resolved target.
+
+Type is deliberately **not** a third coincidence axis. Two
+annotations do not duplicate each other *by* sharing a type. Type
+determines the **price** of a claim — what evidence the checks
+demand of it:
+
+| Claim form | Price |
+|---|---|
+| `test` | must be witnessed; every bound witness must execute each covering implementation |
+| `implementation` | must be executed under covering tests' witnesses |
+| `implication`, `exception`, `todo`, `spec` | free — no checkable obligation |
+
+Quotes and targets say *whether* annotations collide; type says
+*what the collision means*. Every check in this document is a
+predicate over the two partitions the coincidence relations
+induce:
+
+- **Claim classes** (annotations sharing a requirement):
+  multiplicity caps, evidential distinctness, type coherence.
+- **Target classes** (annotations sharing a position): fan-in
+  bounds, mixed-form targets.
+
+Two boundary conditions on the model, stated so nobody over-reads
+it. First, "claim class" is well-defined only if mutual coverage
+is an equivalence relation; that holds for exact/full coverage
+and must be pinned against the code, and partial overlap (the
+`some_overlap` bucket) remains its own pathology entirely outside
+this framework. Second, an environmental fact about targets: code
+formatters relocate comments, so annotations can land on lines the
+author did not choose — same-target collisions can be tooling
+artifacts. This informs error-message wording ("these may have
+been moved together"), never verdicts; the remediation always
+exists.
+
+One engine fact the type rules below depend on, stated as fact
+because the checks implement it: **an `exception` or `implication`
+covering a requirement exempts that requirement from the test
+obligation** (the implementation and test checks in the query
+engine). A free claim form does not merely coexist with a priced
+one — it rewrites the obligations of the entire requirement.
 
 ## The governing principle
 
 > **Duplicates are permissible exactly where a coverage check has
 > the means to disambiguate them. Where no check can tell two
 > copies apart, they must be unique.**
-
-Applied per-type, this yields the table in
-[Decision 3](#decision-3). Applied per-instance, it yields the
-distinctness rule in [Decision 5](#decision-5): two copies whose
-delivered evidence is identical were not, in fact, disambiguated —
-regardless of what their declarations say.
 
 The corollary invariant, which every decision below preserves:
 
@@ -54,12 +103,11 @@ an annotation costs a distinct, passing verification artifact.
 
 ## Vocabulary
 
-- **Duplicate set** — a maximal set of same-type annotations whose
-  quotes mutually cover each other on the same section. Computed
-  by the existing classification (`classify_annotation_coverage`
-  of a type against itself).
-- **Resolved target** — the target line an annotation resolves to
-  (`resolve_target_line`); the position the binding model scores.
+- **Duplicate set** — a maximal claim class restricted to one
+  type: same-type annotations whose quotes mutually cover each
+  other on the same section. Computed by the existing
+  classification (`classify_annotation_coverage` of a type
+  against itself).
 - **Witness (w), binds(T, w), witnesses_for(T), discharged(T, I)**
   — as defined in `design/witness/spec.md` §1.5–1.6. In
   particular discharge quantifies **universally** over bound
@@ -67,8 +115,7 @@ an annotation costs a distinct, passing verification artifact.
   implementation. Witness multiplicity is a conjunction of
   obligations, not a tolerance — the model this document extends
   to annotation multiplicity.
-- **Cap** — the per-type maximum duplicate-set size
-  ([Decision 1](#decision-1)).
+- **Cap** — a configured per-type maximum duplicate-set size.
 
 ---
 
@@ -77,7 +124,7 @@ an annotation costs a distinct, passing verification artifact.
 **Context:** How does a user opt into allowing duplicates, and how
 is the legacy strict behavior preserved?
 
-### Option A: A mode flag (`--allow-duplicates`, old/new behavior versions)
+### Option A: A mode flag (allow-duplicates, old/new behavior versions)
 
 - Con: a binary gate admits unbounded multiplicity the moment it
   opens.
@@ -85,52 +132,72 @@ is the legacy strict behavior preserved?
 
 ### Option B: Per-type numeric caps, default 1
 
-`--max-duplicates <TYPE=N>` (repeatable), e.g.
-`--max-duplicates test=2`. Only `test` and `implementation` may be
-raised ([Decision 3](#decision-3)). Default for every type is 1.
+A configured value per type, e.g. `test = 2`. Only `test` and
+`implementation` may be raised; the per-type verdicts are settled
+two decisions below. Default for every type is 1. Where
+configuration lives — file, flag, or both — is left open here and
+settled once all the policy values this document accumulates are
+on the table.
 
 - Pro: at cap 1 the check is bit-for-bit the historical strict
   check (Property [P-D3](#properties)). Nothing loosens until a
   user writes a bigger number, and that number is visible in
-  config review.
+  review.
 - Pro: the cap bounds proliferation even when every copy carries
   valid evidence — call-graph spray ("MUST foo" on the function,
   its caller, the caller's caller…) loses even when all sites
   execute.
 - Pro: per-type control matches reality: the motivating case is
-  test-type (`test=2`, proof + PBT); implementation duplication
-  has no accepted motivating case
-  ([Rejected: multi-path](#rejected-multi-path)).
+  test-type (`test = 2`, proof + PBT); implementation duplication
+  has no accepted motivating case — the one candidate dissolves
+  under inspection, recorded at the end of this document.
 
 ### Decision: Option B
 
 **Consequences:** Raising a cap is an explicit, audited decision.
 The duplicates report lists every allowed duplicate set with its
 size and member locations, so multiplicity is always surfaced,
-never silent. Cap semantics are monotone
-([P-D4](#properties)): raising N never flips a passing project to
-failing.
+never silent. Cap semantics are monotone ([P-D4](#properties)):
+raising N never flips a passing project to failing.
 
 ---
 
-## Decision 2: Same-resolved-target duplicates always fail {#decision-2}
+## Decision 2: Same claim, same target — always fails, for every type pair {#decision-2}
 
-**Context:** Copies stacked at the same location — five identical
-`//=` blocks above one function — resolve to the same target line.
+**Context:** Copies stacked at the same location: five identical
+`//=` blocks above one function — or a `test` and an
+`implementation` annotation carrying the same quote on the same
+line.
 
-**Decision:** Two same-type duplicates with the same resolved
-target FAIL the duplicates check unconditionally, regardless of
-cap. No evidence can ever distinguish two annotations at one
-location: binding is a function of the resolved target, so their
-witness sets are identical by construction. This is the statically
-visible shadow of [Decision 5](#decision-5)'s evidential rule —
-the fragment decidable without running anything.
+**Decision:** Two annotations with the same claim and the same
+resolved target FAIL the duplicates check unconditionally,
+regardless of cap and **regardless of type**. The rule is
+overdetermined:
+
+1. **Indistinguishability.** Binding is a function of the resolved
+   target, so the two annotations' witness sets are identical by
+   construction. No evidence that could ever arrive can tell them
+   apart. This argument never mentions types; restricting the rule
+   to same-type pairs would be an accident of the current
+   classification, not a decision.
+2. **Co-located claim forms are incoherent.** "This artifact tests
+   R" ∧ "this artifact implements R" at one position is the
+   definition of an `implication` spelled out in two annotations;
+   "we don't do R" ∧ anything-else-about-R is a contradiction
+   wherever it sits.
+
+**Consequences:** The failure message is keyed to the pair —
+same-type: "collapse to one"; `test`+`implementation`: "did you
+mean one `implication`?"; `exception`+anything: "these contradict;
+pick one."
 
 "Same location" is defined as **same resolved target**, not same
 source line: stacked copies above one statement collapse to one
 target and die here; copies scattered through a function body
 resolve to different targets and are governed by the cap and by
-[Decision 5](#decision-5).
+the evidential rule stated later — indistinguishability decidable
+only once evidence arrives. This decision is that rule's
+statically decidable fragment.
 
 ---
 
@@ -138,12 +205,14 @@ resolve to different targets and are governed by the cap and by
 
 **Context:** Which annotation types can ever justify duplicates?
 
-Applying the governing principle per-type:
+Applying the governing principle per-type — the cap may be raised
+exactly where the pricing table gives a coverage check some
+perspective on each copy:
 
 | Type | Coverage-check perspective | Duplicate verdict |
 |---|---|---|
 | `test` | witnessed + discharged (W6, §1.6) | cap may be raised |
-| `implementation` | executed under covering tests' witnesses | cap may be raised |
+| `implementation` | executed under covering tests | cap may be raised |
 | `spec` | none | unique, always |
 | `todo` | none — and a todo-covered requirement already fails the implementation check, so a duplicate todo is noise on a fail | unique, always |
 | `exception` | none — a declaration of absence has nothing to execute or prove | unique, always |
@@ -168,7 +237,63 @@ document.
 
 ---
 
-## Decision 4: No inter-check plumbing — independent contracts {#decision-4}
+## Decision 4: Free claim forms are exclusive within a claim class {#decision-4}
+
+**Context:** [Decision 2](#decision-2) handles mixed types at one
+position. What about mixed types across positions — an `exception`
+and a `test` for the same requirement, an `implication` alongside
+an `implementation`? Today the duplicates check is same-type-only
+and never sees these coexistences.
+
+The engine fact from [the formal space](#formal-space) makes this
+urgent rather than cosmetic: an `exception` or `implication`
+exempts its requirement from the test obligation. So a free form
+added *next to* an existing priced form silently deflates the
+priced form's obligations — an LLM (or a tired human) that learns
+"tests need witnesses and implementations must execute" also
+learns that `implication` requires nothing. Type-shopping is the
+gate-evasion strategy the pricing table predicts, and the free
+forms are its escape valve. A per-target rule cannot catch it: an
+`exception`'s position is incidental, so it evades any co-location
+check by sitting anywhere else.
+
+**Decision:** Within one claim class, the free claim forms are
+exclusive; the priced forms are combinable:
+
+> If a claim class contains an `exception`, `implication`, or
+> `todo` annotation, that annotation must be the **only** member
+> of the class. Any combination of `test` and `implementation`
+> members is permitted, each billed on its own.
+
+Checking this against every pair it derives — no pair-by-pair
+metaphysics needed:
+
+| Coexistence (same claim) | Reading | Verdict under the rule |
+|---|---|---|
+| `exception` + `test` | "we don't do R" ∧ "we test R" | fail — contradiction |
+| `exception` + `implementation` | "we don't do R" ∧ "R is implemented here" | fail — contradiction |
+| `implication` + `implementation` | "R holds by construction" ∧ "R is enforced here, bill it" | fail — the exemption would silently unbill the implementation |
+| `implication` + `test` | "not checkable by evidence" ∧ "tested" | fail — incompatible claims about R's nature |
+| `todo` + `implementation` | "not yet done" ∧ "done here" | fail — and todo→implementation is the intended *lifecycle*: the todo is replaced, not joined; exclusivity enforces exactly that |
+| `test` + `implementation` (different targets) | tested there, implemented here | permitted — this is `discharged(T, I)`, the system itself |
+
+The uniform rationale: **a free form asserts something about the
+requirement's nature that changes everyone's obligations, so it
+does not get to share the claim with forms whose obligations it
+would deflate.**
+
+**Consequences:** This is a static check over claim classes — no
+evidence needed; it belongs to the duplicates check. It is a
+deliberate tightening of released behavior: cross-type
+coexistence on one requirement silently passes today. How the
+tightening ships, and how a project that believes it has a
+legitimate coexistence records that belief, are settled below once
+all policy values are on the table — the short answer is a
+reviewed config line, never a comment.
+
+---
+
+## Decision 5: No inter-check plumbing — independent contracts {#decision-5}
 
 **Context:** When the duplicates check passes a within-cap
 duplicate set, how does the evidence obligation reach the coverage
@@ -181,18 +306,18 @@ fails them if no coverage check runs in the same invocation.
 
 - Con: couples the checks; a check's verdict depends on which
   other checks were requested.
-- Con: complicates command-line composition for no guarantee the
-  independent design doesn't already provide.
+- Con: complicates composition for no guarantee the independent
+  design doesn't already provide.
 
 ### Option B: Independent contracts
 
-The duplicates check enforces structure only (Decisions 1–3): run
+The duplicates check enforces structure only (Decisions 1–4): run
 alone, a within-cap duplicate set **passes**, with its size and
 members surfaced in the report. The coverage check enforces
-evidence (Decision 5) natively and unconditionally — whether or
-not the duplicates check ever runs. Run the full report and the
-composition just works; run one check and you get exactly that
-check's guarantee.
+evidence natively and unconditionally — whether or not the
+duplicates check ever runs (the next decision states the
+evidential rule). Run the full report and the composition just
+works; run one check and you get exactly that check's guarantee.
 
 ### Decision: Option B
 
@@ -202,21 +327,20 @@ its two scoping conditions stated so nobody over-reads it:
 1. For **test** duplicates, the full coverage check alone
    dominates: every copy is an independent T — unwitnessed → W6
    fail; witnessed → per-pair ∀w billing; evidentially identical →
-   [Decision 5](#decision-5) fail.
+   the distinctness failure defined next.
 2. For **implementation** duplicates, coverage dominates the
-   *duplicate-specific* badness only. A citation on a quote no
-   test covers is invisible to coverage — but so is a single such
-   citation. That gap is the test check's job; the division of
-   labor is unchanged.
+   *duplicate-specific* badness only. An implementation annotation
+   on a quote no test covers is invisible to coverage — but so is
+   a single such annotation. That gap is the test check's job; the
+   division of labor is unchanged.
 
 The one composition gap, documented rather than plumbed: a project
 that raises a cap and never runs coverage holds unbilled
-duplicates. The report wording points at
-`--check duplicates,coverage`.
+duplicates. The report wording points at running both checks.
 
 ---
 
-## Decision 5: Coverage fails evidentially indistinct duplicates (W8) {#decision-5}
+## Decision 6: Coverage fails evidentially indistinct duplicates (W8) {#decision-6}
 
 **Context:** Per-instance discharge (W6 + pair billing) is already
 enforced by the coverage check for every duplicate copy — each is
@@ -226,37 +350,49 @@ both answer "do you have evidence?" by pointing at the same
 evidence, and both pass. The current machinery interrogates each
 annotation separately and never notices the evidence is one unit.
 
-**Decision:** The coverage check fails any duplicate set
-containing two members with identical bound witness sets:
+**Decision:** Within each claim class, the coverage check
+partitions the same-type test members by their bound witness set.
+**Every group of size ≥ 2 fails** — those members are mutually
+indistinguishable. Singleton groups pass.
 
-```
-indistinct(A, B)  ⟺  witnesses_for(A) = witnesses_for(B)
-```
+Property **W8 (evidential distinctness):** coverage PASS requires
+that no two same-type mutually-covering test annotations bind the
+same witness set.
 
-Property **W8 (pairwise distinctness):** coverage PASS requires
-every same-type mutually-covering pair (A, B) of test annotations
-to satisfy `witnesses_for(A) ≠ witnesses_for(B)`.
+Two precisions the formulation carries deliberately:
+
+- **Distinct means unequal, never disjoint.** Two sets may share
+  witnesses and still be distinct: `{extent, e₁} ≠ {extent, e₂}`
+  passes. Requiring disjointness would fail legitimate structure.
+- **The verdict attaches to the indistinguishable group, not the
+  class.** If A and B bind identically but C binds differently, A
+  and B fail together and C is untouched. Coverage can prove the
+  group mutually vacuous but cannot pick the canonical member; a
+  human collapses it. (Implementation shape follows: group by
+  witness set and flag collisions — linear, no pairwise walk.)
 
 This is the governing principle applied per-instance: identical
 witness sets mean the tool provably cannot tell the copies apart —
-disambiguation did not happen in fact. The verdict is on the
-**set**: coverage can prove the copies mutually vacuous but cannot
-pick the canonical one; a human collapses them.
+disambiguation did not happen in fact.
+[Decision 2](#decision-2)'s same-target rule is exactly this
+rule's statically decidable shadow: same target implies identical
+sets by construction, but not conversely — positions that always
+execute together are positionally distinct and evidentially
+identical, and only this rule sees them.
 
 **Consequences:**
 
 - The constructions this catches: N copies scattered through one
   test function (all bind that test's witnesses identically); two
   real tests under one merged suite report (both bind the single
-  fat witness — see [Decision 6](#decision-6) for why failing this
-  is correct); two test annotations inside one Verus discharge
-  unit.
+  fat witness — the next decision establishes why failing this is
+  correct); two test annotations inside one Verus discharge unit.
 - The constructions this admits: proof + PBT (`{w_verus}` vs
   `{w_jacoco}`); two tests with per-test reports; two test
   annotations on two different `ensures` clauses of one Verus
   function (distinct clause units → distinct sets — the artifact
   records a span per clause, so cross-clause copies were never
-  identical). The same-citation-on-two-ensures case is admitted
+  identical). The same-claim-on-two-ensures case is admitted
   deliberately: two separately recorded prover obligations are two
   units of evidence. Edgy; pinned by fixture; reopen if dogfooding
   says otherwise.
@@ -266,22 +402,21 @@ pick the canonical one; a human collapses them.
   `{w₁, w₂} = {w₁, w₂}`, still indistinct. Evidence cannot be
   photocopied into distinctness.
 - Implementation surface is additive: the check already computes
-  `bound_witnesses` per test; the new work is grouping duplicate
-  classes and comparing sets, one new result bucket, one status
-  conjunct. Per the engine-glue requirement, the W8 verdict flows
-  through a verified-layer predicate (set equality over the
-  existing `binds` cells) with an exactness proof: report groups
-  A and B ⟺ `witnesses_for(A) = witnesses_for(B)`.
-- Citation-side distinctness (comparing execution profiles of
-  implementation copies) is deferred to a follow-up; tests are
+  `bound_witnesses` per test; the new work is grouping, one new
+  result bucket, one status conjunct. Per the engine-glue
+  requirement, the W8 verdict flows through a verified-layer
+  predicate (set equality over the existing `binds` cells) with an
+  exactness proof: members grouped ⟺ witness sets equal.
+- Implementation-side distinctness (comparing execution profiles
+  of implementation copies) is deferred to a follow-up; tests are
   where the motivating case lives.
 
 ---
 
-## Decision 6: Evidence units come from the artifact, never from inference {#decision-6}
+## Decision 7: Evidence units come from the artifact, never from inference {#decision-7}
 
 **Context:** Under one merged runtime report, two genuinely
-different tests carrying the same citation bind identical witness
+different tests carrying the same claim bind identical witness
 sets and fail W8. Could duvet subdivide the report — e.g. by "the
 test function the annotation sits in," using the classifier's
 scope tree — to tell them apart?
@@ -323,9 +458,18 @@ allowed duplicates; finer evidence buys more. This is the
 monotonicity invariant surfacing as an incentive, and it fails
 toward strictness at every granularity.
 
+The same principle closes a tempting idea in the other direction,
+which returns when the document reaches the target axis: within
+one evidence unit there is **no execution gradient** — an
+annotation on a function head and an annotation on the exact
+enforcing line inside it bind identically under every witness that
+runs the function. No evidence-side analysis can grade *placement
+precision*; only the artifact's own structure (prover clause
+spans) ever subdivides a unit.
+
 ---
 
-## Decision 7: Executed-coverage mode carries no duplicate guarantees {#decision-7}
+## Decision 8: Executed-coverage mode carries no duplicate guarantees {#decision-8}
 
 **Context:** `executed-coverage` skips `NotExecuted` tests by
 design — it is the tight inner loop (run one test in seconds, not
@@ -341,18 +485,172 @@ that resolve to nothing has no refuge here either.)
 
 ---
 
-## Decision 8: Release posture {#decision-8}
+## Decision 9: Duplicate targets — the fan-in axis {#decision-9}
+
+**Context:** Everything above polices coincidence of **claims**.
+The formal space has a second coordinate, and it collides too:
+many annotations with *different* claims all resolving to one
+target — four, five, twelve annotations stacked on a single
+function. Seen frequently in real usage, characteristically from
+LLM sessions. The full matrix:
+
+| | same target | different targets |
+|---|---|---|
+| same claim | dead — [Decision 2](#decision-2) | duplicate set — cap + W8 |
+| different claims | **duplicate target (this decision)** | normal |
+
+This is duplication of the *other* coordinate — not a duplicated
+annotation but a **duplicated target**: fan-in where the cap
+bounds fan-out. The duality is exact: a claim with many targets is
+one thing said in many places; a target with many claims is many
+things said in one place.
+
+**Why it is not a correctness failure.** The evidence layer does
+not collapse here the way it does for true duplicates: stacked
+annotations share witness sets, but each claim's discharge runs
+through *different* covering pairs, so every claim is individually
+billed. The governing principle does not force a failure — these
+claims are disambiguated, by quote and by pair verdict. And the
+legitimate population is large: parsers and validators genuinely
+implementing many MUSTs from one section are real, common code.
+
+**Why it still smells.** The position is doing no work. The
+annotation's position *is* part of its claim, and twelve claims on
+one target mean position discriminates nothing — the stack is
+informationally one comment saying "this function does §3." Costs:
+lazy placement (citing the function head instead of the enforcing
+lines, losing per-claim precision — on the prover side, the
+difference between binding the extent and binding the clause
+unit); rot amplification (a refactor re-homes twelve claims as one
+careless block); and annotation dumping — spray rotated ninety
+degrees. Per [Decision 7](#decision-7), no evidence-side analysis
+can distinguish a well-placed stack from a lazy one within a unit,
+so the tools here are static, and their bounds are policy rather
+than correctness.
+
+An asymmetry recorded for the follow-up on diagnostics: test-side
+fan-in resolves cleanly through per-pair billing. Implementation-
+side fan-in is the commonly observed shape, and a dumped
+implementation annotation has a stranger property: it forces every
+test citing that requirement to execute the dumped-on function, so
+**the dump surfaces as failures on innocent test annotations, far
+from the cause**. The evidence layer pushes back, but with poor
+diagnostic locality.
+
+**Decision, in three parts:**
+
+1. **A query, not (by default) a gate.** A `duplicate-targets`
+   query lists every target bearing more than one annotation,
+   sorted by count descending, with per-target type breakdown and
+   distinct-section count. No verdict — a sorted list needs no
+   threshold and no false-positive story; the human reads the top.
+   Even inspection output owes an exactness obligation: a target
+   appears iff ≥ 2 annotations resolve to it, with exact counts
+   (P-T1 in the property list). The section count is a triage
+   column, not a discriminator: `count=12 sections=1` reads "dense
+   but coherent"; `count=12 sections=8` reads "look here first."
+2. **Snapshot inclusion is the ratchet.** When the table lands in
+   the snapshot, the PR that adds a sixth annotation to a crowded
+   target surfaces as a snapshot diff in review — concentration
+   becomes visible at the moment it grows, with no gate. This is
+   the same posture as "raising a cap is visible in review."
+3. **Opt-in bounds for teams that want the bite**, all default
+   unlimited: `count` (max annotations per target), `sections`
+   (max distinct sections per target), `types` (max distinct claim
+   forms per target). These are the first bounds in this document
+   that fail code for a *smell* rather than a violated evidence
+   property — the entry price of the fan-in axis, named honestly:
+   teams opt into the opinion.
+
+**Mixed claim forms on one target** deserve their own default. A
+position claimed as a test of R1 and an implementation of R2 means
+one artifact is simultaneously test code and implementation code —
+disjoint populations in every codebase we care about. The one
+honest construction is the meta-requirement ("implementations MUST
+validate the test vectors in Appendix A" — the test function that
+runs them *is* that requirement's implementation while *testing*
+the object-level ones). Even there, nothing requires target
+*identity*: the reviewer wants the two annotations close, and
+close is not identical. Default: `test`+`implementation` on one
+target fails; the Appendix-A team relaxes that default and owns
+the decision in review. Where such relaxations are recorded — and
+where all the policy values this document has accumulated live —
+is the next decision.
+
+---
+
+## Decision 10: Policy lives in configuration, not on the command line {#decision-10}
+
+**Context:** The decisions above accumulate policy values — caps
+(Decision 1), coherence cells (Decision 4), fan-in bounds and the
+mixed-form default (Decision 9). Where do they live?
+
+### Option A: CLI flags, possibly mirrored in config
+
+- Con: a verification gate whose semantics vary per invocation is
+  not a gate. Two people running the same commit could get
+  different verdicts; CI and local runs drift.
+- Con: the project's effective policy is reconstructable only from
+  scripts, not readable from the tree.
+
+### Option B: Configuration file only
+
+All policy is checked-in configuration. The shipped defaults
+encode this document's verdicts; a project overrides individual
+cells; omitted cells take the defaults.
+
+```toml
+[duplicates]
+max-duplicates = { test = 2 }          # Decision 1; default: all 1
+# max-target   = { count = 5, sections = 3, types = 1 }   # Decision 9; default: unlimited
+# policy cells (Decision 4, Decision 9), shipped defaults shown:
+# "exception+test.same-claim"          = "fail"
+# "implication+implementation.same-claim" = "fail"
+# "test+implementation.same-target"    = "fail"
+```
+
+### Decision: Option B
+
+The principle: **the verdict is a function of the checked-in tree,
+not of the invocation.** The command line selects which checks
+run, points at evidence artifacts (inputs, not semantics), and
+controls verbosity — display, never verdict.
+
+**Consequences:**
+
+- The discovery loop replaces flag experimentation: run the check
+  verbose, see every group, every default, every below-threshold
+  case; write the numbers you want into config; from then on the
+  run is silent about everything you have accepted.
+- Cell overrides are **rule-level policy declarations**, audited
+  in review — a different thing from the per-instance waiver
+  rejected in the governing principle. That door stays closed.
+- Default changes become survivable: when a shipped default
+  flips, release notes say "pin the old cell to keep prior
+  behavior" — one config line, and the compatibility question gets
+  a structural answer instead of a per-feature negotiation.
+- The whole effective policy of a project is one readable section
+  of one checked-in file.
+
+---
+
+## Decision 11: Release posture {#decision-11}
 
 **Context:** Executed (runtime) coverage has shipped; proof
-coverage has not. W8 changes the coverage verdict on inputs
-containing indistinct duplicate pairs — a loosened-then-tightened
-release sequence would break released behavior.
+coverage has not. Two behavior changes are on the table: W8
+([Decision 6](#decision-6)) changes the coverage verdict on inputs
+containing indistinct duplicate pairs, and type coherence
+([Decision 4](#decision-4)) makes the duplicates check fail
+cross-type coexistences that silently pass today.
 
 **Decision:** W8 ships **in the same release as proof coverage**,
-while the executed-coverage install base is effectively one user.
-No compatibility flag: a `--no-duplicate-distinctness` switch is a
-waiver-by-declaration, rejected on the same grounds as every other
-waiver in this document.
+while the executed-coverage install base is effectively one user —
+the check simply always had these semantics. Type coherence ships
+as a tightened default with its cells pinnable per
+[Decision 10](#decision-10). No compatibility flags in either
+case: a `--no-distinctness` switch is a waiver-by-declaration,
+rejected on the same grounds as every other waiver in this
+document.
 
 **Consequences:** Enforcement invariance is stated honestly as
 **P-C1′**: the new coverage verdict equals the old on every input
@@ -360,16 +658,20 @@ containing no indistinct duplicate pair; on inputs that do, new
 coverage fails where old passed — and that delta is precisely the
 defect class this feature defines. Both exits from the new failure
 are improvements: collapse the copies (the report lists them) or
-individuate the evidence.
+individuate the evidence. Legacy equivalence for the duplicates
+check ([P-D3](#properties)) is likewise scoped: caps at 1 *and*
+coherence cells at their pre-existing effective values reproduce
+the historical verdict; the shipped coherence defaults are a
+deliberate tightening.
 
 A release-direction note, recorded because we got it wrong once
 while designing this: for a verification gate, **loosening a rule
 (fail→pass) is the dangerous direction** — it silently removes
 protection a customer relied on to block bad states from
 production. Tightening is visible; loosening is invisible until
-the thing it would have caught ships. Any future loosening of W8
-(e.g. reopening scope refinement) carries the same burden as
-removing a check.
+the thing it would have caught ships. Any future loosening —
+reopening scope refinement, relaxing a coherence cell's shipped
+default — carries the same burden as removing a check.
 
 ---
 
@@ -384,11 +686,11 @@ sites" (validate-the-header on both encrypt and decrypt paths).
 **Rejected because the case dissolves under inspection:**
 
 - If the requirement text appears in two spec sections (encrypt's
-  and decrypt's), the two citations are not mutually covering —
+  and decrypt's), the two annotations are not mutually covering —
   **not duplicates at all**; the check never fires.
 - If both sites cite one section, duplicated enforcement logic is
   a factoring smell — hoist the shared validation and place one
-  citation on it.
+  annotation on it.
 - If the same requirement text appears twice within one section,
   that is a malformed spec — a known, separate bug.
 
@@ -408,63 +710,29 @@ W6. Healthy spray only survives where testing is coarse.
 
 ---
 
-## Considered: target congestion — named, not yet decided {#considered-congestion}
+## Considered: the evidence transpose — parked {#considered-transpose}
 
-**Observation:** Many annotations with *different* quotes all
-resolving to one target — four, five, twelve citations stacked on
-a single function. Seen frequently in real usage. It completes the
-matrix this document's decisions live on:
+**Considered:** Reading the discharge matrix column-wise — per
+implementation site, the set of witnesses that execute it. A site
+executed by *every* delivered witness has a constant column:
+`discharged(T, I)` is then trivially satisfiable by any test, so
+the claim "R is implemented here" is unfalsifiable by execution
+evidence. This would flag **hot-path dumping** — an implementation
+annotation placed on always-executed code (setup, dispatch,
+`main`) discharges against everything and evades both the static
+fan-in view and pair billing.
 
-| | same target | different targets |
-|---|---|---|
-| same quote | dead — [Decision 2](#decision-2) | duplicate set — cap + W8 |
-| different quotes | **congestion (this section)** | normal |
-
-**This is not a duplicate.** A duplicate is the same claim
-repeated (redundancy); congestion is many different claims
-concentrated on one artifact (fan-in). The evidence layer does not
-collapse: stacked test annotations share witness sets, but each
-claim's discharge runs through a *different* covering
-implementation, so every claim is individually billed. The
-governing principle therefore does not force a failure — these
-claims are disambiguated, by quote and by pair verdict.
-
-**Why it still smells:** the position is doing no work. The
-annotation's position *is* the claim, and twelve claims on one
-target mean position discriminates nothing. Costs: lazy placement
-(citing at the function head instead of the enforcing lines,
-losing per-claim scoring precision — and on the prover side, the
-difference between binding the function extent and binding the
-specific clause unit); rot amplification (a refactor re-homes
-twelve claims as a careless block); and annotation dumping —
-spray rotated ninety degrees, one claim on many places becoming
-many claims on one place.
-
-**An asymmetry worth pulling on later:** test-side congestion
-resolves cleanly (one integration test citing many requirements is
-billed per-pair and either executes each requirement's
-implementation or fails). Implementation-side congestion is the
-commonly observed shape, and dumping there has a stranger
-property: a citation dumped onto an unrelated function forces
-every test citing that requirement to execute that function
-(per-test ∀-aggregation), so **the dumped citation surfaces as
-failures on innocent test annotations, far from the cause**. The
-evidence layer pushes back on impl dumping, but with poor
-diagnostic locality — arguably worse than silence for
-debuggability.
-
-**Current lean, no decision:** report, don't gate. Group by
-resolved target in the duplicates report ("N annotations resolve
-to this target"), optionally a threshold knob, default unlimited —
-unlike the duplicate cap, the legitimate population (parsers,
-validators genuinely implementing many MUSTs) is large, and a
-biting default would fail real projects on code the evidence
-supports. Remediation message: move each annotation to the
-specific line it governs. Since stacking is common and the
-grouping is a trivial second pass over targets the check already
-resolves, this may be a cheap early win; it may also need more
-thought once the impl-dumping diagnostics question is understood.
-Revisit deliberately.
+**Parked, not adopted:** the transpose cannot serve the placement
+question that motivated it — within one evidence unit there is no
+execution gradient ([Decision 7](#decision-7)), so a constant
+column cannot distinguish a lazily-placed annotation from a
+precisely-placed one on a genuinely hot path (a requirement really
+enforced on the universal request path legitimately executes under
+everything). What it *does* measure — which discharge verdicts are
+load-bearing and which are vacuously true — is a different
+question, worth revisiting if hot-path dumping is observed in
+practice. Cost when wanted: a per-site aggregation over cells
+coverage already computes.
 
 ---
 
@@ -474,38 +742,65 @@ Pinned by fixture unless noted; W8's predicate and exactness proof
 live in the verified layer.
 
 - **P-D1 (stacked-spam soundness).** duplicates PASS ⟹ no
-  same-type mutually-covering pair shares a resolved target.
+  mutually-covering pair — any types — shares a resolved target.
 - **P-D2 (uniqueness of non-evidence types).** duplicates PASS ⟹
   every duplicate set of type spec/todo/exception/implication is a
   singleton.
-- **P-D3 (legacy equivalence).** With all caps at 1, the
-  duplicates verdict is identical to the historical check on all
-  inputs. The existing regression fixtures are its test suite,
-  unchanged.
-- **P-D4 (cap monotonicity).** N ≤ N′ ⟹ (PASS at N ⟹ PASS at N′).
+- **P-D3 (scoped legacy equivalence).** With all caps at 1 and
+  coherence cells at pre-existing effective values, the duplicates
+  verdict is identical to the historical check on all inputs. The
+  existing regression fixtures are its test suite, unchanged.
+- **P-D4 (bound monotonicity).** For every configured bound (caps,
+  fan-in bounds): raising it never flips a passing project to
+  failing, lowering it never flips a failing project to passing.
+- **P-D5 (free-form exclusivity).** duplicates PASS ⟹ every claim
+  class containing an exception, implication, or todo annotation
+  is a singleton.
+- **P-T1 (fan-in exactness).** The duplicate-targets listing
+  contains a target iff ≥ 2 annotations resolve to it; counts,
+  type breakdowns, and section counts are exact.
 - **P-C1′ (scoped enforcement invariance).** New coverage verdict
   ≡ old on every input with no indistinct duplicate pair.
 - **P-C2 (per-instance billing).** coverage PASS ⟹ every in-scope
   test annotation, duplicate or not, is witnessed and discharges
   against every covering implementation. (Already true — W6 plus
-  the per-test aggregation; stated so deferral is visibly safe.)
-- **W8 (pairwise distinctness).** coverage PASS ⟹ every same-type
-  mutually-covering test-annotation pair has distinct bound
-  witness sets. Verified-layer predicate; exactness: grouped ⟺
-  sets equal.
+  the per-test aggregation; stated so independence is visibly
+  safe.)
+- **W8 (evidential distinctness).** coverage PASS ⟹ within every
+  claim class, no witness-set group of same-type test members has
+  size ≥ 2. Verified-layer predicate; exactness: grouped ⟺ sets
+  equal. Distinct means unequal, not disjoint.
+- **P-S0 (verdict determinism).** For a fixed set of checks and
+  evidence inputs, the verdict is a function of the checked-in
+  tree (source + config). Verbosity never changes a verdict.
 - **P-S1 (no pass without evidence).** duplicates PASS ∧ coverage
   PASS ⟹ every duplicate copy resolves to a distinct target, every
-  set is within cap, every copy is individually billed, and every
-  pair is evidentially distinct.
+  set is within cap, every claim class is type-coherent, every
+  copy is individually billed, and every pair is evidentially
+  distinct.
 
 ## Follow-ups
 
+- Verify against the engine: the exact control flow by which
+  exception/implication exempt the test obligation (implementation
+  and test checks), so P-D5's fixture set covers the real paths;
+  and that exact/full mutual coverage is transitive, so claim
+  classes are well-defined.
 - Integration fixtures: same-test-fn pair (fail W8); split-test
   pair with per-test reports (pass); fat-report distinct-tests
   pair (fail W8); duplicated-report pair (fail W8); Verus
   same-ensures pair (fail) and cross-ensures pair (pass);
   specificity-boundary binding (annotation on fn header vs inside
-  clause spans); cap fixtures at N=1 (legacy parity) and N=2.
-- Citation-side distinctness (execution profiles) — own follow-up.
-- `--max-duplicates` CLI + config plumbing and help text.
+  clause spans); cap fixtures at N=1 (legacy parity) and N=2;
+  coherence fixtures per row of the Decision 4 table; fan-in
+  listing exactness; mixed-form target default.
+- Config schema (`[duplicates]` section): caps, fan-in bounds,
+  policy cells, shipped defaults.
+- `duplicate-targets` query, then snapshot inclusion once the
+  format stabilizes.
+- Implementation-side distinctness (execution profiles) — own
+  follow-up.
 - Implication duplicates — rider on self-discharging implications.
+- Impl-dump diagnostic locality (pointing failures at the dumped
+  annotation rather than the innocent tests) — revisit with the
+  transpose observation if hot-path dumping is observed.

--- a/design/duplicates/decisions.md
+++ b/design/duplicates/decisions.md
@@ -1,0 +1,451 @@
+# Duplicate Annotations — Decisions
+
+**Status:** Decisions 1–8 proposed, not yet implemented.
+References to `design/witness/` are forward references to the
+witness-coverage work (in flight, not yet on `main`).
+
+## Context
+
+The duplicates check today classifies each annotation type against
+itself: two same-type annotations whose quotes mutually cover each
+other on the same section land in the `duplicates` bucket and the
+check hard-FAILs. There is no escape hatch.
+
+That default is right far more often than it is wrong. Duplicate
+annotations are usually spray: copies accumulate ("one over here,
+and over here, and over here"), nobody cleans them up, and each
+copy is a claim with no additional substance. The failure mode is
+cheap to create — especially for an LLM emitting annotations — and
+expensive to unwind.
+
+But it is not *never* right to duplicate. The motivating case: an
+implementation annotation whose requirement is evidenced twice —
+a test annotation on a Verus proof, and a second test annotation on
+an executed property-based test. Binding is positional, so one
+annotation physically cannot sit on both artifacts. Two evidence
+artifacts structurally force two annotations, and the duplicates
+check punishes exactly the behavior we want to encourage.
+
+This document decides how to admit that case without opening the
+spray door.
+
+## The governing principle
+
+> **Duplicates are permissible exactly where a coverage check has
+> the means to disambiguate them. Where no check can tell two
+> copies apart, they must be unique.**
+
+Applied per-type, this yields the table in
+[Decision 3](#decision-3). Applied per-instance, it yields the
+distinctness rule in [Decision 5](#decision-5): two copies whose
+delivered evidence is identical were not, in fact, disambiguated —
+regardless of what their declarations say.
+
+The corollary invariant, which every decision below preserves:
+
+> **More information about annotations can justify a duplicate;
+> less information never can. There is no path to PASS that does
+> not go through evidence.**
+
+A waiver marker (`duplicate-ok=reason`) was considered and
+rejected at the outset: a declaration is exactly as cheap to spray
+as the annotation it excuses. Under these decisions, duplicating
+an annotation costs a distinct, passing verification artifact.
+
+## Vocabulary
+
+- **Duplicate set** — a maximal set of same-type annotations whose
+  quotes mutually cover each other on the same section. Computed
+  by the existing classification (`classify_annotation_coverage`
+  of a type against itself).
+- **Resolved target** — the target line an annotation resolves to
+  (`resolve_target_line`); the position the binding model scores.
+- **Witness (w), binds(T, w), witnesses_for(T), discharged(T, I)**
+  — as defined in `design/witness/spec.md` §1.5–1.6. In
+  particular discharge quantifies **universally** over bound
+  witnesses: every witness a test binds must execute the
+  implementation. Witness multiplicity is a conjunction of
+  obligations, not a tolerance — the model this document extends
+  to annotation multiplicity.
+- **Cap** — the per-type maximum duplicate-set size
+  ([Decision 1](#decision-1)).
+
+---
+
+## Decision 1: Per-type caps are the sole enablement switch {#decision-1}
+
+**Context:** How does a user opt into allowing duplicates, and how
+is the legacy strict behavior preserved?
+
+### Option A: A mode flag (`--allow-duplicates`, old/new behavior versions)
+
+- Con: a binary gate admits unbounded multiplicity the moment it
+  opens.
+- Con: mode flags fork the check's semantics permanently.
+
+### Option B: Per-type numeric caps, default 1
+
+`--max-duplicates <TYPE=N>` (repeatable), e.g.
+`--max-duplicates test=2`. Only `test` and `implementation` may be
+raised ([Decision 3](#decision-3)). Default for every type is 1.
+
+- Pro: at cap 1 the check is bit-for-bit the historical strict
+  check (Property [P-D3](#properties)). Nothing loosens until a
+  user writes a bigger number, and that number is visible in
+  config review.
+- Pro: the cap bounds proliferation even when every copy carries
+  valid evidence — call-graph spray ("MUST foo" on the function,
+  its caller, the caller's caller…) loses even when all sites
+  execute.
+- Pro: per-type control matches reality: the motivating case is
+  test-type (`test=2`, proof + PBT); implementation duplication
+  has no accepted motivating case
+  ([Rejected: multi-path](#rejected-multi-path)).
+
+### Decision: Option B
+
+**Consequences:** Raising a cap is an explicit, audited decision.
+The duplicates report lists every allowed duplicate set with its
+size and member locations, so multiplicity is always surfaced,
+never silent. Cap semantics are monotone
+([P-D4](#properties)): raising N never flips a passing project to
+failing.
+
+---
+
+## Decision 2: Same-resolved-target duplicates always fail {#decision-2}
+
+**Context:** Copies stacked at the same location — five identical
+`//=` blocks above one function — resolve to the same target line.
+
+**Decision:** Two same-type duplicates with the same resolved
+target FAIL the duplicates check unconditionally, regardless of
+cap. No evidence can ever distinguish two annotations at one
+location: binding is a function of the resolved target, so their
+witness sets are identical by construction. This is the statically
+visible shadow of [Decision 5](#decision-5)'s evidential rule —
+the fragment decidable without running anything.
+
+"Same location" is defined as **same resolved target**, not same
+source line: stacked copies above one statement collapse to one
+target and die here; copies scattered through a function body
+resolve to different targets and are governed by the cap and by
+[Decision 5](#decision-5).
+
+---
+
+## Decision 3: Per-type permissibility {#decision-3}
+
+**Context:** Which annotation types can ever justify duplicates?
+
+Applying the governing principle per-type:
+
+| Type | Coverage-check perspective | Duplicate verdict |
+|---|---|---|
+| `test` | witnessed + discharged (W6, §1.6) | cap may be raised |
+| `implementation` | executed under covering tests' witnesses | cap may be raised |
+| `spec` | none | unique, always |
+| `todo` | none — and a todo-covered requirement already fails the implementation check, so a duplicate todo is noise on a fail | unique, always |
+| `exception` | none — a declaration of absence has nothing to execute or prove | unique, always |
+| `implication` | none **today** | unique **today**; see below |
+
+**Implication is its own animal.** An exception's position is
+incidental; an implication's position is the claim ("*this
+artifact* is correct by construction"). Structurally it patterns
+with `implementation`, not with `exception`. What forces
+uniqueness today is the evidence question: implications carry no
+checkable obligation, and the proof-world answer (self-discharging
+implications, where a verifier's elaboration is the implication's
+own evidence) was deliberately deferred in the witness design
+("Option B: self-discharging implications" — nobody can state the
+discharge obligation precisely yet). Runtime execution of an
+implication's position is evidence about the wrong property: it
+shows liveness, not construction.
+
+**Decision:** unique today; revisit as a rider on the
+self-discharging-implications feature, which owns its own decision
+document.
+
+---
+
+## Decision 4: No inter-check plumbing — independent contracts {#decision-4}
+
+**Context:** When the duplicates check passes a within-cap
+duplicate set, how does the evidence obligation reach the coverage
+check?
+
+### Option A: Deferred-status plumbing
+
+The duplicates check emits `deferred` items; the query engine
+fails them if no coverage check runs in the same invocation.
+
+- Con: couples the checks; a check's verdict depends on which
+  other checks were requested.
+- Con: complicates command-line composition for no guarantee the
+  independent design doesn't already provide.
+
+### Option B: Independent contracts
+
+The duplicates check enforces structure only (Decisions 1–3): run
+alone, a within-cap duplicate set **passes**, with its size and
+members surfaced in the report. The coverage check enforces
+evidence (Decision 5) natively and unconditionally — whether or
+not the duplicates check ever runs. Run the full report and the
+composition just works; run one check and you get exactly that
+check's guarantee.
+
+### Decision: Option B
+
+**Consequences:** The domination claim that makes this safe, with
+its two scoping conditions stated so nobody over-reads it:
+
+1. For **test** duplicates, the full coverage check alone
+   dominates: every copy is an independent T — unwitnessed → W6
+   fail; witnessed → per-pair ∀w billing; evidentially identical →
+   [Decision 5](#decision-5) fail.
+2. For **implementation** duplicates, coverage dominates the
+   *duplicate-specific* badness only. A citation on a quote no
+   test covers is invisible to coverage — but so is a single such
+   citation. That gap is the test check's job; the division of
+   labor is unchanged.
+
+The one composition gap, documented rather than plumbed: a project
+that raises a cap and never runs coverage holds unbilled
+duplicates. The report wording points at
+`--check duplicates,coverage`.
+
+---
+
+## Decision 5: Coverage fails evidentially indistinct duplicates (W8) {#decision-5}
+
+**Context:** Per-instance discharge (W6 + pair billing) is already
+enforced by the coverage check for every duplicate copy — each is
+an independent T. What existing correlation does **not** do is
+compare copies *to each other*: two copies in one test function
+both answer "do you have evidence?" by pointing at the same
+evidence, and both pass. The current machinery interrogates each
+annotation separately and never notices the evidence is one unit.
+
+**Decision:** The coverage check fails any duplicate set
+containing two members with identical bound witness sets:
+
+```
+indistinct(A, B)  ⟺  witnesses_for(A) = witnesses_for(B)
+```
+
+Property **W8 (pairwise distinctness):** coverage PASS requires
+every same-type mutually-covering pair (A, B) of test annotations
+to satisfy `witnesses_for(A) ≠ witnesses_for(B)`.
+
+This is the governing principle applied per-instance: identical
+witness sets mean the tool provably cannot tell the copies apart —
+disambiguation did not happen in fact. The verdict is on the
+**set**: coverage can prove the copies mutually vacuous but cannot
+pick the canonical one; a human collapses them.
+
+**Consequences:**
+
+- The constructions this catches: N copies scattered through one
+  test function (all bind that test's witnesses identically); two
+  real tests under one merged suite report (both bind the single
+  fat witness — see [Decision 6](#decision-6) for why failing this
+  is correct); two test annotations inside one Verus discharge
+  unit.
+- The constructions this admits: proof + PBT (`{w_verus}` vs
+  `{w_jacoco}`); two tests with per-test reports; two test
+  annotations on two different `ensures` clauses of one Verus
+  function (distinct clause units → distinct sets — the artifact
+  records a span per clause, so cross-clause copies were never
+  identical). The same-citation-on-two-ensures case is admitted
+  deliberately: two separately recorded prover obligations are two
+  units of evidence. Edgy; pinned by fixture; reopen if dogfooding
+  says otherwise.
+- **Robust to report duplication:** binding is content-determined
+  (`executed_by` reads the coverage map), so delivering one report
+  twice binds both copies identically for *every* annotation —
+  `{w₁, w₂} = {w₁, w₂}`, still indistinct. Evidence cannot be
+  photocopied into distinctness.
+- Implementation surface is additive: the check already computes
+  `bound_witnesses` per test; the new work is grouping duplicate
+  classes and comparing sets, one new result bucket, one status
+  conjunct. Per the engine-glue requirement, the W8 verdict flows
+  through a verified-layer predicate (set equality over the
+  existing `binds` cells) with an exactness proof: report groups
+  A and B ⟺ `witnesses_for(A) = witnesses_for(B)`.
+- Citation-side distinctness (comparing execution profiles of
+  implementation copies) is deferred to a follow-up; tests are
+  where the motivating case lives.
+
+---
+
+## Decision 6: Evidence units come from the artifact, never from inference {#decision-6}
+
+**Context:** Under one merged runtime report, two genuinely
+different tests carrying the same citation bind identical witness
+sets and fail W8. Could duvet subdivide the report — e.g. by "the
+test function the annotation sits in," using the classifier's
+scope tree — to tell them apart?
+
+### Option A: Scope-refined evidence units
+
+Refine the runtime unit from "the report" to (report, executed
+enclosing scope of the annotation's target).
+
+- Con: requires language-specific scope classification plus
+  walk-out-to-enclosing-test logic that does not exist, purchased
+  per language, forever.
+- Con: **the unit it defines is not the discharge unit.** A merged
+  report is a line union; it cannot attribute a helper or
+  implementation line to one test versus another, and without a
+  call graph "test A's run" cannot even be delimited. The only
+  fact scope refinement establishes is "the lines immediately
+  inside this body lit up" — it distinguishes annotation
+  *positions*, not evidence. A distinctness rule built on it
+  proves the wrong thing.
+- Con: contradicts the witness spec's stated posture: runtime
+  individuation is the operator's responsibility ("one
+  instrumented run per test… duvet does not attempt detection").
+
+### Option B: Units are what the artifact records
+
+Verus gets sub-root units because the prover artifact records a
+span per ensures clause, loop invariant, and proof assert. JaCoCo
+records a merged line union and nothing about how it was produced
+— so the unit is the report, and finer units require finer
+artifacts: one instrumented run per test.
+
+### Decision: Option B. Scope refinement is rejected, not deferred.
+
+**Consequences:** The fat-report W8 failure is designed incentive,
+not accident: merged report → indistinguishable duplicates →
+collapse them or individuate your runs. Coarse evidence buys fewer
+allowed duplicates; finer evidence buys more. This is the
+monotonicity invariant surfacing as an incentive, and it fails
+toward strictness at every granularity.
+
+---
+
+## Decision 7: Executed-coverage mode carries no duplicate guarantees {#decision-7}
+
+**Context:** `executed-coverage` skips `NotExecuted` tests by
+design — it is the tight inner loop (run one test in seconds, not
+the suite in minutes). Duplicate copies on tests that did not run
+this invocation are unbilled there.
+
+**Decision:** Out of scope, by intent. The mode is deliberately
+partial for everything; duplicates inherit that partiality exactly
+as broken-but-not-run tests do. The gate is the full coverage
+check. (Unknown-status positions are still billed even in this
+mode — placement errors fail regardless — so spray at positions
+that resolve to nothing has no refuge here either.)
+
+---
+
+## Decision 8: Release posture {#decision-8}
+
+**Context:** Executed (runtime) coverage has shipped; proof
+coverage has not. W8 changes the coverage verdict on inputs
+containing indistinct duplicate pairs — a loosened-then-tightened
+release sequence would break released behavior.
+
+**Decision:** W8 ships **in the same release as proof coverage**,
+while the executed-coverage install base is effectively one user.
+No compatibility flag: a `--no-duplicate-distinctness` switch is a
+waiver-by-declaration, rejected on the same grounds as every other
+waiver in this document.
+
+**Consequences:** Enforcement invariance is stated honestly as
+**P-C1′**: the new coverage verdict equals the old on every input
+containing no indistinct duplicate pair; on inputs that do, new
+coverage fails where old passed — and that delta is precisely the
+defect class this feature defines. Both exits from the new failure
+are improvements: collapse the copies (the report lists them) or
+individuate the evidence.
+
+A release-direction note, recorded because we got it wrong once
+while designing this: for a verification gate, **loosening a rule
+(fail→pass) is the dangerous direction** — it silently removes
+protection a customer relied on to block bad states from
+production. Tightening is visible; loosening is invisible until
+the thing it would have caught ships. Any future loosening of W8
+(e.g. reopening scope refinement) carries the same burden as
+removing a check.
+
+---
+
+## Rejected: multi-path implementation relaxation {#rejected-multi-path}
+
+**Considered:** Weakening coverage's per-test aggregation (a
+witnessed test currently fails if *any* covering implementation
+was not executed by its witnesses) to a duplicate-class-aware
+form, admitting "one requirement genuinely enforced at two call
+sites" (validate-the-header on both encrypt and decrypt paths).
+
+**Rejected because the case dissolves under inspection:**
+
+- If the requirement text appears in two spec sections (encrypt's
+  and decrypt's), the two citations are not mutually covering —
+  **not duplicates at all**; the check never fires.
+- If both sites cite one section, duplicated enforcement logic is
+  a factoring smell — hoist the shared validation and place one
+  citation on it.
+- If the same requirement text appears twice within one section,
+  that is a malformed spec — a known, separate bug.
+
+No surviving instance justified the semantic change. The
+class-aware aggregation sketched during design is a conservative
+extension (identical to current behavior on duplicate-free
+projects), so rejecting now costs nothing if a real case ever
+arrives; it gets its own decision then.
+
+A useful consequence of keeping the strict aggregation, recorded
+here: **call-graph spray is bounded by test granularity.** A
+fine-grained unit test's witnesses cannot execute distant sprayed
+copies, so every copy the test can't reach fails pair discharge.
+The cap bounds spray's count; testing hygiene bounds its spatial
+extent; decay (copies rotting into never-executed) is caught by
+W6. Healthy spray only survives where testing is coarse.
+
+---
+
+## Properties {#properties}
+
+Pinned by fixture unless noted; W8's predicate and exactness proof
+live in the verified layer.
+
+- **P-D1 (stacked-spam soundness).** duplicates PASS ⟹ no
+  same-type mutually-covering pair shares a resolved target.
+- **P-D2 (uniqueness of non-evidence types).** duplicates PASS ⟹
+  every duplicate set of type spec/todo/exception/implication is a
+  singleton.
+- **P-D3 (legacy equivalence).** With all caps at 1, the
+  duplicates verdict is identical to the historical check on all
+  inputs. The existing regression fixtures are its test suite,
+  unchanged.
+- **P-D4 (cap monotonicity).** N ≤ N′ ⟹ (PASS at N ⟹ PASS at N′).
+- **P-C1′ (scoped enforcement invariance).** New coverage verdict
+  ≡ old on every input with no indistinct duplicate pair.
+- **P-C2 (per-instance billing).** coverage PASS ⟹ every in-scope
+  test annotation, duplicate or not, is witnessed and discharges
+  against every covering implementation. (Already true — W6 plus
+  the per-test aggregation; stated so deferral is visibly safe.)
+- **W8 (pairwise distinctness).** coverage PASS ⟹ every same-type
+  mutually-covering test-annotation pair has distinct bound
+  witness sets. Verified-layer predicate; exactness: grouped ⟺
+  sets equal.
+- **P-S1 (no pass without evidence).** duplicates PASS ∧ coverage
+  PASS ⟹ every duplicate copy resolves to a distinct target, every
+  set is within cap, every copy is individually billed, and every
+  pair is evidentially distinct.
+
+## Follow-ups
+
+- Integration fixtures: same-test-fn pair (fail W8); split-test
+  pair with per-test reports (pass); fat-report distinct-tests
+  pair (fail W8); duplicated-report pair (fail W8); Verus
+  same-ensures pair (fail) and cross-ensures pair (pass);
+  specificity-boundary binding (annotation on fn header vs inside
+  clause spans); cap fixtures at N=1 (legacy parity) and N=2.
+- Citation-side distinctness (execution profiles) — own follow-up.
+- `--max-duplicates` CLI + config plumbing and help text.
+- Implication duplicates — rider on self-discharging implications.

--- a/design/duplicates/decisions.md
+++ b/design/duplicates/decisions.md
@@ -294,7 +294,7 @@ decision document.
 
 ---
 
-## Decision 4: Free claim forms are exclusive within a claim class {#decision-4}
+## Decision 4: Claim form combinations are an allowed-set family {#decision-4}
 
 **Context:** [Decision 2](#decision-2) handles mixed types at one
 position. What about mixed types across positions — an `exception`
@@ -331,26 +331,36 @@ incoherent, …).
   pair by pair; a new annotation type multiplies the cells; and
   the matrix invites cell-by-cell relitigating.
 
-### Option C: One exclusivity rule over the type multiset
+### Option C: One allowed-set family over the class's form set
 
-> If a claim class contains an `exception`, `implication`, or
-> `todo` annotation, that annotation must be the **only** member
-> of the class. Any combination of `test` and `implementation`
-> members is permitted, each billed on its own.
+> A claim class whose non-`spec` members bear two or more distinct
+> claim forms fails unless that form set is admitted by a
+> configured family of allowed form sets. The rule is the family;
+> the policy decision is the family's default value.
 
-- Pro: the entire matrix falls out as derived consequences, with
-  one uniform rationale: **a free form asserts something about the
-  requirement's nature that changes everyone's obligations, so it
-  does not get to share the claim with forms whose obligations it
-  would deflate.**
+- Pro: mechanism and policy separate cleanly. The mechanism is one
+  uniform rule — family membership — and it is the same primitive
+  the target axis uses ([Decision 12](#decision-12)). A project
+  that believes it has a legitimate coexistence writes that form
+  set into the family: a reviewed config line, never a comment.
+- Pro: the entire matrix falls out of the default family as
+  derived consequences, with one uniform rationale for that
+  default: **a free form asserts something about the requirement's
+  nature that changes everyone's obligations, so it does not get
+  to share the claim with forms whose obligations it would
+  deflate.**
 - Pro: a future annotation type gets a verdict by answering one
   question — is it priced? — instead of a row of debates.
 
-### Decision: Option C
+### Decision: Option C, default family = the form sets containing no free form
 
-Checking the rule against every pair the matrix would have argued:
+The default family admits exactly the form sets containing no free
+form: any combination of `test` and `implementation` members may
+share a claim, each billed on its own; a free form never shares a
+claim with another form. Checking that default against every pair
+the matrix would have argued:
 
-| Coexistence (same claim) | Reading | Verdict under the rule |
+| Coexistence (same claim) | Reading | Verdict under the default family |
 |---|---|---|
 | `exception` + `test` | "we don't do R" ∧ "we test R" | fail — contradiction |
 | `exception` + `implementation` | "we don't do R" ∧ "R is implemented here" | fail — contradiction |
@@ -360,10 +370,15 @@ Checking the rule against every pair the matrix would have argued:
 | `test` + `implementation` (different targets) | tested there, implemented here | permitted — this is `discharged(T, I)`, the system itself |
 
 **Consequences:** This is a static check over claim classes — no
-evidence needed; it belongs to the duplicates check. It is a
-deliberate tightening of released behavior: cross-type
-coexistence on one requirement silently passes today. How the
-tightening ships, and how a project that believes it has a
+evidence needed; it belongs to the duplicates check. The family is
+the whole rule, not a carve-out from a free-form precondition: an
+empty family forbids all multi-form claim sharing, `test` +
+`implementation` included. Copies of a single form are outside
+this rule — multiplicity within one form is the caps' business
+([Decision 3](#decision-3)), which holds free forms at one with no
+knob. It is a deliberate tightening of released behavior:
+cross-type coexistence on one requirement silently passes today.
+How the tightening ships, and how a project that believes it has a
 legitimate coexistence records that belief, are settled below once
 all policy values are on the table — the short answer is a
 reviewed config line, never a comment.

--- a/design/duplicates/decisions.md
+++ b/design/duplicates/decisions.md
@@ -169,22 +169,30 @@ raising N never flips a passing project to failing.
 `implementation` annotation carrying the same quote on the same
 line.
 
-**Decision:** Two annotations with the same claim and the same
-resolved target FAIL the duplicates check unconditionally,
-regardless of cap and **regardless of type**. The rule is
-overdetermined:
+### Option A: Same-type pairs only
 
-1. **Indistinguishability.** Binding is a function of the resolved
-   target, so the two annotations' witness sets are identical by
-   construction. No evidence that could ever arrive can tell them
-   apart. This argument never mentions types; restricting the rule
-   to same-type pairs would be an accident of the current
-   classification, not a decision.
-2. **Co-located claim forms are incoherent.** "This artifact tests
-   R" ∧ "this artifact implements R" at one position is the
-   definition of an `implication` spelled out in two annotations;
-   "we don't do R" ∧ anything-else-about-R is a contradiction
-   wherever it sits.
+Extend today's classification, which compares each type against
+itself.
+
+- Pro: no new classification machinery.
+- Con: the argument for failing stacked copies —
+  **indistinguishability** — never mentions types. Binding is a
+  function of the resolved target, so two annotations at one
+  target have identical witness sets by construction, whatever
+  their types. Restricting to same-type would be an accident of
+  the current implementation wearing a decision's clothes.
+- Con: the cross-type stack is independently incoherent. "This
+  artifact tests R" ∧ "this artifact implements R" at one position
+  is the definition of an `implication` spelled out in two
+  annotations; "we don't do R" ∧ anything-else-about-R is a
+  contradiction wherever it sits.
+
+### Option B: Fail for every type pair
+
+Two annotations with the same claim and the same resolved target
+FAIL unconditionally, regardless of cap and regardless of type.
+
+### Decision: Option B
 
 **Consequences:** The failure message is keyed to the pair —
 same-type: "collapse to one"; `test`+`implementation`: "did you
@@ -218,22 +226,29 @@ perspective on each copy:
 | `exception` | none — a declaration of absence has nothing to execute or prove | unique, always |
 | `implication` | none **today** | unique **today**; see below |
 
-**Implication is its own animal.** An exception's position is
-incidental; an implication's position is the claim ("*this
-artifact* is correct by construction"). Structurally it patterns
-with `implementation`, not with `exception`. What forces
-uniqueness today is the evidence question: implications carry no
-checkable obligation, and the proof-world answer (self-discharging
-implications, where a verifier's elaboration is the implication's
-own evidence) was deliberately deferred in the witness design
-("Option B: self-discharging implications" — nobody can state the
-discharge obligation precisely yet). Runtime execution of an
-implication's position is evidence about the wrong property: it
-shows liveness, not construction.
+**Implication was the arm-wrestle in this table.** Two readings
+were debated:
 
-**Decision:** unique today; revisit as a rider on the
-self-discharging-implications feature, which owns its own decision
-document.
+### Option A: Intrinsically unique, like `exception`
+
+- Con: it mistakes the type. An exception's position is
+  incidental (a declaration of absence); an implication's position
+  is the claim ("*this artifact* is correct by construction").
+  Structurally it patterns with `implementation`, not `exception`.
+
+### Option B: Unique today, contingent on future evidence
+
+What forces uniqueness today is the evidence question, not the
+type's nature: implications carry no checkable obligation, and the
+proof-world answer (self-discharging implications, where a
+verifier's elaboration is the implication's own evidence) was
+deliberately deferred in the witness design ("nobody can state the
+discharge obligation precisely yet"). Runtime execution of an
+implication's position was considered as interim evidence and
+rejected: it is evidence about the wrong property — liveness, not
+construction.
+
+### Decision: Option B — unique today; revisit as a rider on the self-discharging-implications feature, which owns its own decision document.
 
 ---
 
@@ -257,16 +272,41 @@ forms are its escape valve. A per-target rule cannot catch it: an
 `exception`'s position is incidental, so it evades any co-location
 check by sitting anywhere else.
 
-**Decision:** Within one claim class, the free claim forms are
-exclusive; the priced forms are combinable:
+### Option A: Leave it alone (today's behavior)
+
+- Con: the exploit is live. Adding an `implication` next to an
+  existing `implementation` annotation silently deflates the
+  requirement's obligations, and nothing reports the coexistence.
+
+### Option B: A pairwise contradiction matrix
+
+Enumerate the type pairs and assign each a verdict
+(`exception`+`test` = contradiction, `implication`+`test` =
+incoherent, …).
+
+- Pro: each verdict is individually explainable.
+- Con: every cell needs its own metaphysical justification, argued
+  pair by pair; a new annotation type multiplies the cells; and
+  the matrix invites cell-by-cell relitigating.
+
+### Option C: One exclusivity rule over the type multiset
 
 > If a claim class contains an `exception`, `implication`, or
 > `todo` annotation, that annotation must be the **only** member
 > of the class. Any combination of `test` and `implementation`
 > members is permitted, each billed on its own.
 
-Checking this against every pair it derives — no pair-by-pair
-metaphysics needed:
+- Pro: the entire matrix falls out as derived consequences, with
+  one uniform rationale: **a free form asserts something about the
+  requirement's nature that changes everyone's obligations, so it
+  does not get to share the claim with forms whose obligations it
+  would deflate.**
+- Pro: a future annotation type gets a verdict by answering one
+  question — is it priced? — instead of a row of debates.
+
+### Decision: Option C
+
+Checking the rule against every pair the matrix would have argued:
 
 | Coexistence (same claim) | Reading | Verdict under the rule |
 |---|---|---|
@@ -276,11 +316,6 @@ metaphysics needed:
 | `implication` + `test` | "not checkable by evidence" ∧ "tested" | fail — incompatible claims about R's nature |
 | `todo` + `implementation` | "not yet done" ∧ "done here" | fail — and todo→implementation is the intended *lifecycle*: the todo is replaced, not joined; exclusivity enforces exactly that |
 | `test` + `implementation` (different targets) | tested there, implemented here | permitted — this is `discharged(T, I)`, the system itself |
-
-The uniform rationale: **a free form asserts something about the
-requirement's nature that changes everyone's obligations, so it
-does not get to share the claim with forms whose obligations it
-would deflate.**
 
 **Consequences:** This is a static check over claim classes — no
 evidence needed; it belongs to the duplicates check. It is a
@@ -350,20 +385,46 @@ both answer "do you have evidence?" by pointing at the same
 evidence, and both pass. The current machinery interrogates each
 annotation separately and never notices the evidence is one unit.
 
-**Decision:** Within each claim class, the coverage check
-partitions the same-type test members by their bound witness set.
-**Every group of size ≥ 2 fails** — those members are mutually
-indistinguishable. Singleton groups pass.
+### Option A: Report the groups, never change the verdict
+
+Surface "these copies are evidentially indistinguishable" as an
+informational grouping — candidates for collapsing, no failure.
+This option was briefly adopted during design, out of sympathy
+for contained multiplicity ("silly but not intrinsically wrong").
+
+- Con: it quietly guts the design's central claim. If
+  indistinguishable copies never fail, coverage resolves only
+  *rot* (unwitnessed, undischarged copies), not *redundancy* —
+  and "the duplicates check can relax because coverage
+  disambiguates the copies" stops being true. The grouping
+  becomes a caption on a pass.
+- Con: the governing principle decides this case directly. If
+  `witnesses_for(A) = witnesses_for(B)`, coverage **cannot
+  disambiguate the copies** — and the principle says duplicates
+  are permissible exactly where it can. Allowing them is not
+  tolerance; it is the principle's own failure condition.
+
+### Option B: Fail the indistinguishable groups
+
+Within each claim class, partition the same-type test members by
+their bound witness set. **Every group of size ≥ 2 fails** —
+those members are mutually indistinguishable. Singleton groups
+pass.
+
+### Decision: Option B
 
 Property **W8 (evidential distinctness):** coverage PASS requires
 that no two same-type mutually-covering test annotations bind the
 same witness set.
 
-Two precisions the formulation carries deliberately:
+The formulation itself was arm-wrestled and carries two
+deliberate precisions:
 
-- **Distinct means unequal, never disjoint.** Two sets may share
-  witnesses and still be distinct: `{extent, e₁} ≠ {extent, e₂}`
-  passes. Requiring disjointness would fail legitimate structure.
+- **Distinct means unequal, never disjoint.** An earlier
+  "pairwise distinct sets" phrasing invited misreading as
+  disjointness. Two sets may share witnesses and still be
+  distinct: `{extent, e₁} ≠ {extent, e₂}` passes. Requiring
+  disjointness would fail legitimate structure.
 - **The verdict attaches to the indistinguishable group, not the
   class.** If A and B bind identically but C binds differently, A
   and B fail together and C is untouched. Coverage can prove the
@@ -371,17 +432,13 @@ Two precisions the formulation carries deliberately:
   human collapses it. (Implementation shape follows: group by
   witness set and flag collisions — linear, no pairwise walk.)
 
-This is the governing principle applied per-instance: identical
-witness sets mean the tool provably cannot tell the copies apart —
-disambiguation did not happen in fact.
-[Decision 2](#decision-2)'s same-target rule is exactly this
-rule's statically decidable shadow: same target implies identical
-sets by construction, but not conversely — positions that always
-execute together are positionally distinct and evidentially
-identical, and only this rule sees them.
-
 **Consequences:**
 
+- [Decision 2](#decision-2)'s same-target rule is exactly this
+  rule's statically decidable shadow: same target implies
+  identical sets by construction, but not conversely — positions
+  that always execute together are positionally distinct and
+  evidentially identical, and only this rule sees them.
 - The constructions this catches: N copies scattered through one
   test function (all bind that test's witnesses identically); two
   real tests under one merged suite report (both bind the single
@@ -476,12 +533,27 @@ design — it is the tight inner loop (run one test in seconds, not
 the suite in minutes). Duplicate copies on tests that did not run
 this invocation are unbilled there.
 
-**Decision:** Out of scope, by intent. The mode is deliberately
-partial for everything; duplicates inherit that partiality exactly
-as broken-but-not-run tests do. The gate is the full coverage
-check. (Unknown-status positions are still billed even in this
-mode — placement errors fail regardless — so spray at positions
-that resolve to nothing has no refuge here either.)
+### Option A: A narrow tightening for the mode
+
+When some members of a duplicate set executed and grouped
+vacuously, fail the set even in executed mode.
+
+- Con: it designs duplicate machinery into a debug loop. The
+  mode's entire purpose is deliberate partiality — run one test in
+  seconds without false positives from everything else. Building
+  duplicate guarantees into it confuses the intentionalities.
+
+### Option B: Out of scope, by intent
+
+The mode is deliberately partial for everything; duplicates
+inherit that partiality exactly as broken-but-not-run tests do.
+The gate is the full coverage check.
+
+### Decision: Option B
+
+**Consequences:** Unknown-status positions are still billed even
+in this mode — placement errors fail regardless — so spray at
+positions that resolve to nothing has no refuge here either.
 
 ---
 
@@ -537,7 +609,30 @@ test citing that requirement to execute the dumped-on function, so
 from the cause**. The evidence layer pushes back, but with poor
 diagnostic locality.
 
-**Decision, in three parts:**
+### Option A: A gate with a default threshold
+
+Fail targets bearing more than N annotations, N shipped with a
+biting default.
+
+- Con: no defensible N exists. A default that bites fails the
+  large legitimate population on day one; a default high enough
+  not to misses the five-stack that motivated the feature. Count
+  is a signal, not a discriminator.
+- Con: unlike every gate above, no evidence property is violated —
+  each stacked claim is billed and distinguishable. Failing code
+  the evidence supports would be the first rule in this document
+  to do so.
+
+### Option B: Disambiguate lazy stacks from dense code with evidence
+
+Use the execution data to tell a lazily-stacked function head from
+a precisely-annotated dense function.
+
+- Con: impossible within a unit, per [Decision 7](#decision-7) —
+  no execution gradient exists. (A related evidence-side idea
+  survives as a parked observation at the end of this document.)
+
+### Option C: Query first, snapshot ratchet, opt-in bounds
 
 1. **A query, not (by default) a gate.** A `duplicate-targets`
    query lists every target bearing more than one annotation,
@@ -561,6 +656,8 @@ diagnostic locality.
    that fail code for a *smell* rather than a violated evidence
    property — the entry price of the fan-in axis, named honestly:
    teams opt into the opinion.
+
+### Decision: Option C
 
 **Mixed claim forms on one target** deserve their own default. A
 position claimed as a test of R1 and an implementation of R2 means
@@ -643,14 +740,34 @@ containing indistinct duplicate pairs, and type coherence
 ([Decision 4](#decision-4)) makes the duplicates check fail
 cross-type coexistences that silently pass today.
 
-**Decision:** W8 ships **in the same release as proof coverage**,
-while the executed-coverage install base is effectively one user —
-the check simply always had these semantics. Type coherence ships
-as a tightened default with its cells pinnable per
-[Decision 10](#decision-10). No compatibility flags in either
-case: a `--no-distinctness` switch is a waiver-by-declaration,
-rejected on the same grounds as every other waiver in this
-document.
+### Option A: A compatibility flag
+
+Ship the new semantics behind `--no-distinctness` /
+`--legacy-coherence` switches.
+
+- Con: a waiver-by-declaration, rejected on the same grounds as
+  every other waiver in this document — and a permanent escape
+  hatch enters the interface for a transitional problem.
+
+### Option B: Staged rollout — warn one release, enforce the next
+
+- Pro: nobody gets ambushed; the warning release lists the exact
+  collapse/split remediation.
+- Con: unnecessary given the facts. It was designed under the
+  assumption of a broad executed-coverage install base; the actual
+  base is effectively one user, and proof coverage has not shipped
+  at all.
+
+### Option C: Ship strict with proof coverage; tightened defaults are pinnable
+
+W8 ships **in the same release as proof coverage** — the check
+simply always had these semantics; no lenient version ever
+existed to be compatible with. Type coherence ships as a
+tightened default with its cells pinnable per
+[Decision 10](#decision-10) — the release notes name the cell
+that restores prior behavior.
+
+### Decision: Option C
 
 **Consequences:** Enforcement invariance is stated honestly as
 **P-C1′**: the new coverage verdict equals the old on every input

--- a/design/duplicates/decisions.md
+++ b/design/duplicates/decisions.md
@@ -73,9 +73,7 @@ and must be pinned against the code, and partial overlap (the
 this framework. Second, an environmental fact about targets: code
 formatters relocate comments, so annotations can land on lines the
 author did not choose — same-target collisions can be tooling
-artifacts. This informs error-message wording ("these may have
-been moved together"), never verdicts; the remediation always
-exists.
+artifacts.
 
 One engine fact the type rules below depend on, stated as fact
 because the checks implement it: **an `exception` or `implication`
@@ -132,12 +130,9 @@ is the legacy strict behavior preserved?
 
 ### Option B: Per-type numeric caps, default 1
 
-A configured value per type, e.g. `test = 2`. Only `test` and
-`implementation` may be raised; the per-type verdicts are settled
-two decisions below. Default for every type is 1. Where
-configuration lives — file, flag, or both — is left open here and
-settled once all the policy values this document accumulates are
-on the table.
+A configured value per type, e.g. `test = 2`. Default for every
+type is 1. Which types accept a raised cap, and where
+configuration lives — file, flag, or both — are left open here.
 
 - Pro: at cap 1 the check is bit-for-bit the historical strict
   check (Property [P-D3](#properties)). Nothing loosens until a
@@ -194,12 +189,8 @@ FAIL unconditionally, regardless of cap and regardless of type.
 
 ### Decision: Option B
 
-**Consequences:** The failure message is keyed to the pair —
-same-type: "collapse to one"; `test`+`implementation`: "did you
-mean one `implication`?"; `exception`+anything: "these contradict;
-pick one."
-
-"Same location" is defined as **same resolved target**, not same
+**Consequences:** "Same location" is defined as **same resolved
+target**, not same
 source line: stacked copies above one statement collapse to one
 target and die here; copies scattered through a function body
 resolve to different targets and are governed by the cap and by
@@ -211,44 +202,68 @@ statically decidable fragment.
 
 ## Decision 3: Per-type permissibility {#decision-3}
 
-**Context:** Which annotation types can ever justify duplicates?
+**Context:** [Decision 1](#decision-1) established the cap
+mechanism and left open which types accept a raised cap. The
+question conflates two things that separate cleanly: what the
+evidence can support, and what a customer may configure.
 
-Applying the governing principle per-type — the cap may be raised
-exactly where the pricing table gives a coverage check some
+What the evidence supports is the pricing table's answer — a
+raised cap is meaningful exactly where a coverage check has some
 perspective on each copy:
 
-| Type | Coverage-check perspective | Duplicate verdict |
-|---|---|---|
-| `test` | witnessed + discharged (W6, §1.6) | cap may be raised |
-| `implementation` | executed under covering tests | cap may be raised |
-| `spec` | none | unique, always |
-| `todo` | none — and a todo-covered requirement already fails the implementation check, so a duplicate todo is noise on a fail | unique, always |
-| `exception` | none — a declaration of absence has nothing to execute or prove | unique, always |
-| `implication` | none **today** | unique **today**; see below |
+| Type | Coverage-check perspective |
+|---|---|
+| `test` | witnessed + discharged (W6, §1.6) |
+| `implementation` | executed under covering tests |
+| `spec` | none |
+| `todo` | none — and a todo-covered requirement already fails the implementation check |
+| `exception` | none — a declaration of absence has nothing to execute or prove |
+| `implication` | none **today**; the arm-wrestle below |
 
-**Implication was the arm-wrestle in this table.** Two readings
+### Option A: Every cap raisable, default 1
+
+- Pro: symmetric, and never refuses a customer's configuration.
+- Con: for the evidence-free forms, a raised cap does not admit
+  verified duplicates — it admits copies no check can ever
+  distinguish, which is exactly the duplication the governing
+  principle forbids, now blessed by a config line.
+- Con: the shipping asymmetry. A knob that never shipped can be
+  added the day a customer arrives with a real case; a shipped
+  knob can never be removed without a breaking change. Frivolous
+  knobs are permanent.
+
+### Option B: Caps raisable only where priced
+
+`test` and `implementation` get raisable caps. `spec`, `todo`,
+`exception`, and `implication` are unique with no knob — a
+shipping decision, not a metaphysical constraint. If a real case
+arrives, the knob is added then.
+
+### Decision: Option B
+
+**Implication was the arm-wrestle in the table.** Two readings
 were debated:
 
-### Option A: Intrinsically unique, like `exception`
+**Reading 1 — intrinsically unique, like `exception`.** Rejected
+because it mistakes the type: an exception's position is
+incidental (a declaration of absence); an implication's position
+is the claim ("*this artifact* is correct by construction").
+Structurally it patterns with `implementation`, not `exception`.
 
-- Con: it mistakes the type. An exception's position is
-  incidental (a declaration of absence); an implication's position
-  is the claim ("*this artifact* is correct by construction").
-  Structurally it patterns with `implementation`, not `exception`.
-
-### Option B: Unique today, contingent on future evidence
-
-What forces uniqueness today is the evidence question, not the
-type's nature: implications carry no checkable obligation, and the
+**Reading 2 — unique today, contingent on future evidence.** What
+forces uniqueness today is the evidence question, not the type's
+nature: implications carry no checkable obligation, and the
 proof-world answer (self-discharging implications, where a
 verifier's elaboration is the implication's own evidence) was
-deliberately deferred in the witness design ("nobody can state the
-discharge obligation precisely yet"). Runtime execution of an
+deliberately deferred in the witness design ("nobody can state
+the discharge obligation precisely yet"). Runtime execution of an
 implication's position was considered as interim evidence and
 rejected: it is evidence about the wrong property — liveness, not
 construction.
 
-### Decision: Option B — unique today; revisit as a rider on the self-discharging-implications feature, which owns its own decision document.
+Reading 2 stands. Revisit as a rider on the
+self-discharging-implications feature, which owns its own
+decision document.
 
 ---
 
@@ -377,13 +392,27 @@ duplicates. The report wording points at running both checks.
 
 ## Decision 6: Coverage fails evidentially indistinct duplicates (W8) {#decision-6}
 
-**Context:** Per-instance discharge (W6 + pair billing) is already
-enforced by the coverage check for every duplicate copy — each is
-an independent T. What existing correlation does **not** do is
-compare copies *to each other*: two copies in one test function
-both answer "do you have evidence?" by pointing at the same
-evidence, and both pass. The current machinery interrogates each
-annotation separately and never notices the evidence is one unit.
+**Context:** A project raises `test = 2`, and a requirement now
+carries two test annotations in two places. What the coverage
+check does with them today: it binds each annotation to its
+witness set — the concrete units of evidence, an instrumented
+test run, a proved clause — and verifies each annotation
+independently: witnessed? discharged against every covering
+implementation? Both copies can answer both questions by pointing
+at the same evidence, and both pass, because nothing ever
+compares the copies *to each other*. Per-instance discharge (W6
+plus pair billing) is already enforced for every copy; what no
+existing machinery asks is whether the two copies are two claims
+or one claim written twice.
+
+One question decides it: **do the copies bind the same witness
+set?** Everything duvet can check about a test annotation — in
+this check or any future one — is a function of its witness set.
+If two copies bind exactly equal sets, no check can ever tell
+them apart; the second copy adds no information. The governing
+principle says duplicates are permissible exactly where coverage
+can disambiguate them, and equal witness sets is precisely where
+it cannot.
 
 ### Option A: Report the groups, never change the verdict
 
@@ -398,15 +427,13 @@ for contained multiplicity ("silly but not intrinsically wrong").
   and "the duplicates check can relax because coverage
   disambiguates the copies" stops being true. The grouping
   becomes a caption on a pass.
-- Con: the governing principle decides this case directly. If
-  `witnesses_for(A) = witnesses_for(B)`, coverage **cannot
-  disambiguate the copies** — and the principle says duplicates
-  are permissible exactly where it can. Allowing them is not
-  tolerance; it is the principle's own failure condition.
+- Con: the governing principle decides this case directly.
+  Allowing indistinguishable copies is not tolerance; it is the
+  principle's own failure condition.
 
 ### Option B: Fail the indistinguishable groups
 
-Within each claim class, partition the same-type test members by
+Within each claim class, group the same-type test members by
 their bound witness set. **Every group of size ≥ 2 fails** —
 those members are mutually indistinguishable. Singleton groups
 pass.
@@ -417,20 +444,50 @@ Property **W8 (evidential distinctness):** coverage PASS requires
 that no two same-type mutually-covering test annotations bind the
 same witness set.
 
-The formulation itself was arm-wrestled and carries two
-deliberate precisions:
+**How you hit it in practice.** Three ways:
+
+- Copy-paste: N copies scattered through one test function all
+  bind that test's witnesses identically. Fails; collapse them.
+- One merged suite report: two *genuinely different* tests run as
+  a single instrumented invocation produce one fat witness, and
+  both annotations bind it. Fails — and this is the case that
+  feels like a false positive, because the tests really are
+  different. But the evidence handed to duvet cannot see the
+  difference, and duvet does not guess at distinctions its
+  evidence cannot support. Two exits, both improvements: collapse
+  the copies, or individuate the runs (per-test reports) so the
+  sets differ. Coarser evidence buys fewer allowed duplicates —
+  the monotonicity invariant surfacing as an incentive.
+- Two test annotations inside one Verus discharge unit bind the
+  same clause span. Fails. Copies on two *different* `ensures`
+  clauses of one function pass — the prover artifact records a
+  span per clause, so the sets were never equal. Two separately
+  recorded prover obligations are two units of evidence; edgy,
+  pinned by fixture, reopened if dogfooding says otherwise.
+
+The constructions this admits are the motivating ones: proof +
+PBT (`{w_verus}` vs `{w_jacoco}`), split tests with per-test
+reports.
+
+**There are no false positives in the strict sense.** Equal sets
+are computed from the delivered evidence, not estimated; when the
+rule fires, the indistinguishability is a fact. The unfair
+*feeling* is always the merged-report case — evidence coarser
+than reality — and the remediation message says so.
+
+The formulation carries two deliberate precisions, both
+arm-wrestled:
 
 - **Distinct means unequal, never disjoint.** An earlier
   "pairwise distinct sets" phrasing invited misreading as
-  disjointness. Two sets may share witnesses and still be
-  distinct: `{extent, e₁} ≠ {extent, e₂}` passes. Requiring
-  disjointness would fail legitimate structure.
+  disjointness, and disjointness would fail legitimate structure:
+  `{extent, e₁} ≠ {extent, e₂}` passes despite the shared
+  witness.
 - **The verdict attaches to the indistinguishable group, not the
   class.** If A and B bind identically but C binds differently, A
   and B fail together and C is untouched. Coverage can prove the
   group mutually vacuous but cannot pick the canonical member; a
-  human collapses it. (Implementation shape follows: group by
-  witness set and flag collisions — linear, no pairwise walk.)
+  human collapses it.
 
 **Consequences:**
 
@@ -439,31 +496,18 @@ deliberate precisions:
   identical sets by construction, but not conversely — positions
   that always execute together are positionally distinct and
   evidentially identical, and only this rule sees them.
-- The constructions this catches: N copies scattered through one
-  test function (all bind that test's witnesses identically); two
-  real tests under one merged suite report (both bind the single
-  fat witness — the next decision establishes why failing this is
-  correct); two test annotations inside one Verus discharge unit.
-- The constructions this admits: proof + PBT (`{w_verus}` vs
-  `{w_jacoco}`); two tests with per-test reports; two test
-  annotations on two different `ensures` clauses of one Verus
-  function (distinct clause units → distinct sets — the artifact
-  records a span per clause, so cross-clause copies were never
-  identical). The same-claim-on-two-ensures case is admitted
-  deliberately: two separately recorded prover obligations are two
-  units of evidence. Edgy; pinned by fixture; reopen if dogfooding
-  says otherwise.
 - **Robust to report duplication:** binding is content-determined
-  (`executed_by` reads the coverage map), so delivering one report
-  twice binds both copies identically for *every* annotation —
-  `{w₁, w₂} = {w₁, w₂}`, still indistinct. Evidence cannot be
-  photocopied into distinctness.
+  (`executed_by` reads the coverage map), so delivering one
+  report twice binds both copies identically for *every*
+  annotation — `{w₁, w₂} = {w₁, w₂}`, still indistinct. Evidence
+  cannot be photocopied into distinctness.
 - Implementation surface is additive: the check already computes
-  `bound_witnesses` per test; the new work is grouping, one new
-  result bucket, one status conjunct. Per the engine-glue
-  requirement, the W8 verdict flows through a verified-layer
-  predicate (set equality over the existing `binds` cells) with an
-  exactness proof: members grouped ⟺ witness sets equal.
+  `bound_witnesses` per test; the new work is grouping by witness
+  set, one new result bucket, one status conjunct — linear, no
+  pairwise walk. Per the engine-glue requirement, the W8 verdict
+  flows through a verified-layer predicate (set equality over the
+  existing `binds` cells) with an exactness proof: members
+  grouped ⟺ witness sets equal.
 - Implementation-side distinctness (comparing execution profiles
   of implementation copies) is deferred to a follow-up; tests are
   where the motivating case lives.
@@ -614,10 +658,16 @@ diagnostic locality.
 Fail targets bearing more than N annotations, N shipped with a
 biting default.
 
-- Con: no defensible N exists. A default that bites fails the
-  large legitimate population on day one; a default high enough
-  not to misses the five-stack that motivated the feature. Count
-  is a signal, not a discriminator.
+- Con: no defensible *intermediate* N exists — 3 and 5 are
+  arbitrary in a way 1 is not. A middle value fails some
+  legitimately dense code while missing some stack it was meant
+  to catch; count is a signal, not a discriminator. N = 1 is
+  different in kind: "one target, one annotation" is not a
+  threshold but the position-must-discriminate principle itself —
+  [Decision 1](#decision-1)'s strict-by-default posture on this
+  axis. Whether it is shippable as a default turns on how large
+  the legitimately dense population actually is; an empirical
+  question, taken up under Option C.
 - Con: unlike every gate above, no evidence property is violated —
   each stacked claim is billed and distinguishable. Failing code
   the evidence supports would be the first rule in this document
@@ -649,13 +699,21 @@ a precisely-annotated dense function.
    target surfaces as a snapshot diff in review — concentration
    becomes visible at the moment it grows, with no gate. This is
    the same posture as "raising a cap is visible in review."
-3. **Opt-in bounds for teams that want the bite**, all default
-   unlimited: `count` (max annotations per target), `sections`
-   (max distinct sections per target), `types` (max distinct claim
-   forms per target). These are the first bounds in this document
-   that fail code for a *smell* rather than a violated evidence
-   property — the entry price of the fan-in axis, named honestly:
-   teams opt into the opinion.
+3. **Opt-in bounds for teams that want the bite**: `count` (max
+   annotations per target), `sections` (max distinct sections per
+   target), `types` (distinct claim forms per target). `sections`
+   and `types` default unlimited. The shipped default for `count`
+   is deliberately left open between unlimited and 1: `count = 1`
+   is [Decision 1](#decision-1)'s posture on this axis — strict
+   by default, raised explicitly where density is real — but it
+   fails the legitimately dense population on day one if that
+   population is large. How large is measurable: survey the
+   public duvet corpus (s2n-quic, s2n-tls, the AWS crypto
+   tooling) for actual target fan-in; the default follows the
+   data, and the survey is a follow-up. These are the first
+   bounds in this document that fail code for a *smell* rather
+   than a violated evidence property — the entry price of the
+   fan-in axis, named honestly: teams opt into the opinion.
 
 ### Decision: Option C
 
@@ -756,7 +814,10 @@ emitted. Internal code keeps its vocabulary.
 
 **Consequences:** One canonical output name prevents the drift
 that two-names-for-one-thing invites. The rename never touches the
-enum.
+enum. The scope is the surfaces this document adds and new
+user-facing output going forward — not a license to retrofit
+existing code or existing output; any retroactive cleanup is its
+own change.
 
 ---
 
@@ -843,19 +904,30 @@ A verdict per type pair, like [Decision 4](#decision-4) Option B.
 
 ### Option C: A family of allowed type-sets
 
-Config declares which combinations may share a target. A target
-class G passes iff `types(G) ⊆ S` for some configured set S:
+Config declares which *combinations* may share a target. Each
+array element is one allowed set, `+` joining the types in it. A
+target class G bearing two or more distinct types passes iff
+`types(G) ⊆ S` for some allowed S. A single-type target always
+passes — one type is not a combination, so a rule about sharing
+never constrains it (singleton entries are legal but redundant):
 
 ```toml
 [duplicates.targets]
-types = ["implementation", "test", "exception+test"]
+types = ["exception+test", "implication+todo"]
+# exception+test on one target: allowed
+# implication+todo:             allowed
+# exception+todo:               fails — inside no allowed set
 ```
+
+`types = []` forbids all mixing; omitting the setting allows
+every combination (the opt-in posture of this axis).
 
 - Pro: downward-closed by construction — a subset of an allowed
   combination is always allowed, so permitting a combination never
-  forbids its parts.
-- Pro: subsumes the numeric form — `types = 1` is the family of
-  singletons. One primitive instead of two.
+  forbids its parts, and a lone annotation is never rejected by a
+  rule about sharing.
+- Pro: subsumes the numeric form — `types = 1` is `types = []`.
+  One primitive instead of two.
 - Pro: the mixed-form default stops being special-case machinery:
   the shipped default family is every combination **not**
   containing both `test` and `implementation`. The Appendix-A team
@@ -1117,10 +1189,11 @@ live in the verified layer.
   contains a target iff ≥ 2 annotations resolve to it; counts,
   type breakdowns, and section counts are exact.
 - **P-T2 (type-family exactness).** With a configured family, a
-  target class fails the type-combination rule iff its type set is
-  a subset of no allowed set. Adding an allowed set never flips a
-  passing project to failing; removing one never flips failing to
-  passing (the family form of P-D4).
+  target class bearing two or more distinct types fails the
+  type-combination rule iff its type set is a subset of no allowed
+  set; single-type targets never fail it. Adding an allowed set
+  never flips a passing project to failing; removing one never
+  flips failing to passing (the family form of P-D4).
 - **P-C1′ (scoped enforcement invariance).** New coverage verdict
   ≡ old on every input with no indistinct duplicate pair.
 - **P-C2 (per-instance billing).** coverage PASS ⟹ every in-scope
@@ -1160,6 +1233,9 @@ live in the verified layer.
   caps, fan-in bounds, the type-set family, coherence cells,
   shipped defaults; `citation` → `implementation` alias at the
   parse boundary, never emitted.
+- Survey the public duvet corpus (s2n-quic, s2n-tls, the AWS
+  crypto tooling) for actual target fan-in frequency — settles
+  Decision 9's open `count` default (unlimited vs 1).
 - Scoped overrides (Decision 14), if demand arrives: glob keys for
   target scope and their overlap-precedence rule; whether spec
   scope without section scope is worth having; fixtures for the

--- a/design/duplicates/decisions.md
+++ b/design/duplicates/decisions.md
@@ -590,10 +590,14 @@ a precisely-annotated dense function.
 
 ### Option C: Query first, snapshot ratchet, opt-in bounds
 
-1. **A query, not (by default) a gate.** A `duplicate-targets`
-   query lists every target bearing more than one annotation,
-   sorted by count descending, with per-target type breakdown and
-   distinct-section count. No verdict — a sorted list needs no
+1. **A listing, not (by default) a gate.** The duplicates check's
+   report carries a fan-in listing: every target bearing more than
+   one annotation, sorted by count descending, with per-target type
+   breakdown and distinct-section count. Not a separate check — the
+   target axis and the claim axis are the two partitions of one
+   model, and one invocation evaluates both, mirroring the one
+   `[duplicates]` configuration table. The listing itself carries no
+   verdict — a sorted list needs no
    threshold and no false-positive story; the human reads the top.
    Even inspection output owes an exactness obligation: a target
    appears iff ≥ 2 annotations resolve to it, with exact counts
@@ -1076,9 +1080,9 @@ Pinned by fixture unless noted.
 - **P-D5 (free-form exclusivity).** duplicates PASS ⟹ every claim
   class containing an exception, implication, or todo annotation
   is a singleton.
-- **P-T1 (fan-in exactness).** The duplicate-targets listing
-  contains a target iff ≥ 2 annotations resolve to it; counts,
-  type breakdowns, and section counts are exact.
+- **P-T1 (fan-in exactness).** The fan-in listing in the
+  duplicates report contains a target iff ≥ 2 annotations resolve
+  to it; counts, type breakdowns, and section counts are exact.
 - **P-T2 (type-family exactness).** With a configured family, a
   target class bearing two or more distinct types fails the
   type-combination rule iff its type set is a subset of no allowed
@@ -1119,8 +1123,7 @@ Pinned by fixture unless noted.
   target scope and their overlap-precedence rule; whether spec
   scope without section scope is worth having; fixtures for the
   three scoping properties.
-- `duplicate-targets` query, then snapshot inclusion once the
-  format stabilizes.
+- Fan-in listing snapshot inclusion, once the format stabilizes.
 - Implication duplicates — rider on self-discharging implications.
 - Impl-dump diagnostic locality (pointing failures at the dumped
   annotation rather than the innocent tests) — revisit with the

--- a/design/duplicates/decisions.md
+++ b/design/duplicates/decisions.md
@@ -408,6 +408,66 @@ W6. Healthy spray only survives where testing is coarse.
 
 ---
 
+## Considered: target congestion — named, not yet decided {#considered-congestion}
+
+**Observation:** Many annotations with *different* quotes all
+resolving to one target — four, five, twelve citations stacked on
+a single function. Seen frequently in real usage. It completes the
+matrix this document's decisions live on:
+
+| | same target | different targets |
+|---|---|---|
+| same quote | dead — [Decision 2](#decision-2) | duplicate set — cap + W8 |
+| different quotes | **congestion (this section)** | normal |
+
+**This is not a duplicate.** A duplicate is the same claim
+repeated (redundancy); congestion is many different claims
+concentrated on one artifact (fan-in). The evidence layer does not
+collapse: stacked test annotations share witness sets, but each
+claim's discharge runs through a *different* covering
+implementation, so every claim is individually billed. The
+governing principle therefore does not force a failure — these
+claims are disambiguated, by quote and by pair verdict.
+
+**Why it still smells:** the position is doing no work. The
+annotation's position *is* the claim, and twelve claims on one
+target mean position discriminates nothing. Costs: lazy placement
+(citing at the function head instead of the enforcing lines,
+losing per-claim scoring precision — and on the prover side, the
+difference between binding the function extent and binding the
+specific clause unit); rot amplification (a refactor re-homes
+twelve claims as a careless block); and annotation dumping —
+spray rotated ninety degrees, one claim on many places becoming
+many claims on one place.
+
+**An asymmetry worth pulling on later:** test-side congestion
+resolves cleanly (one integration test citing many requirements is
+billed per-pair and either executes each requirement's
+implementation or fails). Implementation-side congestion is the
+commonly observed shape, and dumping there has a stranger
+property: a citation dumped onto an unrelated function forces
+every test citing that requirement to execute that function
+(per-test ∀-aggregation), so **the dumped citation surfaces as
+failures on innocent test annotations, far from the cause**. The
+evidence layer pushes back on impl dumping, but with poor
+diagnostic locality — arguably worse than silence for
+debuggability.
+
+**Current lean, no decision:** report, don't gate. Group by
+resolved target in the duplicates report ("N annotations resolve
+to this target"), optionally a threshold knob, default unlimited —
+unlike the duplicate cap, the legitimate population (parsers,
+validators genuinely implementing many MUSTs) is large, and a
+biting default would fail real projects on code the evidence
+supports. Remediation message: move each annotation to the
+specific line it governs. Since stacking is common and the
+grouping is a trivial second pass over targets the check already
+resolves, this may be a cheap early win; it may also need more
+thought once the impl-dumping diagnostics question is understood.
+Revisit deliberately.
+
+---
+
 ## Properties {#properties}
 
 Pinned by fixture unless noted; W8's predicate and exactness proof

--- a/design/duplicates/spec.md
+++ b/design/duplicates/spec.md
@@ -374,7 +374,7 @@ types = ["exception+test"]      # allow this combination on one target
 | `claims.test` | 1 | test duplicate sets are singletons |
 | `claims.implementation` | 1 | implementation duplicate sets are singletons |
 | `claims.types` | all form sets containing no free form | free forms exclusive; `test`/`implementation` may share a claim |
-| `targets.count` | unlimited | listing only (provisional pending the corpus fan-in survey) |
+| `targets.count` | unlimited | listing only. Confirmed by the corpus fan-in survey: the legitimately dense population is large (s2n-quic alone bears 149 multi-annotation targets, 113 of them at count 2), so a biting default fails real dense code on day one |
 | `targets.sections` | unlimited | listing only |
 | `targets.types` | all form sets not containing both `test` and `implementation` | mixed test/implementation targets fail |
 

--- a/design/duplicates/spec.md
+++ b/design/duplicates/spec.md
@@ -179,20 +179,25 @@ claim, not fragments of it. Together with [§2.2](#caps) at cap 1,
 this rule reproduces the historical verdict
 ([P-D3](#property-p-d3)).
 
-### 2.4 Free-form exclusivity {#exclusivity}
+### 2.4 Claim-form family {#exclusivity}
 
-A claim class whose non-`spec` members include an annotation of a
-free form and number more than one MUST fail the duplicates check,
-unless the set of non-`spec` claim forms in the class is admitted
-by the configured claim-form family ([§4.2](#schema-claims)).
+A claim class whose non-`spec` members bear two or more distinct
+claim forms MUST fail the duplicates check unless the set of
+non-`spec` claim forms is admitted by the configured claim-form
+family ([§4.2](#schema-claims)). A claim class whose non-`spec`
+members bear a single claim form MUST NOT fail this rule: copies
+of one form are the caps' business ([§2.2](#caps)).
 ([Decision 4](decisions.md#decision-4);
 [P-D5](#property-p-d5))
 
 The default claim-form family admits exactly the form sets
 containing no free form ([§4.3](#defaults)) — any combination of
 `test` and `implementation` members may share a claim, each billed
-on its own; a free form must be the only member of its class.
-Derived verdicts under the default family, for the record:
+on its own; a free form never shares a claim with another form.
+An empty family (`types = []`) admits no multi-form set: it
+forbids all multi-form claim sharing, `test` + `implementation`
+included. Derived verdicts under the default family, for the
+record:
 
 | Coexistence (same claim) | Verdict |
 |---|---|
@@ -330,9 +335,10 @@ lives in exactly one namespace; no setting name appears in both.
 - `implementation` — cap for `implementation` duplicate sets.
   Positive integer.
 - `types` — the claim-form family: an array of allowed form sets,
-  each set written as form names joined by `+`. A claim class of
-  size greater than one whose form set is a subset of no member
-  of the family fails [§2.4](#exclusivity). This is the
+  each set written as form names joined by `+`. A claim class
+  whose non-`spec` members bear two or more distinct claim forms
+  fails [§2.4](#exclusivity) unless that form set is a subset of
+  some member of the family. This is the
   coherence-cell mechanism of
   [Decision 14](decisions.md#decision-14): the release notes name
   the family value that restores prior behavior.
@@ -461,8 +467,9 @@ it never flips a failing project to passing.
 Under the default claim-form family: if the duplicates check
 passes, every claim class whose non-`spec` members include an
 `exception`, `implication`, or `todo` annotation has exactly one
-non-`spec` member.
-([§2.4](#exclusivity))
+non-`spec` member. Jointly enforced: mixed-form classes fail the
+claim-form family rule, single-form copies exceed the free caps.
+([§2.4](#exclusivity); [§2.2](#caps))
 
 ### P-T1 — fan-in exactness {#property-p-t1}
 

--- a/design/duplicates/spec.md
+++ b/design/duplicates/spec.md
@@ -509,6 +509,13 @@ this specification is a function of the checked-in tree (source
 plus configuration). Verbosity never changes a verdict.
 ([§4.1](#policy-source))
 
+Fixture note: pinned on the verbosity axis (one tree, default and
+`--verbose`, exit codes pinned equal). The full function-of-the-tree
+claim ranges over every command-line option and is held
+architecturally — policy values reach the checks only through
+checked-in configuration ([§4.1](#policy-source)) — rather than by
+fixture enumeration.
+
 ### P-S1 — no pass without evidence {#property-p-s1}
 
 If the duplicates check passes and the coverage check passes:
@@ -518,3 +525,10 @@ claim-form family, and every copy is individually billed by
 coverage. The billing conjunct is the coverage check's own
 contract, restated here so the independence of
 [Decision 5](decisions.md#decision-5) is visibly safe.
+
+Fixture note: no single fixture pins the conjunction. The
+structural conjuncts are pinned by the per-rule fixtures of
+[§2](#duplicates-check)–[§3](#duplicate-targets); the billing
+conjunct is the coverage check's own contract with its own suite.
+P-S1 is their composition, safe by check independence
+([Decision 5](decisions.md#decision-5)).

--- a/design/duplicates/spec.md
+++ b/design/duplicates/spec.md
@@ -4,11 +4,13 @@
 **Date:** 2026-08-07
 **Status:** Draft
 
-This specification defines the semantics of duvet's duplicate
-policing: the `duplicates` check (predicates over annotations that
-share a **claim**) and the `duplicate-targets` query (predicates
-over annotations that share a **resolved target**), together with
-the checked-in configuration that carries their policy.
+This specification defines the semantics of duvet's `duplicates`
+check: predicates over the two partitions annotations induce —
+**claim classes** (annotations sharing a claim) and **target
+classes** (annotations sharing a resolved target) — together with
+the checked-in configuration that carries their policy. One check
+evaluates both axes; the two axes are two namespaces of one
+configuration, never two invocations.
 
 Design rationale lives in [decisions.md](decisions.md).
 This document uses the normative keyword conventions of
@@ -121,10 +123,10 @@ priced nor free; it is unique always ([§2.2](#caps)).
 
 ---
 
-## 2. The duplicates check {#duplicates-check}
+## 2. The duplicates check: claim axis {#duplicates-check}
 
-The `duplicates` check evaluates the rules of this section over
-the in-scope annotation set. Scope selection (spec-slice
+The `duplicates` check evaluates the rules of this section and of
+[§3](#duplicate-targets) over the in-scope annotation set. Scope selection (spec-slice
 filtering) selects the input set; it does not change the rules.
 
 ### 2.1 Same claim, same target {#same-claim-same-target}
@@ -217,7 +219,9 @@ fail on them, matching the historical check.
 ### 2.6 Verdict {#duplicates-verdict}
 
 The duplicates check MUST fail if and only if at least one rule of
-[§2.1](#same-claim-same-target)–[§2.4](#exclusivity) fires.
+[§2.1](#same-claim-same-target)–[§2.4](#exclusivity) or of the
+target axis ([§3.2](#fan-in-bounds)–[§3.3](#type-combinations))
+fires.
 
 Run alone, a passing verdict claims structure only. Evidence
 billing of every copy is the coverage check's contract, enforced
@@ -228,17 +232,20 @@ that partiality ([Decision 7](decisions.md#decision-7)).
 
 ---
 
-## 3. The duplicate-targets query {#duplicate-targets}
+## 3. The duplicates check: target axis {#duplicate-targets}
 
-The `duplicate-targets` query evaluates the target axis: fan-in of
-annotations onto resolved targets. It is a listing first and a
-gate only where configuration opts in
-([Decision 8](decisions.md#decision-8)).
+The target axis polices fan-in of annotations onto resolved
+targets. It is a listing first and a gate only where configuration
+opts in or a shipped family default bites
+([Decision 8](decisions.md#decision-8)). It is not a separate
+check: one invocation evaluates both axes, mirroring the one
+`[duplicates]` configuration table.
 
 ### 3.1 Listing {#fan-in-listing}
 
-The listing MUST contain a target if and only if two or more
-annotations resolve to it.
+The duplicates check's report MUST include the fan-in listing: it
+MUST contain a target if and only if two or more annotations
+resolve to it.
 ([P-T1](#property-p-t1))
 
 Each listed target MUST report its exact annotation count, its
@@ -259,8 +266,8 @@ Two opt-in bounds, both unlimited by default
   one target class.
 
 When a bound is configured, a target class exceeding it MUST fail
-the query. When a bound is not configured, no target class fails
-it.
+the duplicates check. When a bound is not configured, no target
+class fails it.
 
 These are the only rules in this specification that fail code for
 a smell rather than a violated evidence property; teams opt into
@@ -272,9 +279,9 @@ Configuration declares a **family of allowed form sets** for
 target classes ([§4.2](#schema-targets)).
 
 A target class bearing two or more distinct claim forms MUST fail
-the query unless its form set is a subset of some member of the
-family. A target class bearing a single claim form MUST NOT fail
-this rule.
+the duplicates check unless its form set is a subset of some
+member of the family. A target class bearing a single claim form
+MUST NOT fail this rule.
 ([Decision 12](decisions.md#decision-12);
 [P-T2](#property-p-t2))
 
@@ -378,7 +385,30 @@ types = ["exception+test"]      # allow this combination on one target
 | `targets.sections` | unlimited | listing only |
 | `targets.types` | all form sets not containing both `test` and `implementation` | mixed test/implementation targets fail |
 
-### 4.4 Scoped overrides {#scoped-overrides}
+### 4.4 Restoring the historical verdict {#restoring-legacy}
+
+Non-normative recipe. The historical check is reachable by
+configuration, up to [P-D3](#property-p-d3)'s two residuals:
+
+```toml
+[duplicates.claims]
+# caps default to 1 — that is the historical behavior
+types = ["spec+test+implementation+exception+todo+implication"]
+
+[duplicates.targets]
+# count/sections default unlimited
+types = ["spec+test+implementation+exception+todo+implication"]
+```
+
+A family containing the all-forms set admits every combination
+(subset closure), turning [§2.4](#exclusivity) and
+[§3.3](#type-combinations) off. Subsumption ([§2.3](#subsumption))
+needs no knob: it is historical behavior. What no configuration
+restores: cross-form same-claim-same-target stacks
+([§2.1](#same-claim-same-target) is deliberately knobless) and the
+empty-quote accident ([§1.2](#claims)).
+
+### 4.5 Scoped overrides {#scoped-overrides}
 
 Designed and deferred ([Decision 13](decisions.md#decision-13)).
 All values in this version are global. If scoped overrides ship,
@@ -406,11 +436,19 @@ If the duplicates check passes, every duplicate set of form
 
 ### P-D3 — scoped legacy equivalence {#property-p-d3}
 
-With every cap at 1 and the claim-form family admitting every
-form set, the duplicates verdict is identical to the historical
-check's verdict on all inputs, except inputs containing an
-empty-quote annotation ([§1.2](#claims)). The existing regression
-fixtures are this property's test suite, unchanged.
+With every cap at 1, both form families admitting every form set,
+and both fan-in bounds unset, the duplicates verdict is identical
+to the historical check's verdict on all inputs, except:
+
+- inputs containing an empty-quote annotation ([§1.2](#claims)) —
+  the historical check failed them by accident of an early return;
+- inputs containing a cross-form same-claim-same-target stack —
+  [§2.1](#same-claim-same-target) is deliberately unconditional
+  ([Decision 2](decisions.md#decision-2)) and has no knob.
+
+Everything that was a decision is pinnable; the residuals are one
+deliberate unconditional rule and one accident. The existing
+regression fixtures are this property's test suite, unchanged.
 
 ### P-D4 — bound monotonicity {#property-p-d4}
 
@@ -428,9 +466,9 @@ non-`spec` member.
 
 ### P-T1 — fan-in exactness {#property-p-t1}
 
-The duplicate-targets listing contains a target if and only if two
-or more annotations resolve to it; counts, form breakdowns, and
-section counts are exact.
+The fan-in listing in the duplicates report contains a target if
+and only if two or more annotations resolve to it; counts, form
+breakdowns, and section counts are exact.
 ([§3.1](#fan-in-listing))
 
 ### P-T2 — form-family exactness {#property-p-t2}

--- a/design/duplicates/spec.md
+++ b/design/duplicates/spec.md
@@ -218,8 +218,22 @@ never a comment.
 
 Annotations whose quotes overlap without full coverage in either
 direction (the `some_overlap` population) are outside this
-specification's model. The check MUST report them and MUST NOT
-fail on them, matching the historical check.
+specification's model. Three layers, separately stated:
+
+Verdict: a partial overlap MUST NOT fail the duplicates check,
+matching the historical check.
+
+Content: the check MUST identify every partial-overlap pair in
+its analysis.
+
+Presentation, non-normative note: display of the analysis
+population is verbosity-tiered — the default report omits it,
+`--verbose` shows it; verbosity never changes the verdict
+([§4.1](#policy-source)). This is deliberately weaker than
+[§2.2](#caps)'s unconditional surfacing: an admitted duplicate is
+a standing liability kept in view at every verbosity
+([Decision 1](decisions.md#decision-1)); a partial overlap is a
+model-boundary disclosure, not a liability the check prices.
 
 ### 2.6 Verdict {#duplicates-verdict}
 

--- a/design/duplicates/spec.md
+++ b/design/duplicates/spec.md
@@ -1,0 +1,461 @@
+# Duvet Duplicates: Formal Specification
+
+**Version:** 0.1.0
+**Date:** 2026-08-07
+**Status:** Draft
+
+This specification defines the semantics of duvet's duplicate
+policing: the `duplicates` check (predicates over annotations that
+share a **claim**) and the `duplicate-targets` query (predicates
+over annotations that share a **resolved target**), together with
+the checked-in configuration that carries their policy.
+
+Design rationale lives in [decisions.md](decisions.md).
+This document uses the normative keyword conventions of
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+The coverage model and the witness layer are unchanged by this
+specification. Evidence billing of duplicate copies is the
+coverage check's own contract; nothing here depends on it or
+alters it ([Decision 5](decisions.md#decision-5)).
+
+---
+
+## 1. Definitions {#definitions}
+
+### 1.1 Annotation model {#annotation-model}
+
+An annotation is a triple **(τ, q, t)**:
+
+- **τ** — the claim form: one of `test`, `implementation`,
+  `implication`, `exception`, `todo`, `spec`.
+- **q** — the claim ([§1.2](#claims)).
+- **t** — the resolved target ([§1.4](#targets)).
+
+Naming ([Decision 10](decisions.md#decision-10)):
+`implementation` is the canonical user-facing name of the claim
+form the codebase calls `Citation`. Every user-facing surface this
+specification defines — configuration keys, report sections,
+failure messages — MUST emit the name `implementation` and MUST
+NOT emit the name `citation`. Wherever a claim form is read as
+input, `citation` MUST be accepted as an alias for
+`implementation`.
+
+### 1.2 Claims and claim classes {#claims}
+
+The **claim** of an annotation is the pair (target section,
+normalized quote): the specification section the annotation
+names, plus its quoted requirement text after whitespace
+normalization.
+
+Two annotations **share a claim** if and only if their target
+sections are identical and their normalized quotes are identical.
+
+A **claim class** is a maximal set of annotations sharing a claim,
+taken across all claim forms. A **duplicate set** is the
+restriction of a claim class to a single claim form.
+
+Sharing a claim is an equivalence relation by construction
+(equality of the pair), so claim classes are well-defined. This
+pins the design vocabulary "quotes mutually cover each other": for
+a pair of quotes on one section, mutual full coverage holds
+exactly when the normalized quotes are equal. Coverage of one
+claim by several others together is not claim sharing; it is
+subsumption ([§2.3](#subsumption)).
+
+An annotation whose normalized quote is empty is a section-level
+reference, not a claim: it participates in no claim class and no
+rule in [§2](#duplicates-check) applies to it.
+
+A `spec`-form annotation names requirement text itself rather than
+claiming anything about an artifact, and every extracted
+requirement is present as one. Its claim class membership
+therefore counts only for [§2.2](#caps) (spec duplicate sets are
+unique); the cross-form rules ([§2.4](#exclusivity)) range over a
+class's non-`spec` members.
+
+### 1.3 Claim coverage {#claim-coverage}
+
+A claim q is **fully covered** by a set of claims Q if and only if
+every position of q's normalized quote, located in its section,
+is occupied by the located normalized quote of at least one member
+of Q on the same section. This is the engine's existing annotation
+coverage relation; this specification adds no new matching
+semantics.
+
+### 1.4 Resolved targets and target classes {#targets}
+
+The **resolved target** of an annotation is the source position
+its annotation block resolves to under the coverage model's target
+resolution (the classified or the degraded path), identified as
+the pair (source file, resolved line). Nothing in this
+specification depends on *how* resolution happens, only that it is
+a pure function of the checked-in tree.
+
+A **target class** is a maximal set of annotations sharing a
+resolved target.
+
+An annotation whose target does not resolve (defeated
+classification, or resolution yielding no line) participates in no
+target class. Claim-axis rules ([§2.2](#caps)–[§2.4](#exclusivity))
+still apply to it. Environmental note, non-normative: code
+formatters relocate comments, so same-target collisions can be
+tooling artifacts; the rules over target classes are policy about
+placement, not accusations of intent.
+
+### 1.5 Pricing {#pricing}
+
+The **priced forms** are `test` and `implementation`: forms whose
+claims carry checkable obligations under the coverage check (a
+test must be witnessed and discharge; an implementation must be
+executed under covering tests' witnesses).
+
+The **free forms** are `exception`, `implication`, and `todo`:
+forms whose claims carry no checkable obligation. Engine fact this
+specification depends on: a free-form claim on a requirement
+exempts that requirement from the test obligation — it rewrites
+the obligations of the entire requirement, not merely its own.
+
+The `spec` form names requirement text itself and is neither
+priced nor free; it is unique always ([§2.2](#caps)).
+
+---
+
+## 2. The duplicates check {#duplicates-check}
+
+The `duplicates` check evaluates the rules of this section over
+the in-scope annotation set. Scope selection (spec-slice
+filtering) selects the input set; it does not change the rules.
+
+### 2.1 Same claim, same target {#same-claim-same-target}
+
+Two annotations that share a claim and share a resolved target
+MUST fail the duplicates check, regardless of their claim forms
+and regardless of any configured cap.
+([Decision 2](decisions.md#decision-2);
+[P-D1](#property-p-d1))
+
+Same location is defined as same *resolved target*, never same
+source line: stacked copies above one statement collapse to one
+target and fail here; copies that resolve to different targets are
+governed by the cap ([§2.2](#caps)).
+
+### 2.2 Multiplicity caps {#caps}
+
+Each claim form has a **cap**: a positive integer, default 1
+([§4.3](#defaults)).
+
+A duplicate set whose size exceeds its form's cap MUST fail the
+duplicates check.
+([Decision 1](decisions.md#decision-1))
+
+Caps MUST be configurable only for the priced forms. The caps of
+`spec`, `todo`, `exception`, and `implication` are fixed at 1 and
+MUST NOT be configurable.
+([Decision 3](decisions.md#decision-3);
+[P-D2](#property-p-d2))
+
+A duplicate set within its cap MUST pass this check
+([Decision 5](decisions.md#decision-5)), and when its size exceeds
+one it MUST be reported with its size and every member's location,
+so multiplicity is always surfaced, never silent.
+([Decision 1](decisions.md#decision-1))
+
+### 2.3 Subsumption {#subsumption}
+
+An annotation whose claim is fully covered
+([§1.3](#claim-coverage)) by the claims of same-form annotations
+outside its own claim class MUST fail the duplicates check,
+regardless of any configured cap.
+
+Rationale, non-normative: this is the historical check's
+union-coverage semantics, separated from the cap rule. A fragment
+copy claims nothing its coverers do not already claim; no cap
+admits it, because the motivating case for a raised cap (two
+evidence artifacts for one requirement) is copies of the *same*
+claim, not fragments of it. Together with [§2.2](#caps) at cap 1,
+this rule reproduces the historical verdict
+([P-D3](#property-p-d3)).
+
+### 2.4 Free-form exclusivity {#exclusivity}
+
+A claim class whose non-`spec` members include an annotation of a
+free form and number more than one MUST fail the duplicates check,
+unless the set of non-`spec` claim forms in the class is admitted
+by the configured claim-form family ([§4.2](#schema-claims)).
+([Decision 4](decisions.md#decision-4);
+[P-D5](#property-p-d5))
+
+The default claim-form family admits exactly the form sets
+containing no free form ([§4.3](#defaults)) — any combination of
+`test` and `implementation` members may share a claim, each billed
+on its own; a free form must be the only member of its class.
+Derived verdicts under the default family, for the record:
+
+| Coexistence (same claim) | Verdict |
+|---|---|
+| `exception` + `test` | fail — contradiction |
+| `exception` + `implementation` | fail — contradiction |
+| `implication` + `implementation` | fail — silent unbilling |
+| `implication` + `test` | fail — incompatible claims about R's nature |
+| `todo` + `implementation` | fail — the todo is replaced, not joined |
+| `test` + `implementation` (different targets) | pass — the system itself |
+
+This rule is a deliberate tightening of released behavior
+([Decision 14](decisions.md#decision-14)): cross-form coexistence
+on one requirement silently passes the historical check. The
+restoration path is a configuration line ([§4.2](#schema-claims)),
+never a comment.
+
+### 2.5 Partial overlap {#partial-overlap}
+
+Annotations whose quotes overlap without full coverage in either
+direction (the `some_overlap` population) are outside this
+specification's model. The check MUST report them and MUST NOT
+fail on them, matching the historical check.
+
+### 2.6 Verdict {#duplicates-verdict}
+
+The duplicates check MUST fail if and only if at least one rule of
+[§2.1](#same-claim-same-target)–[§2.4](#exclusivity) fires.
+
+Run alone, a passing verdict claims structure only. Evidence
+billing of every copy is the coverage check's contract, enforced
+whether or not this check runs ([Decision 5](decisions.md#decision-5)).
+The `executed-coverage` mode carries no duplicate guarantees; it
+is deliberately partial for everything, and duplicates inherit
+that partiality ([Decision 7](decisions.md#decision-7)).
+
+---
+
+## 3. The duplicate-targets query {#duplicate-targets}
+
+The `duplicate-targets` query evaluates the target axis: fan-in of
+annotations onto resolved targets. It is a listing first and a
+gate only where configuration opts in
+([Decision 8](decisions.md#decision-8)).
+
+### 3.1 Listing {#fan-in-listing}
+
+The listing MUST contain a target if and only if two or more
+annotations resolve to it.
+([P-T1](#property-p-t1))
+
+Each listed target MUST report its exact annotation count, its
+per-form breakdown, and its distinct-section count, and the
+listing MUST be sorted by annotation count descending.
+
+The distinct-section count is a triage column, not a
+discriminator: `count=12 sections=1` reads "dense but coherent";
+`count=12 sections=8` reads "look here first."
+
+### 3.2 Fan-in bounds {#fan-in-bounds}
+
+Two opt-in bounds, both unlimited by default
+([§4.3](#defaults)):
+
+- `count` — the maximum number of annotations in one target class.
+- `sections` — the maximum number of distinct sections claimed by
+  one target class.
+
+When a bound is configured, a target class exceeding it MUST fail
+the query. When a bound is not configured, no target class fails
+it.
+
+These are the only rules in this specification that fail code for
+a smell rather than a violated evidence property; teams opt into
+the opinion.
+
+### 3.3 Target form combinations {#type-combinations}
+
+Configuration declares a **family of allowed form sets** for
+target classes ([§4.2](#schema-targets)).
+
+A target class bearing two or more distinct claim forms MUST fail
+the query unless its form set is a subset of some member of the
+family. A target class bearing a single claim form MUST NOT fail
+this rule.
+([Decision 12](decisions.md#decision-12);
+[P-T2](#property-p-t2))
+
+The default family admits every form set that does not contain
+both `test` and `implementation`
+([Decision 8](decisions.md#decision-8)): a position claimed as
+test code and implementation code simultaneously fails by default;
+the meta-requirement case relaxes the default in configuration and
+owns the decision in review.
+
+An empty family (`types = []`) forbids all form mixing on a
+target.
+
+### 3.4 Snapshot inclusion {#snapshot}
+
+Future work, recorded so the deferral is a decision: once the
+listing format stabilizes, the listing lands in the snapshot so
+concentration growth surfaces as a snapshot diff in review. Not
+part of this version.
+
+---
+
+## 4. Configuration {#configuration}
+
+### 4.1 Policy source {#policy-source}
+
+Every policy value in this specification MUST be read from
+checked-in configuration. The shipped defaults
+([§4.3](#defaults)) apply where configuration is silent.
+
+Command-line options MUST NOT change any verdict: the command line
+selects which checks run, points at evidence artifacts, and
+controls verbosity — display, never verdict.
+([Decision 9](decisions.md#decision-9);
+[P-S0](#property-p-s0))
+
+### 4.2 Schema {#schema}
+
+Policy lives in two namespaces mirroring the two coincidence
+axes ([Decision 11](decisions.md#decision-11)). Every setting
+lives in exactly one namespace; no setting name appears in both.
+
+#### 4.2.1 `[duplicates.claims]` — predicates over claim classes {#schema-claims}
+
+- `test` — cap for `test` duplicate sets. Positive integer.
+- `implementation` — cap for `implementation` duplicate sets.
+  Positive integer.
+- `types` — the claim-form family: an array of allowed form sets,
+  each set written as form names joined by `+`. A claim class of
+  size greater than one whose form set is a subset of no member
+  of the family fails [§2.4](#exclusivity). This is the
+  coherence-cell mechanism of
+  [Decision 14](decisions.md#decision-14): the release notes name
+  the family value that restores prior behavior.
+
+#### 4.2.2 `[duplicates.targets]` — predicates over target classes {#schema-targets}
+
+- `count` — fan-in bound ([§3.2](#fan-in-bounds)). Positive
+  integer.
+- `sections` — distinct-section bound ([§3.2](#fan-in-bounds)).
+  Positive integer.
+- `types` — the target-form family ([§3.3](#type-combinations)):
+  an array of allowed form sets, `+`-joined.
+
+#### 4.2.3 Shared rules {#schema-shared}
+
+Form names in configuration use the canonical vocabulary
+([§1.1](#annotation-model)); `citation` MUST be accepted as an
+alias for `implementation` and MUST NOT appear in any emitted
+output.
+
+An unrecognized key under `[duplicates.claims]` or
+`[duplicates.targets]` MUST be a configuration error, so a typo
+never silently takes a default.
+
+Configuring a cap for a form other than `test` or
+`implementation` MUST be a configuration error
+([§2.2](#caps)).
+
+Example:
+
+```toml
+[duplicates.claims]
+test = 2                        # proof + PBT: two evidence artifacts
+# implementation defaults to 1
+# types defaults to the free-form-exclusive family (§4.3)
+
+[duplicates.targets]
+count = 15                      # opt-in fan-in bound
+types = ["exception+test"]      # allow this combination on one target
+```
+
+### 4.3 Defaults {#defaults}
+
+| Setting | Default | Meaning at default |
+|---|---|---|
+| `claims.test` | 1 | test duplicate sets are singletons |
+| `claims.implementation` | 1 | implementation duplicate sets are singletons |
+| `claims.types` | all form sets containing no free form | free forms exclusive; `test`/`implementation` may share a claim |
+| `targets.count` | unlimited | listing only (provisional pending the corpus fan-in survey) |
+| `targets.sections` | unlimited | listing only |
+| `targets.types` | all form sets not containing both `test` and `implementation` | mixed test/implementation targets fail |
+
+### 4.4 Scoped overrides {#scoped-overrides}
+
+Designed and deferred ([Decision 13](decisions.md#decision-13)).
+All values in this version are global. If scoped overrides ship,
+they MUST satisfy resolution determinism, unconfigured
+equivalence, and shadowing monotonicity as stated there.
+
+---
+
+## 5. Properties {#properties}
+
+Each property MUST be pinned by an integration fixture, except
+where noted.
+
+### P-D1 — stacked-spam soundness {#property-p-d1}
+
+If the duplicates check passes, no two annotations sharing a claim
+share a resolved target, across all claim forms.
+([§2.1](#same-claim-same-target))
+
+### P-D2 — uniqueness of non-priced forms {#property-p-d2}
+
+If the duplicates check passes, every duplicate set of form
+`spec`, `todo`, `exception`, or `implication` is a singleton.
+([§2.2](#caps))
+
+### P-D3 — scoped legacy equivalence {#property-p-d3}
+
+With every cap at 1 and the claim-form family admitting every
+form set, the duplicates verdict is identical to the historical
+check's verdict on all inputs, except inputs containing an
+empty-quote annotation ([§1.2](#claims)). The existing regression
+fixtures are this property's test suite, unchanged.
+
+### P-D4 — bound monotonicity {#property-p-d4}
+
+For every configured numeric bound (caps, `count`, `sections`):
+raising it never flips a passing project to failing, and lowering
+it never flips a failing project to passing.
+
+### P-D5 — free-form exclusivity {#property-p-d5}
+
+Under the default claim-form family: if the duplicates check
+passes, every claim class whose non-`spec` members include an
+`exception`, `implication`, or `todo` annotation has exactly one
+non-`spec` member.
+([§2.4](#exclusivity))
+
+### P-T1 — fan-in exactness {#property-p-t1}
+
+The duplicate-targets listing contains a target if and only if two
+or more annotations resolve to it; counts, form breakdowns, and
+section counts are exact.
+([§3.1](#fan-in-listing))
+
+### P-T2 — form-family exactness {#property-p-t2}
+
+With a configured family, a target class bearing two or more
+distinct claim forms fails the form-combination rule if and only
+if its form set is a subset of no allowed set; single-form target
+classes never fail it. Adding an allowed set never flips a passing
+project to failing; removing one never flips a failing project to
+passing.
+([§3.3](#type-combinations))
+
+### P-S0 — verdict determinism {#property-p-s0}
+
+For a fixed set of checks and evidence inputs, every verdict in
+this specification is a function of the checked-in tree (source
+plus configuration). Verbosity never changes a verdict.
+([§4.1](#policy-source))
+
+### P-S1 — no pass without evidence {#property-p-s1}
+
+If the duplicates check passes and the coverage check passes:
+every duplicate copy resolves to a distinct target, every
+duplicate set is within its cap, every claim class satisfies the
+claim-form family, and every copy is individually billed by
+coverage. The billing conjunct is the coverage check's own
+contract, restated here so the independence of
+[Decision 5](decisions.md#decision-5) is visibly safe.

--- a/duvet-coverage/src/degraded.rs
+++ b/duvet-coverage/src/degraded.rs
@@ -114,16 +114,6 @@ fn coverage_status_at(coverage: &CoverageReport, line: u64) -> (result: Option<C
 ///   Missing coverage never yields a verdict (it yields `Unknown`).
 /// - **P3 (target below annotation):** any decided target lies strictly below
 ///   `annotation.end_line`.
-//= design/query/coverage-model-spec.md#property-d1-direct-observation
-//= type=implication
-//# The implementation MUST prove that the degraded status is a direct
-//# observation of the target line's own coverage, never an inference propagated
-//# from another line.
-//= design/query/coverage-model-spec.md#property-d2-degraded-target-bounds
-//= type=implication
-//# The implementation MUST prove that any `Executed` or `NotExecuted` degraded
-//# status resolves a target strictly below the annotation
-//# (`target > annotation.end_line`).
 pub fn degraded_execution_status(
     annotation: &AnnotationSpan,
     classifications: &[Option<LineClass>],
@@ -155,6 +145,11 @@ pub fn degraded_execution_status(
             &&& coverage@[t.unwrap()] == CoverageStatus::Miss
         },
 {
+    //= design/query/coverage-model-spec.md#property-d2-degraded-target-bounds
+    //= type=implication
+    //# The implementation MUST prove that any `Executed` or `NotExecuted` degraded
+    //# status resolves a target strictly below the annotation
+    //# (`target > annotation.end_line`).
     let target = annotation_target(annotation, classifications, file_length);
     match target {
         None => {
@@ -172,6 +167,11 @@ pub fn degraded_execution_status(
                 assert(annotation_target_spec(annotation, classifications, file_length)
                     == Some(t.line_number));
             }
+            //= design/query/coverage-model-spec.md#property-d1-direct-observation
+            //= type=implication
+            //# The implementation MUST prove that the degraded status is a direct
+            //# observation of the target line's own coverage, never an inference propagated
+            //# from another line.
             match coverage_status_at(coverage, t.line_number) {
                 Some(CoverageStatus::Hit) => ExecutionStatus::Executed,
                 Some(CoverageStatus::Miss) => ExecutionStatus::NotExecuted,

--- a/duvet-coverage/src/predicates.rs
+++ b/duvet-coverage/src/predicates.rs
@@ -157,7 +157,6 @@ pub open spec fn scope_has_non_linear_control(
 }
 
 //= design/query/coverage-model-spec.md#property-3-conservative-fallback
-//= type=implication
 //# If an ancestor scope S contains `NonLinearControl` but a child
 //# scope S' does not, propagation MAY occur through S'.
 /// Spec predicate: line was reached via backward propagation from hit_line.

--- a/duvet-coverage/src/proofs.rs
+++ b/duvet-coverage/src/proofs.rs
@@ -4,9 +4,6 @@
 //! Correctness properties for the coverage model (spec Section 5).
 
 //= design/query/coverage-model-spec.md#correctness-properties
-//# These properties MUST be proven with Verus.
-
-//= design/query/coverage-model-spec.md#correctness-properties
 //= type=implication
 //# The Verus proof files MUST carry
 //# duvet annotations linking each `proof fn` back to the corresponding property
@@ -169,7 +166,6 @@ proof fn lemma_no_cross_scope_leakage(
 }
 
 //= design/query/coverage-model-spec.md#property-2-no-cross-scope-leakage
-//= type=implication
 //# The implementation MUST prove that for any two lines A and B where A is in
 //# scope S1 and B is in scope S2 and S1 ≠ S2 and S1 is not a parent of S2 and
 //# S2 is not a parent of S1:
@@ -298,7 +294,6 @@ proof fn lemma_conservative_fallback(
 }
 
 //= design/query/coverage-model-spec.md#property-3-conservative-fallback
-//= type=implication
 //# The implementation MUST prove that no backward propagation occurs WITHIN a
 //# scope that contains a `NonLinearControl` line.
 /// Property 3, composed end-to-end over the *public* `is_annotation_executed`.
@@ -480,7 +475,6 @@ proof fn lemma_validly_in_exec_set_monotone(
 }
 
 //= design/query/coverage-model-spec.md#property-4-monotonicity
-//= type=implication
 //# The implementation MUST prove that given two coverage reports E1 and E2 where
 //# E1 ⊆ E2 (E2 reports all the same hits as E1, plus possibly more):
 /// Property 4, composed end-to-end over the *public* `is_annotation_executed`.
@@ -733,9 +727,6 @@ mod tests {
         lines.iter().map(|&l| (l, CoverageStatus::Hit)).collect()
     }
 
-    //= design/query/coverage-model-spec.md#correctness-properties
-    //= type=test
-    //# These properties MUST be proven with Verus.
     //= design/query/coverage-model-spec.md#property-2-no-cross-scope-leakage
     //= type=test
     //# The implementation MUST prove that for any two lines A and B where A is in

--- a/duvet/src/config.rs
+++ b/duvet/src/config.rs
@@ -1,11 +1,178 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{extract::Extraction, Result};
+use crate::{annotation::AnnotationType, extract::Extraction, Result};
 use duvet_core::{path::Path, vfs};
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 pub mod schema;
+
+/// A set of claim forms admitted to coexist, e.g. `{exception, test}`.
+pub type FormSet = BTreeSet<AnnotationType>;
+
+/// A family of allowed form sets. `None` means the shipped default family for
+/// its axis; `Some(vec![])` forbids all mixing.
+pub type FormFamily = Option<Vec<FormSet>>;
+
+/// The canonical user-facing name of a claim form.
+///
+/// //= design/duplicates/spec.md#annotation-model
+/// //# Every user-facing surface this
+/// //# specification defines — configuration keys, report sections,
+/// //# failure messages — MUST emit the name `implementation` and MUST
+/// //# NOT emit the name `citation`.
+pub fn form_name(form: AnnotationType) -> &'static str {
+    match form {
+        AnnotationType::Spec => "spec",
+        AnnotationType::Test => "test",
+        AnnotationType::Citation => "implementation",
+        AnnotationType::Exception => "exception",
+        AnnotationType::Todo => "todo",
+        AnnotationType::Implication => "implication",
+    }
+}
+
+/// The free claim forms: no checkable obligation, and a claim of one exempts
+/// its requirement from the test obligation (spec §1.5).
+pub fn is_free_form(form: AnnotationType) -> bool {
+    matches!(
+        form,
+        AnnotationType::Exception | AnnotationType::Implication | AnnotationType::Todo
+    )
+}
+
+/// Render a form set as `a+b+c` in the canonical vocabulary.
+pub fn form_set_name_of(forms: &FormSet) -> String {
+    forms
+        .iter()
+        .map(|form| form_name(*form))
+        .collect::<Vec<_>>()
+        .join("+")
+}
+
+/// Policy for the duplicates check and the duplicate-targets query
+/// (design/duplicates/spec.md §4). All policy is checked-in configuration;
+/// the command line never changes a verdict.
+#[derive(Clone, Debug, Default)]
+pub struct DuplicatesPolicy {
+    pub claims: ClaimsPolicy,
+    pub targets: TargetsPolicy,
+}
+
+/// Predicates over claim classes (spec §4.2.1).
+#[derive(Clone, Debug)]
+pub struct ClaimsPolicy {
+    /// Cap for `test` duplicate sets. Default 1.
+    pub test: u32,
+    /// Cap for `implementation` duplicate sets. Default 1.
+    pub implementation: u32,
+    /// The claim-form family (spec §2.4). `None` = default family: every form
+    /// set containing no free form.
+    pub types: FormFamily,
+}
+
+impl Default for ClaimsPolicy {
+    fn default() -> Self {
+        Self {
+            test: 1,
+            implementation: 1,
+            types: None,
+        }
+    }
+}
+
+impl ClaimsPolicy {
+    /// The multiplicity cap for a claim form.
+    ///
+    /// //= design/duplicates/spec.md#caps
+    /// //# The caps of
+    /// //# `spec`, `todo`, `exception`, and `implication` are fixed at 1 and
+    /// //# MUST NOT be configurable.
+    pub fn cap(&self, form: AnnotationType) -> u32 {
+        match form {
+            AnnotationType::Test => self.test,
+            AnnotationType::Citation => self.implementation,
+            _ => 1,
+        }
+    }
+
+    /// Whether the claim-form family admits this set of coexisting forms.
+    ///
+    /// //= design/duplicates/spec.md#exclusivity
+    /// //# The default claim-form family admits exactly the form sets
+    /// //# containing no free form
+    pub fn admits(&self, forms: &FormSet) -> bool {
+        match &self.types {
+            Some(family) => family.iter().any(|allowed| forms.is_subset(allowed)),
+            None => !forms.iter().any(|form| is_free_form(*form)),
+        }
+    }
+}
+
+/// Predicates over target classes (spec §4.2.2). Bounds are opt-in:
+/// unlimited when unset.
+#[derive(Clone, Debug, Default)]
+pub struct TargetsPolicy {
+    /// Fan-in bound: maximum annotations in one target class.
+    pub count: Option<u64>,
+    /// Maximum distinct sections claimed by one target class.
+    pub sections: Option<u64>,
+    /// The target-form family (spec §3.3). `None` = default family: every
+    /// form set that does not contain both `test` and `implementation`.
+    pub types: FormFamily,
+}
+
+impl TargetsPolicy {
+    /// Whether the target-form family admits this set of coexisting forms.
+    ///
+    /// //= design/duplicates/spec.md#type-combinations
+    /// //# The default family admits every form set that does not contain
+    /// //# both `test` and `implementation`
+    pub fn admits(&self, forms: &FormSet) -> bool {
+        match &self.types {
+            Some(family) => family.iter().any(|allowed| forms.is_subset(allowed)),
+            None => {
+                !(forms.contains(&AnnotationType::Test)
+                    && forms.contains(&AnnotationType::Citation))
+            }
+        }
+    }
+}
+
+/// Parse a claim form name as configuration input. `citation` is accepted as
+/// an alias for `implementation`; the canonical name is what we emit.
+pub fn parse_form_name(name: &str) -> Result<AnnotationType> {
+    match name.trim() {
+        "spec" => Ok(AnnotationType::Spec),
+        "test" => Ok(AnnotationType::Test),
+        "implementation" | "citation" => Ok(AnnotationType::Citation),
+        "exception" => Ok(AnnotationType::Exception),
+        "todo" => Ok(AnnotationType::Todo),
+        "implication" => Ok(AnnotationType::Implication),
+        other => Err(duvet_core::error!(
+            "unknown claim form {other:?} in duplicates configuration; \
+             expected one of: spec, test, implementation, exception, todo, implication"
+        )),
+    }
+}
+
+/// Parse a `+`-joined form-set family, e.g. `["exception+test"]`.
+pub fn parse_form_family(entries: &[String]) -> Result<Vec<FormSet>> {
+    let mut family = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let mut set = FormSet::new();
+        for name in entry.split('+') {
+            set.insert(parse_form_name(name)?);
+        }
+        if set.is_empty() {
+            return Err(duvet_core::error!(
+                "empty form set in duplicates configuration"
+            ));
+        }
+        family.push(set);
+    }
+    Ok(family)
+}
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -13,6 +180,7 @@ pub struct Config {
     pub requirements: Vec<Requirement>,
     pub specifications: Vec<Specification>,
     pub report: Report,
+    pub duplicates: DuplicatesPolicy,
     pub requirements_path: Path,
     pub download_path: Path,
 }
@@ -120,6 +288,7 @@ pub async fn load(path: Path, root: Path) -> Result<Arc<Config>> {
     let requirements_path = schema.requirements_path(&path, &root);
     let download_path = schema.download_path(&path, &root);
     let report = schema.report(&path, &root);
+    let duplicates = schema.duplicates()?;
 
     Ok(Arc::new(Config {
         sources,
@@ -128,6 +297,7 @@ pub async fn load(path: Path, root: Path) -> Result<Arc<Config>> {
         requirements_path,
         download_path,
         report,
+        duplicates,
     }))
 }
 
@@ -139,4 +309,96 @@ pub async fn default_path_and_root() -> Option<(Path, Path)> {
     let _ = vfs::read_metadata(&path).await.ok()?;
 
     Some((path, root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn forms(names: &[&str]) -> FormSet {
+        names
+            .iter()
+            .map(|name| parse_form_name(name).unwrap())
+            .collect()
+    }
+
+    /// spec §2.4: the default claim-form family admits exactly the form sets
+    /// containing no free form.
+    #[test]
+    fn default_claims_family_excludes_free_forms() {
+        let policy = ClaimsPolicy::default();
+        assert!(policy.admits(&forms(&["test", "implementation"])));
+        assert!(policy.admits(&forms(&["test"])));
+        for free in ["exception", "implication", "todo"] {
+            assert!(!policy.admits(&forms(&[free, "test"])), "{free}+test");
+            assert!(
+                !policy.admits(&forms(&[free, "implementation"])),
+                "{free}+implementation"
+            );
+        }
+    }
+
+    /// spec §3.3: the default target-form family admits every form set that
+    /// does not contain both `test` and `implementation`.
+    #[test]
+    fn default_targets_family_splits_test_from_implementation() {
+        let policy = TargetsPolicy::default();
+        assert!(!policy.admits(&forms(&["test", "implementation"])));
+        assert!(!policy.admits(&forms(&["test", "implementation", "exception"])));
+        assert!(policy.admits(&forms(&["exception", "test"])));
+        assert!(policy.admits(&forms(&["implementation", "implication"])));
+    }
+
+    /// spec §3.3: a configured family admits exactly subsets of its members;
+    /// `types = []` forbids all mixing.
+    #[test]
+    fn configured_family_is_subset_closed() {
+        let family = parse_form_family(&["exception+test".to_string()]).unwrap();
+        let policy = TargetsPolicy {
+            types: Some(family),
+            ..Default::default()
+        };
+        assert!(policy.admits(&forms(&["exception", "test"])));
+        assert!(policy.admits(&forms(&["exception"])), "subset is admitted");
+        assert!(!policy.admits(&forms(&["exception", "todo"])));
+
+        let empty = TargetsPolicy {
+            types: Some(vec![]),
+            ..Default::default()
+        };
+        assert!(!empty.admits(&forms(&["exception", "test"])));
+    }
+
+    /// spec §2.2: free-form caps are fixed at 1 regardless of the priced caps.
+    #[test]
+    fn free_form_caps_are_fixed() {
+        let policy = ClaimsPolicy {
+            test: 5,
+            implementation: 5,
+            types: None,
+        };
+        assert_eq!(policy.cap(AnnotationType::Test), 5);
+        assert_eq!(policy.cap(AnnotationType::Citation), 5);
+        for fixed in [
+            AnnotationType::Spec,
+            AnnotationType::Exception,
+            AnnotationType::Implication,
+            AnnotationType::Todo,
+        ] {
+            assert_eq!(policy.cap(fixed), 1, "{fixed:?}");
+        }
+    }
+
+    /// spec §1.1 / §4.2.3: `citation` accepted on input, `implementation`
+    /// emitted, unknown names rejected.
+    #[test]
+    fn form_name_round_trip() {
+        assert_eq!(
+            parse_form_name("citation").unwrap(),
+            AnnotationType::Citation
+        );
+        assert_eq!(form_name(AnnotationType::Citation), "implementation");
+        assert!(parse_form_name("citations").is_err());
+        assert!(parse_form_family(&["".to_string()]).is_err());
+    }
 }

--- a/duvet/src/config.rs
+++ b/duvet/src/config.rs
@@ -50,13 +50,80 @@ pub fn form_set_name_of(forms: &FormSet) -> String {
         .join("+")
 }
 
-/// Policy for the duplicates check and the duplicate-targets query
+/// Policy for the duplicates check
 /// (design/duplicates/spec.md §4). All policy is checked-in configuration;
 /// the command line never changes a verdict.
 #[derive(Clone, Debug, Default)]
 pub struct DuplicatesPolicy {
     pub claims: ClaimsPolicy,
     pub targets: TargetsPolicy,
+}
+
+impl DuplicatesPolicy {
+    /// Whether any target-axis gate is configured (fan-in bounds or an
+    /// explicit form family). When false, the target axis gates only on the
+    /// shipped form-family default.
+    pub fn targets_gates_configured(&self) -> bool {
+        self.targets.count.is_some()
+            || self.targets.sections.is_some()
+            || self.targets.types.is_some()
+    }
+
+    /// The effective policy, one line per setting, with values equal to the
+    /// shipped default labeled `(default)`. This is the discovery loop of
+    /// design/duplicates/decisions.md Decision 9: see every value, write the
+    /// numbers you want into config, and the run goes silent about everything
+    /// you have accepted.
+    pub fn describe(&self) -> String {
+        fn family(types: &FormFamily, default_meaning: &str) -> (String, &'static str) {
+            match types {
+                None => (default_meaning.to_string(), " (default)"),
+                Some(sets) => {
+                    let sets = sets
+                        .iter()
+                        .map(|set| format!("{:?}", form_set_name_of(set)))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    (format!("[{sets}]"), "")
+                }
+            }
+        }
+        fn bound(value: Option<u64>) -> (String, &'static str) {
+            match value {
+                None => ("unlimited".to_string(), " (default)"),
+                Some(value) => (value.to_string(), ""),
+            }
+        }
+
+        let mut out = String::new();
+        let mut line = |key: &str, value: String, label: &str| {
+            out.push_str(&format!("  {key} = {value}{label}\n"));
+        };
+
+        let default_mark = |cap: u32| if cap == 1 { " (default)" } else { "" };
+        line(
+            "claims.test",
+            self.claims.test.to_string(),
+            default_mark(self.claims.test),
+        );
+        line(
+            "claims.implementation",
+            self.claims.implementation.to_string(),
+            default_mark(self.claims.implementation),
+        );
+        let (value, label) = family(&self.claims.types, "no free form shares a claim");
+        line("claims.types", value, label);
+        let (value, label) = bound(self.targets.count);
+        line("targets.count", value, label);
+        let (value, label) = bound(self.targets.sections);
+        line("targets.sections", value, label);
+        let (value, label) = family(
+            &self.targets.types,
+            "any combination except test+implementation",
+        );
+        line("targets.types", value, label);
+        out
+    }
 }
 
 /// Predicates over claim classes (spec §4.2.1).

--- a/duvet/src/config.rs
+++ b/duvet/src/config.rs
@@ -15,13 +15,12 @@ pub type FormSet = BTreeSet<AnnotationType>;
 pub type FormFamily = Option<Vec<FormSet>>;
 
 /// The canonical user-facing name of a claim form.
-///
-/// //= design/duplicates/spec.md#annotation-model
-/// //# Every user-facing surface this
-/// //# specification defines — configuration keys, report sections,
-/// //# failure messages — MUST emit the name `implementation` and MUST
-/// //# NOT emit the name `citation`.
 pub fn form_name(form: AnnotationType) -> &'static str {
+    //= design/duplicates/spec.md#annotation-model
+    //# Every user-facing surface this
+    //# specification defines — configuration keys, report sections,
+    //# failure messages — MUST emit the name `implementation` and MUST
+    //# NOT emit the name `citation`.
     match form {
         AnnotationType::Spec => "spec",
         AnnotationType::Test => "test",
@@ -150,12 +149,11 @@ impl Default for ClaimsPolicy {
 
 impl ClaimsPolicy {
     /// The multiplicity cap for a claim form.
-    ///
-    /// //= design/duplicates/spec.md#caps
-    /// //# The caps of
-    /// //# `spec`, `todo`, `exception`, and `implication` are fixed at 1 and
-    /// //# MUST NOT be configurable.
     pub fn cap(&self, form: AnnotationType) -> u32 {
+        //= design/duplicates/spec.md#caps
+        //# The caps of
+        //# `spec`, `todo`, `exception`, and `implication` are fixed at 1 and
+        //# MUST NOT be configurable.
         match form {
             AnnotationType::Test => self.test,
             AnnotationType::Citation => self.implementation,
@@ -164,11 +162,10 @@ impl ClaimsPolicy {
     }
 
     /// Whether the claim-form family admits this set of coexisting forms.
-    ///
-    /// //= design/duplicates/spec.md#exclusivity
-    /// //# The default claim-form family admits exactly the form sets
-    /// //# containing no free form
     pub fn admits(&self, forms: &FormSet) -> bool {
+        //= design/duplicates/spec.md#exclusivity
+        //# The default claim-form family admits exactly the form sets
+        //# containing no free form
         match &self.types {
             Some(family) => family.iter().any(|allowed| forms.is_subset(allowed)),
             None => !forms.iter().any(|form| is_free_form(*form)),
@@ -191,11 +188,10 @@ pub struct TargetsPolicy {
 
 impl TargetsPolicy {
     /// Whether the target-form family admits this set of coexisting forms.
-    ///
-    /// //= design/duplicates/spec.md#type-combinations
-    /// //# The default family admits every form set that does not contain
-    /// //# both `test` and `implementation`
     pub fn admits(&self, forms: &FormSet) -> bool {
+        //= design/duplicates/spec.md#type-combinations
+        //# The default family admits every form set that does not contain
+        //# both `test` and `implementation`
         match &self.types {
             Some(family) => family.iter().any(|allowed| forms.is_subset(allowed)),
             None => {
@@ -209,6 +205,10 @@ impl TargetsPolicy {
 /// Parse a claim form name as configuration input. `citation` is accepted as
 /// an alias for `implementation`; the canonical name is what we emit.
 pub fn parse_form_name(name: &str) -> Result<AnnotationType> {
+    //= design/duplicates/spec.md#annotation-model
+    //# Wherever a claim form is read as
+    //# input, `citation` MUST be accepted as an alias for
+    //# `implementation`.
     match name.trim() {
         "spec" => Ok(AnnotationType::Spec),
         "test" => Ok(AnnotationType::Test),
@@ -225,6 +225,11 @@ pub fn parse_form_name(name: &str) -> Result<AnnotationType> {
 
 /// Parse a `+`-joined form-set family, e.g. `["exception+test"]`.
 pub fn parse_form_family(entries: &[String]) -> Result<Vec<FormSet>> {
+    //= design/duplicates/spec.md#schema-shared
+    //# Form names in configuration use the canonical vocabulary
+    //# ([§1.1](#annotation-model)); `citation` MUST be accepted as an
+    //# alias for `implementation` and MUST NOT appear in any emitted
+    //# output.
     let mut family = Vec::with_capacity(entries.len());
     for entry in entries {
         let mut set = FormSet::new();
@@ -393,6 +398,10 @@ mod tests {
     /// containing no free form.
     #[test]
     fn default_claims_family_excludes_free_forms() {
+        //= design/duplicates/spec.md#exclusivity
+        //= type=test
+        //# The default claim-form family admits exactly the form sets
+        //# containing no free form
         let policy = ClaimsPolicy::default();
         assert!(policy.admits(&forms(&["test", "implementation"])));
         assert!(policy.admits(&forms(&["test"])));
@@ -409,6 +418,10 @@ mod tests {
     /// does not contain both `test` and `implementation`.
     #[test]
     fn default_targets_family_splits_test_from_implementation() {
+        //= design/duplicates/spec.md#type-combinations
+        //= type=test
+        //# The default family admits every form set that does not contain
+        //# both `test` and `implementation`
         let policy = TargetsPolicy::default();
         assert!(!policy.admits(&forms(&["test", "implementation"])));
         assert!(!policy.admits(&forms(&["test", "implementation", "exception"])));
@@ -439,6 +452,11 @@ mod tests {
     /// spec §2.2: free-form caps are fixed at 1 regardless of the priced caps.
     #[test]
     fn free_form_caps_are_fixed() {
+        //= design/duplicates/spec.md#caps
+        //= type=test
+        //# The caps of
+        //# `spec`, `todo`, `exception`, and `implication` are fixed at 1 and
+        //# MUST NOT be configurable.
         let policy = ClaimsPolicy {
             test: 5,
             implementation: 5,
@@ -460,12 +478,33 @@ mod tests {
     /// emitted, unknown names rejected.
     #[test]
     fn form_name_round_trip() {
+        //= design/duplicates/spec.md#annotation-model
+        //= type=test
+        //# Wherever a claim form is read as
+        //# input, `citation` MUST be accepted as an alias for
+        //# `implementation`.
         assert_eq!(
             parse_form_name("citation").unwrap(),
             AnnotationType::Citation
         );
+        //= design/duplicates/spec.md#annotation-model
+        //= type=test
+        //# Every user-facing surface this
+        //# specification defines — configuration keys, report sections,
+        //# failure messages — MUST emit the name `implementation` and MUST
+        //# NOT emit the name `citation`.
         assert_eq!(form_name(AnnotationType::Citation), "implementation");
         assert!(parse_form_name("citations").is_err());
         assert!(parse_form_family(&["".to_string()]).is_err());
+        //= design/duplicates/spec.md#schema-shared
+        //= type=test
+        //# Form names in configuration use the canonical vocabulary
+        //# ([§1.1](#annotation-model)); `citation` MUST be accepted as an
+        //# alias for `implementation` and MUST NOT appear in any emitted
+        //# output.
+        assert_eq!(
+            parse_form_family(&["citation+test".to_string()]).unwrap(),
+            vec![forms(&["implementation", "test"])]
+        );
     }
 }

--- a/duvet/src/config/schema.rs
+++ b/duvet/src/config/schema.rs
@@ -67,6 +67,12 @@ impl Schema {
             Schema::V1_0_0(schema) => schema.report(config, root),
         }
     }
+
+    pub fn duplicates(&self) -> Result<config::DuplicatesPolicy> {
+        match self {
+            Schema::V1_0_0(schema) => schema.duplicates(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/duvet/src/config/schema/v0_4_0.rs
+++ b/duvet/src/config/schema/v0_4_0.rs
@@ -113,11 +113,10 @@ impl Schema {
     }
 
     /// Convert the raw `[duplicates]` section into the validated policy.
-    ///
-    /// //= design/duplicates/spec.md#policy-source
-    /// //# Every policy value in this specification MUST be read from
-    /// //# checked-in configuration.
     pub fn duplicates(&self) -> Result<config::DuplicatesPolicy> {
+        //= design/duplicates/spec.md#policy-source
+        //# Every policy value in this specification MUST be read from
+        //# checked-in configuration.
         let Some(schema) = &self.duplicates else {
             return Ok(config::DuplicatesPolicy::default());
         };
@@ -173,11 +172,11 @@ fn positive_cap(value: u32, key: &str) -> Result<u32> {
 /// The `[duplicates]` configuration section (design/duplicates/spec.md §4.2).
 /// Two namespaces mirror the two coincidence axes; every setting lives in
 /// exactly one namespace.
-///
-/// //= design/duplicates/spec.md#schema-shared
-/// //# An unrecognized key under `[duplicates.claims]` or
-/// //# `[duplicates.targets]` MUST be a configuration error, so a typo
-/// //# never silently takes a default.
+//
+//= design/duplicates/spec.md#schema-shared
+//# An unrecognized key under `[duplicates.claims]` or
+//# `[duplicates.targets]` MUST be a configuration error, so a typo
+//# never silently takes a default.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
@@ -189,14 +188,19 @@ pub struct DuplicatesSchema {
 }
 
 /// `[duplicates.claims]` — predicates over claim classes.
-///
-/// //= design/duplicates/spec.md#caps
-/// //# Caps MUST be configurable only for the priced forms.
+//
+//= design/duplicates/spec.md#caps
+//# Caps MUST be configurable only for the priced forms.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(schemars::JsonSchema))]
 pub struct DuplicatesClaims {
     /// Cap for `test` duplicate sets. Default 1.
+    //
+    //= design/duplicates/spec.md#schema-shared
+    //# Configuring a cap for a form other than `test` or
+    //# `implementation` MUST be a configuration error
+    //# ([§2.2](#caps)).
     #[serde(default)]
     pub test: Option<u32>,
     /// Cap for `implementation` duplicate sets. Default 1. `citation` is
@@ -501,6 +505,27 @@ impl From<SpecificationFormat> for crate::specification::Format {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn duplicates_schema_rejects_unknown_and_unpriced_caps() {
+        //= design/duplicates/spec.md#schema-shared
+        //= type=test
+        //# An unrecognized key under `[duplicates.claims]` or
+        //# `[duplicates.targets]` MUST be a configuration error, so a typo
+        //# never silently takes a default.
+        assert!(serde_json::from_str::<DuplicatesSchema>(r#"{"claims":{"bogus":1}}"#).is_err());
+        assert!(serde_json::from_str::<DuplicatesSchema>(r#"{"targets":{"bogus":1}}"#).is_err());
+        //= design/duplicates/spec.md#schema-shared
+        //= type=test
+        //# Configuring a cap for a form other than `test` or
+        //# `implementation` MUST be a configuration error
+        //# ([§2.2](#caps)).
+        assert!(serde_json::from_str::<DuplicatesSchema>(r#"{"claims":{"exception":1}}"#).is_err());
+        //= design/duplicates/spec.md#caps
+        //= type=test
+        //# Caps MUST be configurable only for the priced forms.
+        assert!(serde_json::from_str::<DuplicatesSchema>(r#"{"claims":{"todo":1}}"#).is_err());
+    }
 
     #[test]
     fn schema_test() {

--- a/duvet/src/config/schema/v0_4_0.rs
+++ b/duvet/src/config/schema/v0_4_0.rs
@@ -28,6 +28,11 @@ pub struct Schema {
     #[serde(default, rename = "specification")]
     pub specifications: Arc<[Specification]>,
 
+    /// Policy for the duplicates check and the duplicate-targets query
+    /// (design/duplicates/spec.md §4).
+    #[serde(default)]
+    pub duplicates: Option<DuplicatesSchema>,
+
     #[serde(rename = "$schema")]
     _schema: Option<Arc<str>>,
 }
@@ -106,6 +111,121 @@ impl Schema {
     pub fn report(&self, _config: &Path, _root: &Path) -> config::Report {
         (&*self.report).into()
     }
+
+    /// Convert the raw `[duplicates]` section into the validated policy.
+    ///
+    /// //= design/duplicates/spec.md#policy-source
+    /// //# Every policy value in this specification MUST be read from
+    /// //# checked-in configuration.
+    pub fn duplicates(&self) -> Result<config::DuplicatesPolicy> {
+        let Some(schema) = &self.duplicates else {
+            return Ok(config::DuplicatesPolicy::default());
+        };
+
+        let mut policy = config::DuplicatesPolicy::default();
+
+        if let Some(claims) = &schema.claims {
+            if let Some(test) = claims.test {
+                policy.claims.test = positive_cap(test, "duplicates.claims.test")?;
+            }
+            if let Some(implementation) = claims.implementation {
+                policy.claims.implementation =
+                    positive_cap(implementation, "duplicates.claims.implementation")?;
+            }
+            if let Some(types) = &claims.types {
+                policy.claims.types = Some(config::parse_form_family(types)?);
+            }
+        }
+
+        if let Some(targets) = &schema.targets {
+            if let Some(count) = targets.count {
+                if count == 0 {
+                    return Err(duvet_core::error!(
+                        "duplicates.targets.count must be a positive integer"
+                    ));
+                }
+                policy.targets.count = Some(count);
+            }
+            if let Some(sections) = targets.sections {
+                if sections == 0 {
+                    return Err(duvet_core::error!(
+                        "duplicates.targets.sections must be a positive integer"
+                    ));
+                }
+                policy.targets.sections = Some(sections);
+            }
+            if let Some(types) = &targets.types {
+                policy.targets.types = Some(config::parse_form_family(types)?);
+            }
+        }
+
+        Ok(policy)
+    }
+}
+
+fn positive_cap(value: u32, key: &str) -> Result<u32> {
+    if value == 0 {
+        return Err(duvet_core::error!("{key} must be a positive integer"));
+    }
+    Ok(value)
+}
+
+/// The `[duplicates]` configuration section (design/duplicates/spec.md §4.2).
+/// Two namespaces mirror the two coincidence axes; every setting lives in
+/// exactly one namespace.
+///
+/// //= design/duplicates/spec.md#schema-shared
+/// //# An unrecognized key under `[duplicates.claims]` or
+/// //# `[duplicates.targets]` MUST be a configuration error, so a typo
+/// //# never silently takes a default.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct DuplicatesSchema {
+    #[serde(default)]
+    pub claims: Option<DuplicatesClaims>,
+    #[serde(default)]
+    pub targets: Option<DuplicatesTargets>,
+}
+
+/// `[duplicates.claims]` — predicates over claim classes.
+///
+/// //= design/duplicates/spec.md#caps
+/// //# Caps MUST be configurable only for the priced forms.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct DuplicatesClaims {
+    /// Cap for `test` duplicate sets. Default 1.
+    #[serde(default)]
+    pub test: Option<u32>,
+    /// Cap for `implementation` duplicate sets. Default 1. `citation` is
+    /// accepted as an input alias and never emitted.
+    #[serde(default, alias = "citation")]
+    pub implementation: Option<u32>,
+    /// The claim-form family: allowed coexisting form sets, `+`-joined
+    /// (e.g. `["exception+test"]`). Unset = default family (no free form
+    /// shares a claim).
+    #[serde(default)]
+    pub types: Option<Vec<String>>,
+}
+
+/// `[duplicates.targets]` — predicates over target classes. Bounds are
+/// opt-in: unlimited when unset.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
+pub struct DuplicatesTargets {
+    /// Fan-in bound: maximum annotations per target.
+    #[serde(default)]
+    pub count: Option<u64>,
+    /// Maximum distinct sections per target.
+    #[serde(default)]
+    pub sections: Option<u64>,
+    /// The target-form family: allowed coexisting form sets, `+`-joined.
+    /// Unset = default family (everything except `test`+`implementation`).
+    #[serde(default)]
+    pub types: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/duvet/src/config/schema/v0_4_0.rs
+++ b/duvet/src/config/schema/v0_4_0.rs
@@ -28,7 +28,7 @@ pub struct Schema {
     #[serde(default, rename = "specification")]
     pub specifications: Arc<[Specification]>,
 
-    /// Policy for the duplicates check and the duplicate-targets query
+    /// Policy for the duplicates check — both coincidence axes
     /// (design/duplicates/spec.md §4).
     #[serde(default)]
     pub duplicates: Option<DuplicatesSchema>,

--- a/duvet/src/init.rs
+++ b/duvet/src/init.rs
@@ -88,18 +88,23 @@ impl Init {
                 out,
                 "# Duplicate policy for `duvet query --check duplicates`"
             )?;
+            writeln!(out, "# (semantics: design/duplicates/spec.md)")?;
+            writeln!(out, "# [duplicates.claims]")?;
             writeln!(
                 out,
-                "# (defaults shown; semantics: design/duplicates/spec.md)"
+                "# test = 1           # copies of one claim, per type (the default)"
             )?;
-            writeln!(out, "# [duplicates.claims]")?;
-            writeln!(out, "# test = 1           # copies of one claim, per type")?;
-            writeln!(out, "# implementation = 1")?;
+            writeln!(out, "# implementation = 1 # (the default)")?;
             writeln!(out, "# [duplicates.targets]")?;
             writeln!(
                 out,
-                "# count = 1           # annotations per resolved target (unlimited if unset)"
+                "# count = 1           # EXAMPLE, not the default (default: unlimited)."
             )?;
+            writeln!(
+                out,
+                "#                     # \"One target, one annotation\" -- the strict posture;"
+            )?;
+            writeln!(out, "#                     # duvet's own tree holds it.")?;
 
             Ok(())
         });

--- a/duvet/src/init.rs
+++ b/duvet/src/init.rs
@@ -82,6 +82,24 @@ impl Init {
             )?;
             writeln!(out, "[report.snapshot]")?;
             writeln!(out, "enabled = true")?;
+            writeln!(out)?;
+
+            writeln!(
+                out,
+                "# Duplicate policy for `duvet query --check duplicates`"
+            )?;
+            writeln!(
+                out,
+                "# (defaults shown; semantics: design/duplicates/spec.md)"
+            )?;
+            writeln!(out, "# [duplicates.claims]")?;
+            writeln!(out, "# test = 1           # copies of one claim, per type")?;
+            writeln!(out, "# implementation = 1")?;
+            writeln!(out, "# [duplicates.targets]")?;
+            writeln!(
+                out,
+                "# count = 1           # annotations per resolved target (unlimited if unset)"
+            )?;
 
             Ok(())
         });

--- a/duvet/src/query.rs
+++ b/duvet/src/query.rs
@@ -155,32 +155,27 @@ This is helpful for quick on-off checking of a single test.
     )]
     ExecutedCoverage,
     #[value(
-        help = "Checks annotations that share a claim (same section, same quoted requirement).
+        help = "Checks duplicate annotations on both coincidence axes: shared claims
+(same section, same quoted requirement) and shared targets (fan-in: several
+annotations resolving to one source position).
 
 The check FAILS when:
 - Two annotations with the same claim resolve to the same source position (any types)
 - A duplicate set (same-type copies of one claim) exceeds its configured cap
 - An annotation's claim is fully covered by other same-type annotations' claims
 - A free claim form (exception, implication, todo) shares a claim with any other annotation
-
-Policy lives in checked-in configuration ([duplicates.claims] in .duvet/config.toml);
-the command line never changes a verdict. Semantics: design/duplicates/spec.md"
-    )]
-    Duplicates,
-    #[value(
-        help = "Lists every source position that more than one annotation resolves to (fan-in),
-sorted by annotation count descending, with per-type breakdown and distinct-section count.
-
-The query FAILS when:
-- A target bears more annotations than the configured [duplicates.targets] count bound
-- A target bears annotations from more distinct sections than the sections bound
+- A target exceeds a configured [duplicates.targets] count/sections bound (opt-in)
 - A target mixes claim forms outside the allowed combinations (by default,
   test+implementation on one target fails)
 
-Bounds are opt-in (unlimited by default); the listing itself carries no verdict.
-Semantics: design/duplicates/spec.md"
+The report always includes the fan-in listing: every target bearing more than
+one annotation, count descending, with per-type breakdown and section count.
+
+Policy lives in checked-in configuration ([duplicates.claims] and
+[duplicates.targets] in .duvet/config.toml); the command line never changes a
+verdict. Semantics: design/duplicates/spec.md"
     )]
-    DuplicateTargets,
+    Duplicates,
 }
 
 impl Query {

--- a/duvet/src/query.rs
+++ b/duvet/src/query.rs
@@ -171,9 +171,25 @@ The check FAILS when:
 The report always includes the fan-in listing: every target bearing more than
 one annotation, count descending, with per-type breakdown and section count.
 
-Policy lives in checked-in configuration ([duplicates.claims] and
-[duplicates.targets] in .duvet/config.toml); the command line never changes a
-verdict. Semantics: design/duplicates/spec.md"
+Policy lives in checked-in configuration in .duvet/config.toml; the command
+line never changes a verdict. All keys, with their defaults:
+
+    [duplicates.claims]
+    test = 1            # max copies of one claim as test annotations
+    implementation = 1  # max copies as implementation annotations
+                        # (spec/todo/exception/implication: always unique)
+    types = [...]       # type combinations that may share one claim, each a
+                        # `+`-joined set, e.g. ['exception+test']. Unset:
+                        # test+implementation may mix; free forms never share
+
+    [duplicates.targets]
+    count = N           # max annotations per resolved target (unset: unlimited)
+    sections = N        # max distinct sections per target (unset: unlimited)
+    types = [...]       # type combinations that may share one target. Unset:
+                        # every combination except test+implementation
+
+Run with --verbose to print the effective policy of the current project.
+Semantics: design/duplicates/spec.md"
     )]
     Duplicates,
 }

--- a/duvet/src/query.rs
+++ b/duvet/src/query.rs
@@ -154,7 +154,33 @@ This is helpful for quick on-off checking of a single test.
 "
     )]
     ExecutedCoverage,
+    #[value(
+        help = "Checks annotations that share a claim (same section, same quoted requirement).
+
+The check FAILS when:
+- Two annotations with the same claim resolve to the same source position (any types)
+- A duplicate set (same-type copies of one claim) exceeds its configured cap
+- An annotation's claim is fully covered by other same-type annotations' claims
+- A free claim form (exception, implication, todo) shares a claim with any other annotation
+
+Policy lives in checked-in configuration ([duplicates.claims] in .duvet/config.toml);
+the command line never changes a verdict. Semantics: design/duplicates/spec.md"
+    )]
     Duplicates,
+    #[value(
+        help = "Lists every source position that more than one annotation resolves to (fan-in),
+sorted by annotation count descending, with per-type breakdown and distinct-section count.
+
+The query FAILS when:
+- A target bears more annotations than the configured [duplicates.targets] count bound
+- A target bears annotations from more distinct sections than the sections bound
+- A target mixes claim forms outside the allowed combinations (by default,
+  test+implementation on one target fails)
+
+Bounds are opt-in (unlimited by default); the listing itself carries no verdict.
+Semantics: design/duplicates/spec.md"
+    )]
+    DuplicateTargets,
 }
 
 impl Query {

--- a/duvet/src/query/checks/coverage.rs
+++ b/duvet/src/query/checks/coverage.rs
@@ -371,7 +371,7 @@ fn apply_annotation_override(
 }
 
 /// Stamp `{Annotation}` over an inclusive 1-based `(start, end)` line range.
-fn stamp_annotation_range(classifications: &mut [Option<LineClass>], range: (u64, u64)) {
+pub(super) fn stamp_annotation_range(classifications: &mut [Option<LineClass>], range: (u64, u64)) {
     let (start_line, end_line) = range;
     for line_num in start_line..=end_line {
         let idx = (line_num - 1) as usize;

--- a/duvet/src/query/checks/duplicates.rs
+++ b/duvet/src/query/checks/duplicates.rs
@@ -123,12 +123,16 @@ pub struct DuplicatesAnalysis {
 }
 
 impl DuplicatesAnalysis {
-    /// //= design/duplicates/spec.md#duplicates-verdict
-    /// //# The duplicates check MUST fail if and only if at least one rule of
-    /// //# [§2.1](#same-claim-same-target)–[§2.4](#exclusivity) or of the
-    /// //# target axis ([§3.2](#fan-in-bounds)–[§3.3](#type-combinations))
-    /// //# fires.
     pub fn passes(&self) -> bool {
+        //= design/duplicates/spec.md#duplicates-verdict
+        //# The duplicates check MUST fail if and only if at least one rule of
+        //# [§2.1](#same-claim-same-target)–[§2.4](#exclusivity) or of the
+        //# target axis ([§3.2](#fan-in-bounds)–[§3.3](#type-combinations))
+        //# fires.
+        //
+        //= design/duplicates/spec.md#partial-overlap
+        //# Verdict: a partial overlap MUST NOT fail the duplicates check,
+        //# matching the historical check.
         self.stacked.is_empty()
             && self.over_cap.is_empty()
             && self.subsumed.is_empty()
@@ -410,8 +414,8 @@ pub async fn analyze_duplicates(
                 analysis.subsumed.push(coverage);
             } else if !coverage.covering_annotations.is_empty() {
                 //= design/duplicates/spec.md#partial-overlap
-                //# The check MUST report them and MUST NOT
-                //# fail on them, matching the historical check.
+                //# Content: the check MUST identify every partial-overlap pair in
+                //# its analysis.
                 analysis.some_overlap.push(coverage);
             } else {
                 unique_by_form

--- a/duvet/src/query/checks/duplicates.rs
+++ b/duvet/src/query/checks/duplicates.rs
@@ -391,14 +391,23 @@ pub async fn analyze_duplicates(
     }
 
     for (form, form_annotations) in &by_form {
-        for annotation in form_annotations {
-            let Some(key) = ClaimKey::of(annotation) else {
+        // Precompute each annotation's claim key once. `ClaimKey::of` is a
+        // pure normalization, so hoisting it out of the pair loop is
+        // behavior-preserving; recomputing it per (annotation, other) pair
+        // was O(n²) normalizations per form.
+        let keyed: Vec<(&Arc<Annotation>, Option<ClaimKey>)> = form_annotations
+            .iter()
+            .map(|annotation| (annotation, ClaimKey::of(annotation)))
+            .collect();
+
+        for (annotation, annotation_key) in &keyed {
+            let Some(key) = annotation_key else {
                 continue;
             };
-            let pool: Vec<Arc<Annotation>> = form_annotations
+            let pool: Vec<Arc<Annotation>> = keyed
                 .iter()
-                .filter(|other| ClaimKey::of(other).as_ref() != Some(&key))
-                .cloned()
+                .filter(|(_, other_key)| other_key.as_ref() != Some(key))
+                .map(|(other, _)| Arc::clone(other))
                 .collect();
 
             let (coverage, coverage_errors) =
@@ -425,7 +434,7 @@ pub async fn analyze_duplicates(
                 unique_by_form
                     .entry(*form)
                     .or_default()
-                    .push(annotation.clone());
+                    .push(Arc::clone(annotation));
             }
         }
     }

--- a/duvet/src/query/checks/duplicates.rs
+++ b/duvet/src/query/checks/duplicates.rs
@@ -12,7 +12,7 @@
 
 use crate::{
     annotation::{Annotation, AnnotationType},
-    config::{is_free_form, DuplicatesPolicy, FormSet},
+    config::{DuplicatesPolicy, FormSet},
     query::{
         checks::{coverage::stamp_annotation_range, is_annotation_covered},
         classify::{classifier_for_path, Classification, DefaultClassifier, LineClassifier},
@@ -91,7 +91,8 @@ pub struct StackedClaim {
     pub members: Vec<Arc<Annotation>>,
 }
 
-/// A claim class failing free-form exclusivity (spec §2.4).
+/// A claim class whose mixed claim forms are admitted by no member of the
+/// claim-form family (spec §2.4).
 #[derive(Debug)]
 pub struct ExclusivityViolation {
     pub forms: FormSet,
@@ -344,26 +345,24 @@ pub async fn analyze_duplicates(
             }
         }
 
-        // §2.4 — free-form exclusivity over the class's non-spec members.
+        // §2.4 — the claim-form family over the class's non-spec members.
         //
         //= design/duplicates/spec.md#exclusivity
-        //# A claim class whose non-`spec` members include an annotation of a
-        //# free form and number more than one MUST fail the duplicates check,
-        //# unless the set of non-`spec` claim forms in the class is admitted
-        //# by the configured claim-form family
+        //# A claim class whose non-`spec` members bear two or more distinct
+        //# claim forms MUST fail the duplicates check unless the set of
+        //# non-`spec` claim forms is admitted by the configured claim-form
+        //# family
         let non_spec: Vec<Arc<Annotation>> = members
             .iter()
             .filter(|member| member.anno != AnnotationType::Spec)
             .cloned()
             .collect();
-        if non_spec.len() > 1 && non_spec.iter().any(|member| is_free_form(member.anno)) {
-            let forms: FormSet = non_spec.iter().map(|member| member.anno).collect();
-            if !policy.claims.admits(&forms) {
-                analysis.exclusivity.push(ExclusivityViolation {
-                    forms,
-                    members: non_spec,
-                });
-            }
+        let forms: FormSet = non_spec.iter().map(|member| member.anno).collect();
+        if forms.len() >= 2 && !policy.claims.admits(&forms) {
+            analysis.exclusivity.push(ExclusivityViolation {
+                forms,
+                members: non_spec,
+            });
         }
     }
 

--- a/duvet/src/query/checks/duplicates.rs
+++ b/duvet/src/query/checks/duplicates.rs
@@ -10,7 +10,7 @@
 
 use crate::{
     annotation::{Annotation, AnnotationType},
-    config::{is_free_form, FormSet},
+    config::{is_free_form, DuplicatesPolicy, FormSet},
     query::{
         checks::{coverage::stamp_annotation_range, is_annotation_covered},
         classify::{classifier_for_path, Classification, DefaultClassifier, LineClassifier},
@@ -114,17 +114,23 @@ pub struct DuplicatesAnalysis {
     pub some_overlap: Vec<AnnotationCoverage>,
     /// Annotations with no duplicate relationship at all (verbose display).
     pub unique: Vec<(AnnotationType, Vec<Arc<Annotation>>)>,
+    /// The target axis (spec §3): fan-in listing and its bounds. One check
+    /// evaluates both axes, mirroring the one `[duplicates]` config table.
+    pub targets: DuplicateTargetsAnalysis,
 }
 
 impl DuplicatesAnalysis {
     /// //= design/duplicates/spec.md#duplicates-verdict
     /// //# The duplicates check MUST fail if and only if at least one rule of
-    /// //# [§2.1](#same-claim-same-target)–[§2.4](#exclusivity) fires.
+    /// //# [§2.1](#same-claim-same-target)–[§2.4](#exclusivity) or of the
+    /// //# target axis ([§3.2](#fan-in-bounds)–[§3.3](#type-combinations))
+    /// //# fires.
     pub fn passes(&self) -> bool {
         self.stacked.is_empty()
             && self.over_cap.is_empty()
             && self.subsumed.is_empty()
             && self.exclusivity.is_empty()
+            && self.targets.passes()
     }
 }
 
@@ -280,7 +286,10 @@ pub async fn analyze_duplicates(
     let classes = claim_classes(&annotations);
     let targets = resolve_targets(&annotations).await?;
 
-    let mut analysis = DuplicatesAnalysis::default();
+    let mut analysis = DuplicatesAnalysis {
+        targets: analyze_target_axis(&annotations, &targets, policy),
+        ..Default::default()
+    };
 
     for (_key, members) in classes.iter() {
         // §2.1 — same claim, same resolved target: always fails, every form
@@ -417,23 +426,15 @@ pub async fn analyze_duplicates(
     Ok((analysis, errors))
 }
 
-/// Run the duplicate-targets query (spec §3) over the in-scope annotations.
-pub async fn analyze_duplicate_targets(
-    project_data: &ProjectData,
-    mode: &RequirementMode,
-) -> Result<DuplicateTargetsAnalysis> {
-    let annotations: Vec<Arc<Annotation>> = project_data
-        .annotations
-        .iter()
-        .filter(|annotation| mode.in_scope(annotation))
-        .cloned()
-        .collect();
-
-    let policy = &project_data.duplicates_policy;
-    let targets = resolve_targets(&annotations).await?;
-
+/// The target axis (spec §3) over the in-scope annotations and their
+/// precomputed resolution.
+fn analyze_target_axis(
+    annotations: &[Arc<Annotation>],
+    targets: &HashMap<Arc<Annotation>, ResolvedTarget>,
+    policy: &DuplicatesPolicy,
+) -> DuplicateTargetsAnalysis {
     let mut by_target: BTreeMap<ResolvedTarget, Vec<Arc<Annotation>>> = BTreeMap::new();
-    for annotation in &annotations {
+    for annotation in annotations {
         if let Some(target) = targets.get(annotation) {
             by_target
                 .entry(target.clone())
@@ -443,7 +444,8 @@ pub async fn analyze_duplicate_targets(
     }
 
     //= design/duplicates/spec.md#fan-in-listing
-    //# The listing MUST contain a target if and only if two or more
+    //# it
+    //# MUST contain a target if and only if two or more
     //# annotations resolve to it.
     let mut listing: Vec<TargetClass> = by_target
         .into_iter()
@@ -481,7 +483,7 @@ pub async fn analyze_duplicate_targets(
     for (index, class) in analysis.listing.iter().enumerate() {
         //= design/duplicates/spec.md#fan-in-bounds
         //# When a bound is configured, a target class exceeding it MUST fail
-        //# the query.
+        //# the duplicates check.
         if let Some(count) = policy.targets.count {
             if class.count() as u64 > count {
                 analysis.count_violations.push(index);
@@ -495,13 +497,13 @@ pub async fn analyze_duplicate_targets(
 
         //= design/duplicates/spec.md#type-combinations
         //# A target class bearing two or more distinct claim forms MUST fail
-        //# the query unless its form set is a subset of some member of the
-        //# family.
+        //# the duplicates check unless its form set is a subset of some
+        //# member of the family.
         let form_set = class.form_set();
         if form_set.len() >= 2 && !policy.targets.admits(&form_set) {
             analysis.type_violations.push(index);
         }
     }
 
-    Ok(analysis)
+    analysis
 }

--- a/duvet/src/query/checks/duplicates.rs
+++ b/duvet/src/query/checks/duplicates.rs
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The duplicates check and the duplicate-targets query.
+//! The duplicates check.
 //!
 //! Normative semantics: design/duplicates/spec.md. Rationale:
 //! design/duplicates/decisions.md. Every rule here is a predicate over one of
 //! the two partitions the spec defines — claim classes (annotations sharing a
 //! requirement) and target classes (annotations sharing a resolved position).
+//! One check evaluates both axes, mirroring the one `[duplicates]` config
+//! table.
 
 use crate::{
     annotation::{Annotation, AnnotationType},
@@ -134,7 +136,7 @@ impl DuplicatesAnalysis {
     }
 }
 
-/// One entry of the duplicate-targets listing: a target class of size ≥ 2.
+/// One entry of the fan-in listing: a target class of size ≥ 2.
 #[derive(Debug)]
 pub struct TargetClass {
     pub target: ResolvedTarget,
@@ -155,7 +157,7 @@ impl TargetClass {
     }
 }
 
-/// The duplicate-targets query's analysis (spec §3).
+/// The target-axis analysis of the duplicates check (spec §3).
 #[derive(Debug, Default)]
 pub struct DuplicateTargetsAnalysis {
     /// §3.1: every target class of size ≥ 2, sorted by count descending.

--- a/duvet/src/query/checks/duplicates.rs
+++ b/duvet/src/query/checks/duplicates.rs
@@ -355,12 +355,16 @@ pub async fn analyze_duplicates(
         //# A claim class whose non-`spec` members bear two or more distinct
         //# claim forms MUST fail the duplicates check unless the set of
         //# non-`spec` claim forms is admitted by the configured claim-form
-        //# family
+        //# family ([§4.2](#schema-claims)).
         let non_spec: Vec<Arc<Annotation>> = members
             .iter()
             .filter(|member| member.anno != AnnotationType::Spec)
             .cloned()
             .collect();
+        //= design/duplicates/spec.md#exclusivity
+        //# A claim class whose non-`spec`
+        //# members bear a single claim form MUST NOT fail this rule: copies
+        //# of one form are the caps' business ([§2.2](#caps)).
         let forms: FormSet = non_spec.iter().map(|member| member.anno).collect();
         if forms.len() >= 2 && !policy.claims.admits(&forms) {
             analysis.exclusivity.push(ExclusivityViolation {
@@ -449,9 +453,9 @@ fn analyze_target_axis(
     }
 
     //= design/duplicates/spec.md#fan-in-listing
-    //# it
-    //# MUST contain a target if and only if two or more
-    //# annotations resolve to it.
+    //# The duplicates check's report MUST include the fan-in listing: it
+    //# MUST contain a target if and only if two or more annotations
+    //# resolve to it.
     let mut listing: Vec<TargetClass> = by_target
         .into_iter()
         .filter(|(_, members)| members.len() >= 2)
@@ -472,8 +476,9 @@ fn analyze_target_axis(
         .collect();
 
     //= design/duplicates/spec.md#fan-in-listing
-    //# the listing MUST be
-    //# sorted by annotation count descending.
+    //# Each listed target MUST report its exact annotation count, its
+    //# per-form breakdown, and its distinct-section count, and the
+    //# listing MUST be sorted by annotation count descending.
     listing.sort_by(|a, b| {
         b.count()
             .cmp(&a.count())
@@ -505,6 +510,9 @@ fn analyze_target_axis(
         //# the duplicates check unless its form set is a subset of some
         //# member of the family.
         let form_set = class.form_set();
+        //= design/duplicates/spec.md#type-combinations
+        //# A target class bearing a single claim form
+        //# MUST NOT fail this rule.
         if form_set.len() >= 2 && !policy.targets.admits(&form_set) {
             analysis.type_violations.push(index);
         }

--- a/duvet/src/query/checks/duplicates.rs
+++ b/duvet/src/query/checks/duplicates.rs
@@ -1,0 +1,507 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The duplicates check and the duplicate-targets query.
+//!
+//! Normative semantics: design/duplicates/spec.md. Rationale:
+//! design/duplicates/decisions.md. Every rule here is a predicate over one of
+//! the two partitions the spec defines — claim classes (annotations sharing a
+//! requirement) and target classes (annotations sharing a resolved position).
+
+use crate::{
+    annotation::{Annotation, AnnotationType},
+    config::{is_free_form, FormSet},
+    query::{
+        checks::{coverage::stamp_annotation_range, is_annotation_covered},
+        classify::{classifier_for_path, Classification, DefaultClassifier, LineClassifier},
+        engine::ProjectData,
+        requirements::RequirementMode,
+        result::AnnotationCoverage,
+    },
+    text::whitespace,
+    Error, Result,
+};
+use duvet_core::path::Path;
+use duvet_coverage::{target_resolution::annotation_target, types::AnnotationSpan};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    sync::Arc,
+};
+
+/// A resolved target: the source position an annotation resolves to under the
+/// coverage model's target resolution, identified as (file, line).
+///
+/// //= design/duplicates/spec.md#targets
+/// //# The **resolved target** of an annotation is the source position
+/// //# its annotation block resolves to under the coverage model's target
+/// //# resolution (the classified or the degraded path), identified as
+/// //# the pair (source file, resolved line).
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ResolvedTarget {
+    pub file: Path,
+    pub line: u64,
+}
+
+/// The claim of an annotation: its target (spec + section) plus its
+/// whitespace-normalized quote.
+///
+/// //= design/duplicates/spec.md#claims
+/// //# Two annotations **share a claim** if and only if their target
+/// //# sections are identical and their normalized quotes are identical.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ClaimKey {
+    pub target: String,
+    pub quote: String,
+}
+
+impl ClaimKey {
+    /// The claim of an annotation, or `None` for a section-level reference.
+    ///
+    /// //= design/duplicates/spec.md#claims
+    /// //# An annotation whose normalized quote is empty is a section-level
+    /// //# reference, not a claim: it participates in no claim class and no
+    /// //# rule in [§2](#duplicates-check) applies to it.
+    pub fn of(annotation: &Annotation) -> Option<Self> {
+        let quote = whitespace::normalize(&annotation.quote);
+        if quote.is_empty() {
+            return None;
+        }
+        Some(Self {
+            target: annotation.target.clone(),
+            quote,
+        })
+    }
+}
+
+/// A duplicate set: the members of one claim class restricted to one form,
+/// with the cap that governs it.
+#[derive(Debug)]
+pub struct DuplicateSet {
+    pub form: AnnotationType,
+    pub cap: u32,
+    pub members: Vec<Arc<Annotation>>,
+}
+
+/// A same-claim-same-target stack (spec §2.1).
+#[derive(Debug)]
+pub struct StackedClaim {
+    pub target: ResolvedTarget,
+    pub members: Vec<Arc<Annotation>>,
+}
+
+/// A claim class failing free-form exclusivity (spec §2.4).
+#[derive(Debug)]
+pub struct ExclusivityViolation {
+    pub forms: FormSet,
+    pub members: Vec<Arc<Annotation>>,
+}
+
+/// The duplicates check's analysis (spec §2).
+#[derive(Debug, Default)]
+pub struct DuplicatesAnalysis {
+    /// §2.1 violations: same claim, same resolved target — any forms.
+    pub stacked: Vec<StackedClaim>,
+    /// §2.2 violations: duplicate sets over their cap.
+    pub over_cap: Vec<DuplicateSet>,
+    /// §2.2 surfaced multiplicity: duplicate sets of size > 1 within cap.
+    pub allowed_sets: Vec<DuplicateSet>,
+    /// §2.3 violations: claims fully covered by same-form claims outside
+    /// their class.
+    pub subsumed: Vec<AnnotationCoverage>,
+    /// §2.4 violations: free forms sharing a claim.
+    pub exclusivity: Vec<ExclusivityViolation>,
+    /// §2.5: partial overlap, reported and never failed.
+    pub some_overlap: Vec<AnnotationCoverage>,
+    /// Annotations with no duplicate relationship at all (verbose display).
+    pub unique: Vec<(AnnotationType, Vec<Arc<Annotation>>)>,
+}
+
+impl DuplicatesAnalysis {
+    /// //= design/duplicates/spec.md#duplicates-verdict
+    /// //# The duplicates check MUST fail if and only if at least one rule of
+    /// //# [§2.1](#same-claim-same-target)–[§2.4](#exclusivity) fires.
+    pub fn passes(&self) -> bool {
+        self.stacked.is_empty()
+            && self.over_cap.is_empty()
+            && self.subsumed.is_empty()
+            && self.exclusivity.is_empty()
+    }
+}
+
+/// One entry of the duplicate-targets listing: a target class of size ≥ 2.
+#[derive(Debug)]
+pub struct TargetClass {
+    pub target: ResolvedTarget,
+    pub members: Vec<Arc<Annotation>>,
+    /// Per-form member counts.
+    pub forms: BTreeMap<AnnotationType, usize>,
+    /// Distinct (spec, section) targets claimed by members.
+    pub sections: usize,
+}
+
+impl TargetClass {
+    pub fn count(&self) -> usize {
+        self.members.len()
+    }
+
+    pub fn form_set(&self) -> FormSet {
+        self.forms.keys().copied().collect()
+    }
+}
+
+/// The duplicate-targets query's analysis (spec §3).
+#[derive(Debug, Default)]
+pub struct DuplicateTargetsAnalysis {
+    /// §3.1: every target class of size ≥ 2, sorted by count descending.
+    pub listing: Vec<TargetClass>,
+    /// Indices into `listing` violating the `count` bound (§3.2).
+    pub count_violations: Vec<usize>,
+    /// Indices into `listing` violating the `sections` bound (§3.2).
+    pub sections_violations: Vec<usize>,
+    /// Indices into `listing` violating the form-combination rule (§3.3).
+    pub type_violations: Vec<usize>,
+}
+
+impl DuplicateTargetsAnalysis {
+    pub fn passes(&self) -> bool {
+        self.count_violations.is_empty()
+            && self.sections_violations.is_empty()
+            && self.type_violations.is_empty()
+    }
+}
+
+/// Resolve the target of every annotation, statically: classification only,
+/// no coverage data. Files with a language classifier use its classification;
+/// files without one use the minimal universal classification (the degraded
+/// path's input). Both feed the same verified forward walk.
+///
+/// //= design/duplicates/spec.md#targets
+/// //# An annotation whose target does not resolve (defeated
+/// //# classification, or resolution yielding no line) participates in no
+/// //# target class.
+pub async fn resolve_targets(
+    annotations: &[Arc<Annotation>],
+) -> Result<HashMap<Arc<Annotation>, ResolvedTarget>> {
+    let mut by_file: BTreeMap<Path, Vec<Arc<Annotation>>> = BTreeMap::new();
+    for annotation in annotations {
+        // Requirement TOMLs are not source files; their annotations (extracted
+        // requirements) have no source position to resolve.
+        if annotation
+            .source
+            .extension()
+            .is_some_and(|ext| ext == "toml")
+        {
+            continue;
+        }
+        by_file
+            .entry(annotation.source.clone())
+            .or_default()
+            .push(annotation.clone());
+    }
+
+    let mut resolved = HashMap::new();
+
+    for (file, file_annotations) in by_file {
+        let source = duvet_core::vfs::read_string(&file).await?;
+        let content = source.to_string();
+        let line_count = content.lines().count() as u64;
+
+        // Classified when a language classifier exists and parses the file;
+        // otherwise the minimal universal classification. A defeated
+        // classification (parse failure) resolves nothing in the file.
+        let classification = match classifier_for_path(&file) {
+            Some(classifier) => classifier.classify(&content),
+            None => DefaultClassifier.classify(&content),
+        };
+        let mut classifications = match classification {
+            Classification::Classified(c) => c,
+            Classification::Unclassifiable { .. } => continue,
+        };
+
+        // Duvet's parsed annotation ranges are authoritative over the
+        // classifier's heuristic prefix detection — same override the
+        // coverage model applies before resolution.
+        for annotation in &file_annotations {
+            stamp_annotation_range(&mut classifications, annotation.line_range());
+        }
+
+        for annotation in file_annotations {
+            let (start_line, end_line) = annotation.line_range();
+            // `end_line` is a line tally; u64::MAX lines is unreachable.
+            debug_assert!(end_line < u64::MAX);
+            let span = AnnotationSpan {
+                start_line,
+                end_line,
+            };
+            if let Some(target) = annotation_target(&span, &classifications, line_count) {
+                resolved.insert(
+                    annotation,
+                    ResolvedTarget {
+                        file: file.clone(),
+                        line: target.line_number,
+                    },
+                );
+            }
+        }
+    }
+
+    Ok(resolved)
+}
+
+/// Group annotations into claim classes (spec §1.2). Section-level references
+/// (empty normalized quote) participate in no class.
+fn claim_classes(annotations: &[Arc<Annotation>]) -> BTreeMap<ClaimKey, Vec<Arc<Annotation>>> {
+    let mut classes: BTreeMap<ClaimKey, Vec<Arc<Annotation>>> = BTreeMap::new();
+    for annotation in annotations {
+        if let Some(key) = ClaimKey::of(annotation) {
+            classes.entry(key).or_default().push(annotation.clone());
+        }
+    }
+    classes
+}
+
+/// Run the duplicates check (spec §2) over the in-scope annotations.
+///
+/// Returns the analysis plus every quote-location error collected along the
+/// way; the caller aggregates and fails the run if any were found, after all
+/// were gathered.
+pub async fn analyze_duplicates(
+    project_data: &ProjectData,
+    mode: &RequirementMode,
+) -> Result<(DuplicatesAnalysis, Vec<Error>)> {
+    let annotations: Vec<Arc<Annotation>> = project_data
+        .annotations
+        .iter()
+        .filter(|annotation| mode.in_scope(annotation))
+        .cloned()
+        .collect();
+
+    let policy = &project_data.duplicates_policy;
+    let classes = claim_classes(&annotations);
+    let targets = resolve_targets(&annotations).await?;
+
+    let mut analysis = DuplicatesAnalysis::default();
+
+    for (_key, members) in classes.iter() {
+        // §2.1 — same claim, same resolved target: always fails, every form
+        // pair, cap-independent.
+        //
+        //= design/duplicates/spec.md#same-claim-same-target
+        //# Two annotations that share a claim and share a resolved target
+        //# MUST fail the duplicates check, regardless of their claim forms
+        //# and regardless of any configured cap.
+        let mut by_target: BTreeMap<&ResolvedTarget, Vec<Arc<Annotation>>> = BTreeMap::new();
+        for member in members {
+            if let Some(target) = targets.get(member) {
+                by_target.entry(target).or_default().push(member.clone());
+            }
+        }
+        for (target, stack) in by_target {
+            if stack.len() > 1 {
+                analysis.stacked.push(StackedClaim {
+                    target: target.clone(),
+                    members: stack,
+                });
+            }
+        }
+
+        // §2.2 — multiplicity caps per duplicate set.
+        //
+        //= design/duplicates/spec.md#caps
+        //# A duplicate set whose size exceeds its form's cap MUST fail the
+        //# duplicates check.
+        let mut by_form: BTreeMap<AnnotationType, Vec<Arc<Annotation>>> = BTreeMap::new();
+        for member in members {
+            by_form.entry(member.anno).or_default().push(member.clone());
+        }
+        for (form, set_members) in &by_form {
+            let cap = policy.claims.cap(*form);
+            let set = DuplicateSet {
+                form: *form,
+                cap,
+                members: set_members.clone(),
+            };
+            if set_members.len() as u64 > cap as u64 {
+                analysis.over_cap.push(set);
+            } else if set_members.len() > 1 {
+                //= design/duplicates/spec.md#caps
+                //# A duplicate set within its cap MUST pass this check
+                //# ([Decision 5](decisions.md#decision-5)), and when its size exceeds
+                //# one it MUST be reported with its size and every member's location,
+                //# so multiplicity is always surfaced, never silent.
+                analysis.allowed_sets.push(set);
+            }
+        }
+
+        // §2.4 — free-form exclusivity over the class's non-spec members.
+        //
+        //= design/duplicates/spec.md#exclusivity
+        //# A claim class whose non-`spec` members include an annotation of a
+        //# free form and number more than one MUST fail the duplicates check,
+        //# unless the set of non-`spec` claim forms in the class is admitted
+        //# by the configured claim-form family
+        let non_spec: Vec<Arc<Annotation>> = members
+            .iter()
+            .filter(|member| member.anno != AnnotationType::Spec)
+            .cloned()
+            .collect();
+        if non_spec.len() > 1 && non_spec.iter().any(|member| is_free_form(member.anno)) {
+            let forms: FormSet = non_spec.iter().map(|member| member.anno).collect();
+            if !policy.claims.admits(&forms) {
+                analysis.exclusivity.push(ExclusivityViolation {
+                    forms,
+                    members: non_spec,
+                });
+            }
+        }
+    }
+
+    // §2.3 — subsumption: a claim fully covered by same-form claims outside
+    // its own class. Reuses the engine's coverage relation with the coverer
+    // pool restricted to same-form annotations whose claim differs, so a
+    // claim-class twin never counts as a coverer (twins are the cap's
+    // business, §2.2). Partial overlap surfaces here too (§2.5).
+    let mut errors: Vec<Error> = Vec::new();
+    let mut unique_by_form: BTreeMap<AnnotationType, Vec<Arc<Annotation>>> = BTreeMap::new();
+
+    let mut by_form: BTreeMap<AnnotationType, Vec<Arc<Annotation>>> = BTreeMap::new();
+    for annotation in &annotations {
+        by_form
+            .entry(annotation.anno)
+            .or_default()
+            .push(annotation.clone());
+    }
+
+    for (form, form_annotations) in &by_form {
+        for annotation in form_annotations {
+            let Some(key) = ClaimKey::of(annotation) else {
+                continue;
+            };
+            let pool: Vec<Arc<Annotation>> = form_annotations
+                .iter()
+                .filter(|other| ClaimKey::of(other).as_ref() != Some(&key))
+                .cloned()
+                .collect();
+
+            let (coverage, coverage_errors) =
+                is_annotation_covered(annotation, &project_data.specifications, &pool).await;
+            errors.extend(coverage_errors);
+
+            let Some(coverage) = coverage else {
+                continue;
+            };
+
+            if coverage.fully_covered {
+                //= design/duplicates/spec.md#subsumption
+                //# An annotation whose claim is fully covered
+                //# ([§1.3](#claim-coverage)) by the claims of same-form annotations
+                //# outside its own claim class MUST fail the duplicates check,
+                //# regardless of any configured cap.
+                analysis.subsumed.push(coverage);
+            } else if !coverage.covering_annotations.is_empty() {
+                //= design/duplicates/spec.md#partial-overlap
+                //# The check MUST report them and MUST NOT
+                //# fail on them, matching the historical check.
+                analysis.some_overlap.push(coverage);
+            } else {
+                unique_by_form
+                    .entry(*form)
+                    .or_default()
+                    .push(annotation.clone());
+            }
+        }
+    }
+
+    analysis.unique = unique_by_form.into_iter().collect();
+
+    Ok((analysis, errors))
+}
+
+/// Run the duplicate-targets query (spec §3) over the in-scope annotations.
+pub async fn analyze_duplicate_targets(
+    project_data: &ProjectData,
+    mode: &RequirementMode,
+) -> Result<DuplicateTargetsAnalysis> {
+    let annotations: Vec<Arc<Annotation>> = project_data
+        .annotations
+        .iter()
+        .filter(|annotation| mode.in_scope(annotation))
+        .cloned()
+        .collect();
+
+    let policy = &project_data.duplicates_policy;
+    let targets = resolve_targets(&annotations).await?;
+
+    let mut by_target: BTreeMap<ResolvedTarget, Vec<Arc<Annotation>>> = BTreeMap::new();
+    for annotation in &annotations {
+        if let Some(target) = targets.get(annotation) {
+            by_target
+                .entry(target.clone())
+                .or_default()
+                .push(annotation.clone());
+        }
+    }
+
+    //= design/duplicates/spec.md#fan-in-listing
+    //# The listing MUST contain a target if and only if two or more
+    //# annotations resolve to it.
+    let mut listing: Vec<TargetClass> = by_target
+        .into_iter()
+        .filter(|(_, members)| members.len() >= 2)
+        .map(|(target, members)| {
+            let mut forms: BTreeMap<AnnotationType, usize> = BTreeMap::new();
+            let mut sections: BTreeSet<&str> = BTreeSet::new();
+            for member in &members {
+                *forms.entry(member.anno).or_default() += 1;
+                sections.insert(member.target.as_str());
+            }
+            TargetClass {
+                target,
+                sections: sections.len(),
+                forms,
+                members,
+            }
+        })
+        .collect();
+
+    //= design/duplicates/spec.md#fan-in-listing
+    //# the listing MUST be
+    //# sorted by annotation count descending.
+    listing.sort_by(|a, b| {
+        b.count()
+            .cmp(&a.count())
+            .then_with(|| a.target.cmp(&b.target))
+    });
+
+    let mut analysis = DuplicateTargetsAnalysis {
+        listing,
+        ..Default::default()
+    };
+
+    for (index, class) in analysis.listing.iter().enumerate() {
+        //= design/duplicates/spec.md#fan-in-bounds
+        //# When a bound is configured, a target class exceeding it MUST fail
+        //# the query.
+        if let Some(count) = policy.targets.count {
+            if class.count() as u64 > count {
+                analysis.count_violations.push(index);
+            }
+        }
+        if let Some(sections) = policy.targets.sections {
+            if class.sections as u64 > sections {
+                analysis.sections_violations.push(index);
+            }
+        }
+
+        //= design/duplicates/spec.md#type-combinations
+        //# A target class bearing two or more distinct claim forms MUST fail
+        //# the query unless its form set is a subset of some member of the
+        //# family.
+        let form_set = class.form_set();
+        if form_set.len() >= 2 && !policy.targets.admits(&form_set) {
+            analysis.type_violations.push(index);
+        }
+    }
+
+    Ok(analysis)
+}

--- a/duvet/src/query/checks/mod.rs
+++ b/duvet/src/query/checks/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 use std::{collections::HashMap, sync::Arc};
 
 pub mod coverage;
+pub mod duplicates;
 
 /// Check if a target annotation is covered by a collection annotations
 /// A target annotation is covered,

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -13,9 +13,8 @@ use super::{
     coverage::ExecutionStatus,
     requirements::RequirementMode,
     result::{
-        CheckResult, CoverageResult, CoveredTestAnnotation, DuplicateTargetsResult,
-        DuplicatesResult, ImplementationResult, NotExecutedAnnotation, QueryResult, QueryStatus,
-        TestResult,
+        CheckResult, CoverageResult, CoveredTestAnnotation, DuplicatesResult, ImplementationResult,
+        NotExecutedAnnotation, QueryResult, QueryStatus, TestResult,
     },
     CheckType,
 };
@@ -58,10 +57,6 @@ pub async fn execute_checks(
             }
             CheckType::Duplicates => {
                 let result = execute_duplicates(&project_data, mode, verbose).await?;
-                results.push(result);
-            }
-            CheckType::DuplicateTargets => {
-                let result = execute_duplicate_targets(&project_data, mode, verbose).await?;
                 results.push(result);
             }
             CheckType::Coverage | CheckType::ExecutedCoverage => {
@@ -664,9 +659,10 @@ async fn execute_coverage_check(
     }))
 }
 
-/// The duplicates check (design/duplicates/spec.md §2): predicates over claim
-/// classes — same-target stacking, multiplicity caps, subsumption, and
-/// free-form exclusivity. Structure only: evidence billing of duplicate
+/// The duplicates check (design/duplicates/spec.md §2–§3): predicates over
+/// both coincidence axes — claim classes (same-target stacking, multiplicity
+/// caps, subsumption, free-form exclusivity) and target classes (fan-in
+/// listing, opt-in bounds, form combinations). Structure only: evidence billing of duplicate
 /// copies is the coverage check's own contract, enforced whether or not this
 /// check runs (decisions.md Decision 5).
 async fn execute_duplicates(
@@ -693,31 +689,6 @@ async fn execute_duplicates(
     };
 
     Ok(CheckResult::Duplicates(DuplicatesResult {
-        status,
-        analysis,
-        verbose,
-    }))
-}
-
-/// The duplicate-targets query (design/duplicates/spec.md §3): the fan-in
-/// axis. A listing first — every target bearing more than one annotation,
-/// count descending — and a gate only where configuration opts in (`count`,
-/// `sections`) or the target-form family's default bites
-/// (`test`+`implementation` on one target).
-async fn execute_duplicate_targets(
-    project_data: &ProjectData,
-    mode: &RequirementMode,
-    verbose: bool,
-) -> Result<CheckResult> {
-    let analysis = super::checks::duplicates::analyze_duplicate_targets(project_data, mode).await?;
-
-    let status = if analysis.passes() {
-        QueryStatus::Pass
-    } else {
-        QueryStatus::Fail
-    };
-
-    Ok(CheckResult::DuplicateTargets(DuplicateTargetsResult {
         status,
         analysis,
         verbose,

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -120,7 +120,7 @@ pub struct ProjectData {
     >,
     pub project_sources: Arc<HashSet<SourceFile>>,
     pub annotations: AnnotationSet,
-    /// Checked-in policy for the duplicates check and duplicate-targets query
+    /// Checked-in policy for the duplicates check — both coincidence axes
     /// (design/duplicates/spec.md §4). Defaults apply when no config exists.
     pub duplicates_policy: crate::config::DuplicatesPolicy,
 }

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -691,6 +691,7 @@ async fn execute_duplicates(
     Ok(CheckResult::Duplicates(DuplicatesResult {
         status,
         analysis,
+        policy: project_data.duplicates_policy.clone(),
         verbose,
     }))
 }

--- a/duvet/src/query/engine.rs
+++ b/duvet/src/query/engine.rs
@@ -13,7 +13,7 @@ use super::{
     coverage::ExecutionStatus,
     requirements::RequirementMode,
     result::{
-        AnnotationCoverage, CheckResult, CoverageResult, CoveredTestAnnotation, Duplicates,
+        CheckResult, CoverageResult, CoveredTestAnnotation, DuplicateTargetsResult,
         DuplicatesResult, ImplementationResult, NotExecutedAnnotation, QueryResult, QueryStatus,
         TestResult,
     },
@@ -30,7 +30,7 @@ use crate::{
 use duvet_core::{diagnostic::IntoDiagnostic, progress};
 use glob::glob;
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashSet},
     sync::Arc,
 };
 
@@ -58,6 +58,10 @@ pub async fn execute_checks(
             }
             CheckType::Duplicates => {
                 let result = execute_duplicates(&project_data, mode, verbose).await?;
+                results.push(result);
+            }
+            CheckType::DuplicateTargets => {
+                let result = execute_duplicate_targets(&project_data, mode, verbose).await?;
                 results.push(result);
             }
             CheckType::Coverage | CheckType::ExecutedCoverage => {
@@ -121,6 +125,9 @@ pub struct ProjectData {
     >,
     pub project_sources: Arc<HashSet<SourceFile>>,
     pub annotations: AnnotationSet,
+    /// Checked-in policy for the duplicates check and duplicate-targets query
+    /// (design/duplicates/spec.md §4). Defaults apply when no config exists.
+    pub duplicates_policy: crate::config::DuplicatesPolicy,
 }
 
 async fn load_project_data(verbose: bool) -> Result<ProjectData> {
@@ -128,6 +135,10 @@ async fn load_project_data(verbose: bool) -> Result<ProjectData> {
 
     let config = project.config().await?;
     let config = config.as_ref();
+
+    let duplicates_policy = config
+        .map(|config| config.duplicates.clone())
+        .unwrap_or_default();
 
     if let Some(config) = config {
         let progress = progress!("Extracting requirements");
@@ -167,6 +178,7 @@ async fn load_project_data(verbose: bool) -> Result<ProjectData> {
         specifications,
         project_sources,
         annotations,
+        duplicates_policy,
     })
 }
 
@@ -652,119 +664,64 @@ async fn execute_coverage_check(
     }))
 }
 
+/// The duplicates check (design/duplicates/spec.md §2): predicates over claim
+/// classes — same-target stacking, multiplicity caps, subsumption, and
+/// free-form exclusivity. Structure only: evidence billing of duplicate
+/// copies is the coverage check's own contract, enforced whether or not this
+/// check runs (decisions.md Decision 5).
 async fn execute_duplicates(
     project_data: &ProjectData,
     mode: &RequirementMode,
     verbose: bool,
 ) -> Result<CheckResult> {
-    // Unlike the coverage-fold checks, duplicates classifies each type against
-    // *itself*, so there is no requirement/coverer split and no coverage mosaic
-    // to dismantle: the worst a spec-slice filter can do here is not *show* you a
-    // duplicate that lies outside the slice — it can never flip a verdict. So the
-    // filter is applied uniformly, which is also what "only look at this slice"
-    // means for a duplicate report.
-    let annotations_by_type: HashMap<AnnotationType, Vec<Arc<Annotation>>> = project_data
-        .annotations
-        .iter()
-        .filter(|annotation| mode.in_scope(annotation))
-        .fold(
-            HashMap::new(),
-            |mut acc: HashMap<AnnotationType, Vec<Arc<Annotation>>>, annotation| {
-                acc.entry(annotation.anno)
-                    .or_default()
-                    .push(annotation.clone());
-                acc
-            },
-        );
+    // The spec-slice filter selects the input set; it does not change the
+    // rules. Claim classes never span sections, so the worst a slice can do
+    // is not *show* you a class that lies outside it.
+    let (analysis, errors) =
+        super::checks::duplicates::analyze_duplicates(project_data, mode).await?;
 
-    // Create futures for concurrent classification by annotation type
-    let classification_futures: Vec<_> = annotations_by_type
-        .iter()
-        .map(|(annotation_type, annotations)| {
-            let annotation_type = *annotation_type;
-            let annotations = annotations.clone();
-            async move {
-                let classified_coverage = classify_annotation_coverage(
-                    project_data,
-                    &annotations,
-                    &annotations,
-                    &Vec::new(),
-                )
-                .await?;
-                Ok::<_, crate::Error>((annotation_type, classified_coverage))
-            }
-        })
-        .collect();
+    // Any collected quote-location error fails the run, but only after all
+    // were gathered — the user sees every problem in one pass.
+    if !errors.is_empty() {
+        return Err(errors.into());
+    }
 
-    let classification_results = futures::future::try_join_all(classification_futures).await?;
-    let classified_annotations_by_type: HashMap<AnnotationType, ClassifiedCoverage> =
-        classification_results.into_iter().collect();
-
-    let mut duplicates_by_type: HashMap<AnnotationType, Duplicates> =
-        classified_annotations_by_type
-            .into_iter()
-            .map(|(annotation_type, classified)| {
-                (annotation_type, convert_to_duplicates(classified))
-            })
-            .collect();
-
-    let has_duplicates = duplicates_by_type
-        .iter()
-        .any(|(_type, by_type)| !by_type.duplicates.is_empty());
-
-    let status = if has_duplicates {
-        QueryStatus::Fail
-    } else {
+    let status = if analysis.passes() {
         QueryStatus::Pass
+    } else {
+        QueryStatus::Fail
     };
-
-    // Build categories in a stable order
-    let category_order: &[(&str, AnnotationType)] = &[
-        ("Spec", AnnotationType::Spec),
-        ("Implementation", AnnotationType::Citation),
-        ("Test", AnnotationType::Test),
-        ("Exception", AnnotationType::Exception),
-        ("Todo", AnnotationType::Todo),
-        ("Implication", AnnotationType::Implication),
-    ];
-    let categories: Vec<(&'static str, Duplicates)> = category_order
-        .iter()
-        .map(|(name, anno_type)| {
-            (
-                *name,
-                duplicates_by_type
-                    .remove(anno_type)
-                    .unwrap_or_else(empty_duplicates),
-            )
-        })
-        .collect();
 
     Ok(CheckResult::Duplicates(DuplicatesResult {
         status,
-        categories,
+        analysis,
         verbose,
     }))
 }
 
-fn convert_to_duplicates(classified: ClassifiedCoverage) -> Duplicates {
-    // This assumes that you used classify_annotation_coverage
-    // where annotations == maybe_satisfied_covering_annotations
-    // This means that mixed_coverage == [] && pending_coverage == []
+/// The duplicate-targets query (design/duplicates/spec.md §3): the fan-in
+/// axis. A listing first — every target bearing more than one annotation,
+/// count descending — and a gate only where configuration opts in (`count`,
+/// `sections`) or the target-form family's default bites
+/// (`test`+`implementation` on one target).
+async fn execute_duplicate_targets(
+    project_data: &ProjectData,
+    mode: &RequirementMode,
+    verbose: bool,
+) -> Result<CheckResult> {
+    let analysis = super::checks::duplicates::analyze_duplicate_targets(project_data, mode).await?;
 
-    let duplicates = deduplicate_annotation_coverage(classified.complete_coverage);
-    Duplicates {
-        duplicates,
-        some_overlap: classified.incomplete_coverage,
-        unique: classified.no_coverage,
-    }
-}
+    let status = if analysis.passes() {
+        QueryStatus::Pass
+    } else {
+        QueryStatus::Fail
+    };
 
-fn empty_duplicates() -> Duplicates {
-    Duplicates {
-        duplicates: Vec::new(),
-        some_overlap: Vec::new(),
-        unique: Vec::new(),
-    }
+    Ok(CheckResult::DuplicateTargets(DuplicateTargetsResult {
+        status,
+        analysis,
+        verbose,
+    }))
 }
 
 /// Fold an annotation's execution status across the given coverage reports
@@ -798,32 +755,6 @@ fn fold_execution_status<'a>(
         }
     }
     folded
-}
-
-fn deduplicate_annotation_coverage(
-    coverage_list: Vec<AnnotationCoverage>,
-) -> Vec<AnnotationCoverage> {
-    let mut seen_annotations = HashSet::new();
-    let mut result = Vec::new();
-
-    for coverage in coverage_list {
-        if !seen_annotations.contains(&coverage.target) {
-            // This target hasn't been seen yet, so keep this coverage.
-            //
-            // Only the *target* is marked seen — not its covering annotations.
-            // A covering annotation can independently be the target of another
-            // duplicate relationship (e.g. two identical annotations both cover
-            // a third with a partial quote, but are also exact duplicates of
-            // each other). Marking coverers seen dropped that second
-            // relationship, hiding real duplicate pairs from the report.
-            seen_annotations.insert(coverage.target.clone());
-
-            result.push(coverage);
-        }
-        // else: target already seen, skip this duplicate coverage
-    }
-
-    result
 }
 
 fn expand_coverage_globs(reports: &[String]) -> Result<Vec<String>> {

--- a/duvet/src/query/result.rs
+++ b/duvet/src/query/result.rs
@@ -78,6 +78,9 @@ pub struct CoverageResult {
 pub struct DuplicatesResult {
     pub status: QueryStatus,
     pub analysis: crate::query::checks::duplicates::DuplicatesAnalysis,
+    /// The effective policy, rendered for discoverability (Decision 9's
+    /// discovery loop): verbose prints every value, defaults labeled.
+    pub policy: crate::config::DuplicatesPolicy,
     pub verbose: bool,
 }
 
@@ -526,6 +529,16 @@ impl fmt::Display for DuplicatesResult {
         writeln!(f, "Duplicates: {}", self.status)?;
         writeln!(f)?;
 
+        if self.verbose {
+            writeln!(
+                f,
+                "Effective policy ([duplicates] in .duvet/config.toml; \
+                 semantics: design/duplicates/spec.md §4):"
+            )?;
+            write!(f, "{}", self.policy.describe())?;
+            writeln!(f)?;
+        }
+
         let analysis = &self.analysis;
 
         // §2.1 — same claim, same resolved target.
@@ -607,6 +620,15 @@ impl fmt::Display for DuplicatesResult {
                 f,
                 "Targets bearing more than one annotation (count descending):"
             )?;
+            // Discoverability (decisions.md Decision 9): the moment a reader
+            // is looking at fan-in with no gate configured, name the knob.
+            if !self.policy.targets_gates_configured() {
+                writeln!(
+                    f,
+                    "  (opt-in bounds: [duplicates.targets] count / sections / types \
+                     in .duvet/config.toml — design/duplicates/spec.md §3)"
+                )?;
+            }
             for class in &targets.listing {
                 let forms = class
                     .forms

--- a/duvet/src/query/result.rs
+++ b/duvet/src/query/result.rs
@@ -695,6 +695,10 @@ impl fmt::Display for DuplicatesResult {
             writeln!(f, "{error:?}")?;
         }
 
+        //= design/duplicates/spec.md#policy-source
+        //# Command-line options MUST NOT change any verdict: the command line
+        //# selects which checks run, points at evidence artifacts, and
+        //# controls verbosity — display, never verdict.
         if self.verbose {
             // §2.5 — partial overlap: reported, never failed.
             for coverage in &analysis.some_overlap {

--- a/duvet/src/query/result.rs
+++ b/duvet/src/query/result.rs
@@ -23,7 +23,6 @@ pub enum CheckResult {
     Tests(TestResult),
     Coverage(CoverageResult),
     Duplicates(DuplicatesResult),
-    DuplicateTargets(DuplicateTargetsResult),
 }
 
 impl CheckResult {
@@ -33,7 +32,6 @@ impl CheckResult {
             CheckResult::Tests(r) => &r.status,
             CheckResult::Coverage(r) => &r.status,
             CheckResult::Duplicates(r) => &r.status,
-            CheckResult::DuplicateTargets(r) => &r.status,
         }
     }
 }
@@ -75,19 +73,11 @@ pub struct CoverageResult {
     pub verbose: bool,
 }
 
-/// The duplicates check's result (design/duplicates/spec.md §2).
+/// The duplicates check's result (design/duplicates/spec.md §2–§3).
 #[derive(Debug)]
 pub struct DuplicatesResult {
     pub status: QueryStatus,
     pub analysis: crate::query::checks::duplicates::DuplicatesAnalysis,
-    pub verbose: bool,
-}
-
-/// The duplicate-targets query's result (design/duplicates/spec.md §3).
-#[derive(Debug)]
-pub struct DuplicateTargetsResult {
-    pub status: QueryStatus,
-    pub analysis: crate::query::checks::duplicates::DuplicateTargetsAnalysis,
     pub verbose: bool,
 }
 
@@ -178,7 +168,6 @@ impl fmt::Display for CheckResult {
             CheckResult::Tests(test_result) => write!(f, "{test_result}"),
             CheckResult::Coverage(coverage_result) => write!(f, "{coverage_result}"),
             CheckResult::Duplicates(duplicates_result) => write!(f, "{duplicates_result}"),
-            CheckResult::DuplicateTargets(result) => write!(f, "{result}"),
         }
     }
 }
@@ -610,54 +599,15 @@ impl fmt::Display for DuplicatesResult {
             writeln!(f, "{set_info:?}")?;
         }
 
-        if self.verbose {
-            // §2.5 — partial overlap: reported, never failed.
-            for coverage in &analysis.some_overlap {
-                let mut overlap_info = info!("Annotations with some overlap");
-                match coverage.covering_annotations.split_first() {
-                    Some((first, rest)) => {
-                        overlap_info = with_annotation(overlap_info, first, "Some overlap");
-                        overlap_info = with_related_annotations(overlap_info, rest, "Some overlap");
-                    }
-                    None => {
-                        overlap_info =
-                            with_annotation(overlap_info, &coverage.target, "Some overlap");
-                    }
-                }
-                writeln!(f, "{overlap_info:?}")?;
-            }
-
-            for (form, annotations) in &analysis.unique {
-                if !annotations.is_empty() {
-                    let mut unique_info = info!("Unique {} annotations", form_name(*form));
-                    unique_info = with_related_annotations(unique_info, annotations, "Unique");
-                    writeln!(f, "{unique_info:?}")?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl fmt::Display for DuplicateTargetsResult {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use crate::config::{form_name, form_set_name_of};
-
-        writeln!(f)?;
-        writeln!(f, "Duplicate targets: {}", self.status)?;
-        writeln!(f)?;
-
-        let analysis = &self.analysis;
-
-        if analysis.listing.is_empty() {
-            writeln!(f, "No target bears more than one annotation.")?;
-        } else {
+        // The target axis (spec §3): the fan-in listing is part of this
+        // check's report; bounds and form-combination violations as errors.
+        let targets = &analysis.targets;
+        if !targets.listing.is_empty() {
             writeln!(
                 f,
                 "Targets bearing more than one annotation (count descending):"
             )?;
-            for class in &analysis.listing {
+            for class in &targets.listing {
                 let forms = class
                     .forms
                     .iter()
@@ -687,8 +637,8 @@ impl fmt::Display for DuplicateTargetsResult {
             writeln!(f)?;
         }
 
-        for &index in &analysis.count_violations {
-            let class = &analysis.listing[index];
+        for &index in &targets.count_violations {
+            let class = &targets.listing[index];
             let error = error!(
                 "Target {}:{} bears {} annotations, exceeding the configured count bound",
                 class.target.file.display(),
@@ -699,8 +649,8 @@ impl fmt::Display for DuplicateTargetsResult {
             writeln!(f, "{error:?}")?;
         }
 
-        for &index in &analysis.sections_violations {
-            let class = &analysis.listing[index];
+        for &index in &targets.sections_violations {
+            let class = &targets.listing[index];
             let error = error!(
                 "Target {}:{} bears annotations from {} distinct sections, exceeding the configured sections bound",
                 class.target.file.display(),
@@ -711,8 +661,8 @@ impl fmt::Display for DuplicateTargetsResult {
             writeln!(f, "{error:?}")?;
         }
 
-        for &index in &analysis.type_violations {
-            let class = &analysis.listing[index];
+        for &index in &targets.type_violations {
+            let class = &targets.listing[index];
             let error = error!(
                 "Target {}:{} mixes claim forms {} — the combination is inside no allowed set",
                 class.target.file.display(),
@@ -721,6 +671,32 @@ impl fmt::Display for DuplicateTargetsResult {
             );
             let error = with_related_annotations(error, &class.members, "Mixed forms");
             writeln!(f, "{error:?}")?;
+        }
+
+        if self.verbose {
+            // §2.5 — partial overlap: reported, never failed.
+            for coverage in &analysis.some_overlap {
+                let mut overlap_info = info!("Annotations with some overlap");
+                match coverage.covering_annotations.split_first() {
+                    Some((first, rest)) => {
+                        overlap_info = with_annotation(overlap_info, first, "Some overlap");
+                        overlap_info = with_related_annotations(overlap_info, rest, "Some overlap");
+                    }
+                    None => {
+                        overlap_info =
+                            with_annotation(overlap_info, &coverage.target, "Some overlap");
+                    }
+                }
+                writeln!(f, "{overlap_info:?}")?;
+            }
+
+            for (form, annotations) in &analysis.unique {
+                if !annotations.is_empty() {
+                    let mut unique_info = info!("Unique {} annotations", form_name(*form));
+                    unique_info = with_related_annotations(unique_info, annotations, "Unique");
+                    writeln!(f, "{unique_info:?}")?;
+                }
+            }
         }
 
         Ok(())

--- a/duvet/src/query/result.rs
+++ b/duvet/src/query/result.rs
@@ -23,6 +23,7 @@ pub enum CheckResult {
     Tests(TestResult),
     Coverage(CoverageResult),
     Duplicates(DuplicatesResult),
+    DuplicateTargets(DuplicateTargetsResult),
 }
 
 impl CheckResult {
@@ -32,6 +33,7 @@ impl CheckResult {
             CheckResult::Tests(r) => &r.status,
             CheckResult::Coverage(r) => &r.status,
             CheckResult::Duplicates(r) => &r.status,
+            CheckResult::DuplicateTargets(r) => &r.status,
         }
     }
 }
@@ -73,18 +75,20 @@ pub struct CoverageResult {
     pub verbose: bool,
 }
 
+/// The duplicates check's result (design/duplicates/spec.md §2).
 #[derive(Debug)]
 pub struct DuplicatesResult {
     pub status: QueryStatus,
-    pub categories: Vec<(&'static str, Duplicates)>,
+    pub analysis: crate::query::checks::duplicates::DuplicatesAnalysis,
     pub verbose: bool,
 }
 
+/// The duplicate-targets query's result (design/duplicates/spec.md §3).
 #[derive(Debug)]
-pub struct Duplicates {
-    pub duplicates: Vec<AnnotationCoverage>,
-    pub some_overlap: Vec<AnnotationCoverage>,
-    pub unique: Vec<Arc<Annotation>>,
+pub struct DuplicateTargetsResult {
+    pub status: QueryStatus,
+    pub analysis: crate::query::checks::duplicates::DuplicateTargetsAnalysis,
+    pub verbose: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -174,6 +178,7 @@ impl fmt::Display for CheckResult {
             CheckResult::Tests(test_result) => write!(f, "{test_result}"),
             CheckResult::Coverage(coverage_result) => write!(f, "{coverage_result}"),
             CheckResult::Duplicates(duplicates_result) => write!(f, "{duplicates_result}"),
+            CheckResult::DuplicateTargets(result) => write!(f, "{result}"),
         }
     }
 }
@@ -526,55 +531,196 @@ impl fmt::Display for CoverageResult {
 
 impl fmt::Display for DuplicatesResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use crate::config::{form_name, form_set_name_of};
+
         writeln!(f)?;
         writeln!(f, "Duplicates: {}", self.status)?;
         writeln!(f)?;
 
-        for (category_name, duplicates) in &self.categories {
-            if !duplicates.duplicates.is_empty() {
-                for coverage in &duplicates.duplicates {
-                    let duplicate_error = coverage2error(
-                        coverage,
-                        format!("Duplicate {} annotations", category_name.to_lowercase()),
-                        "Duplicate".to_string(),
-                        "Duplicate".to_string(),
-                    );
-                    writeln!(f, "{duplicate_error:?}")?;
+        let analysis = &self.analysis;
+
+        // §2.1 — same claim, same resolved target.
+        for stacked in &analysis.stacked {
+            let (first, rest) = stacked
+                .members
+                .split_first()
+                .expect("stacked class has >= 2 members");
+            let mut error = error!(
+                "Same claim stacked on one target ({}:{})",
+                stacked.target.file.display(),
+                stacked.target.line
+            );
+            error = with_annotation(error, first, "Stacked");
+            error = with_related_annotations(error, rest, "Stacked");
+            writeln!(f, "{error:?}")?;
+        }
+
+        // §2.2 — duplicate sets over cap.
+        for set in &analysis.over_cap {
+            let (first, rest) = set
+                .members
+                .split_first()
+                .expect("over-cap set has >= 1 member");
+            let mut error = error!(
+                "Duplicate {} annotations: {} copies exceed the cap of {}",
+                form_name(set.form),
+                set.members.len(),
+                set.cap
+            );
+            error = with_annotation(error, first, "Duplicate");
+            error = with_related_annotations(error, rest, "Duplicate");
+            writeln!(f, "{error:?}")?;
+        }
+
+        // §2.3 — subsumption.
+        for coverage in &analysis.subsumed {
+            let duplicate_error = coverage2error(
+                coverage,
+                "Subsumed annotation: its claim is fully covered by other annotations".to_string(),
+                "Subsumed".to_string(),
+                "Covered by".to_string(),
+            );
+            writeln!(f, "{duplicate_error:?}")?;
+        }
+
+        // §2.4 — free-form exclusivity.
+        for violation in &analysis.exclusivity {
+            let (first, rest) = violation
+                .members
+                .split_first()
+                .expect("exclusivity violation has >= 2 members");
+            let mut error = error!(
+                "Free claim forms are exclusive: {} share one claim",
+                form_set_name_of(&violation.forms)
+            );
+            error = with_annotation(error, first, "Shared claim");
+            error = with_related_annotations(error, rest, "Shared claim");
+            writeln!(f, "{error:?}")?;
+        }
+
+        // §2.2 — within-cap multiplicity is always surfaced, never silent.
+        for set in &analysis.allowed_sets {
+            let mut set_info = info!(
+                "Allowed duplicate set: {} {} annotations (cap {})",
+                set.members.len(),
+                form_name(set.form),
+                set.cap
+            );
+            set_info = with_related_annotations(set_info, &set.members, "Allowed duplicate");
+            writeln!(f, "{set_info:?}")?;
+        }
+
+        if self.verbose {
+            // §2.5 — partial overlap: reported, never failed.
+            for coverage in &analysis.some_overlap {
+                let mut overlap_info = info!("Annotations with some overlap");
+                match coverage.covering_annotations.split_first() {
+                    Some((first, rest)) => {
+                        overlap_info = with_annotation(overlap_info, first, "Some overlap");
+                        overlap_info = with_related_annotations(overlap_info, rest, "Some overlap");
+                    }
+                    None => {
+                        overlap_info =
+                            with_annotation(overlap_info, &coverage.target, "Some overlap");
+                    }
+                }
+                writeln!(f, "{overlap_info:?}")?;
+            }
+
+            for (form, annotations) in &analysis.unique {
+                if !annotations.is_empty() {
+                    let mut unique_info = info!("Unique {} annotations", form_name(*form));
+                    unique_info = with_related_annotations(unique_info, annotations, "Unique");
+                    writeln!(f, "{unique_info:?}")?;
                 }
             }
         }
 
-        if self.verbose {
-            for (category_name, duplicates) in &self.categories {
-                if !duplicates.some_overlap.is_empty() {
-                    for coverage in &duplicates.some_overlap {
-                        let mut overlap_info =
-                            info!("{} annotations with some overlap", category_name);
-                        match coverage.covering_annotations.split_first() {
-                            Some((first, rest)) => {
-                                overlap_info = with_annotation(overlap_info, first, "Some overlap");
-                                overlap_info =
-                                    with_related_annotations(overlap_info, rest, "Some overlap");
-                            }
-                            // Whitespace-only quote: trivially covered, no coverers. Render
-                            // the target rather than panicking on an empty slice.
-                            None => {
-                                overlap_info =
-                                    with_annotation(overlap_info, &coverage.target, "Some overlap");
-                            }
-                        }
-                        writeln!(f, "{overlap_info:?}")?;
-                    }
-                }
+        Ok(())
+    }
+}
 
-                if !duplicates.unique.is_empty() {
-                    let mut unique_info =
-                        info!("Unique {} annotations", category_name.to_lowercase());
-                    unique_info =
-                        with_related_annotations(unique_info, &duplicates.unique, "Unique");
-                    writeln!(f, "{unique_info:?}")?;
+impl fmt::Display for DuplicateTargetsResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use crate::config::{form_name, form_set_name_of};
+
+        writeln!(f)?;
+        writeln!(f, "Duplicate targets: {}", self.status)?;
+        writeln!(f)?;
+
+        let analysis = &self.analysis;
+
+        if analysis.listing.is_empty() {
+            writeln!(f, "No target bears more than one annotation.")?;
+        } else {
+            writeln!(
+                f,
+                "Targets bearing more than one annotation (count descending):"
+            )?;
+            for class in &analysis.listing {
+                let forms = class
+                    .forms
+                    .iter()
+                    .map(|(form, count)| format!("{}:{}", form_name(*form), count))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                writeln!(
+                    f,
+                    "  {}:{} count={} sections={} forms={}",
+                    class.target.file.display(),
+                    class.target.line,
+                    class.count(),
+                    class.sections,
+                    forms
+                )?;
+                if self.verbose {
+                    let members_info = info!(
+                        "Annotations resolving to {}:{}",
+                        class.target.file.display(),
+                        class.target.line
+                    );
+                    let members_info =
+                        with_related_annotations(members_info, &class.members, "Resolves here");
+                    writeln!(f, "{members_info:?}")?;
                 }
             }
+            writeln!(f)?;
+        }
+
+        for &index in &analysis.count_violations {
+            let class = &analysis.listing[index];
+            let error = error!(
+                "Target {}:{} bears {} annotations, exceeding the configured count bound",
+                class.target.file.display(),
+                class.target.line,
+                class.count()
+            );
+            let error = with_related_annotations(error, &class.members, "Fan-in");
+            writeln!(f, "{error:?}")?;
+        }
+
+        for &index in &analysis.sections_violations {
+            let class = &analysis.listing[index];
+            let error = error!(
+                "Target {}:{} bears annotations from {} distinct sections, exceeding the configured sections bound",
+                class.target.file.display(),
+                class.target.line,
+                class.sections
+            );
+            let error = with_related_annotations(error, &class.members, "Fan-in");
+            writeln!(f, "{error:?}")?;
+        }
+
+        for &index in &analysis.type_violations {
+            let class = &analysis.listing[index];
+            let error = error!(
+                "Target {}:{} mixes claim forms {} — the combination is inside no allowed set",
+                class.target.file.display(),
+                class.target.line,
+                form_set_name_of(&class.form_set())
+            );
+            let error = with_related_annotations(error, &class.members, "Mixed forms");
+            writeln!(f, "{error:?}")?;
         }
 
         Ok(())

--- a/duvet/src/query/result.rs
+++ b/duvet/src/query/result.rs
@@ -585,14 +585,14 @@ impl fmt::Display for DuplicatesResult {
             writeln!(f, "{duplicate_error:?}")?;
         }
 
-        // §2.4 — free-form exclusivity.
+        // §2.4 — the claim-form family.
         for violation in &analysis.exclusivity {
             let (first, rest) = violation
                 .members
                 .split_first()
                 .expect("exclusivity violation has >= 2 members");
             let mut error = error!(
-                "Free claim forms are exclusive: {} share one claim",
+                "One claim shared by forms {} — the combination is inside no allowed set",
                 form_set_name_of(&violation.forms)
             );
             error = with_annotation(error, first, "Shared claim");

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -10,3 +10,4 @@
   - [init](./command/init.md)
   - [extract](./command/extract.md)
   - [report](./command/report.md)
+  - [query](./command/query.md)

--- a/guide/src/example-config.toml
+++ b/guide/src/example-config.toml
@@ -50,3 +50,35 @@ path = ".duvet/reports/report.html" # Sets the path to the report output
 [report.snapshot]
 enabled = true               # Enables the snapshot report
 path = ".duvet/snapshot.txt" # Sets the path to the report output
+
+# Policy for `duvet query --check duplicates`. Two namespaces mirror the two
+# ways annotations can collide: sharing a claim (same section, same quoted
+# requirement) or sharing a resolved target (several annotations on one
+# source position). The check runs with its defaults even when this whole
+# section is absent; every key below states its default.
+# Full semantics: design/duplicates/spec.md
+[duplicates.claims]
+test = 2                        # Max copies of one claim as `test` annotations
+                                # (default 1). Raise to admit multiple evidence
+                                # artifacts per requirement, e.g. a proof and a
+                                # property-based test
+implementation = 1              # Max copies as `implementation` annotations
+                                # (default 1). spec/todo/exception/implication
+                                # are always unique, with no knob
+types = ["exception+test"]      # Which type combinations may share one claim,
+                                # each entry a `+`-joined set. Default when
+                                # unset: any mix of test+implementation, and
+                                # the free forms (exception, implication,
+                                # todo) never share a claim
+
+[duplicates.targets]
+count = 5                       # Max annotations resolving to one source
+                                # position (default: unlimited — the fan-in
+                                # listing still shows every target bearing
+                                # more than one annotation)
+sections = 2                    # Max distinct spec sections claimed at one
+                                # position (default: unlimited)
+types = ["test+implementation"] # Which type combinations may share one
+                                # position. Default when unset: every
+                                # combination except test+implementation
+                                # together

--- a/guide/src/query.md
+++ b/guide/src/query.md
@@ -18,7 +18,7 @@ $ duvet query -c implementation -c test
 | `test` | Do all in-scope implementation annotations have corresponding test annotations? |
 | `coverage` | Do test annotations actually execute their corresponding implementation annotations? |
 | `executed-coverage` | Same as `coverage`, but skips test annotations the supplied coverage data shows as not executed. Useful when iterating on a single test. |
-| `duplicates` | Do annotations collide on either coincidence axis — several copies of one claim (same section, same quoted text), or several annotations resolving to one source position (fan-in)? Policy lives in `[duplicates.claims]` / `[duplicates.targets]` in `.duvet/config.toml`; the report always includes the fan-in listing. |
+| `duplicates` | Do annotations collide on either coincidence axis — several copies of one claim (same section, same quoted text), or several annotations resolving to one source position (fan-in)? Policy lives in `[duplicates.claims]` / `[duplicates.targets]` in `.duvet/config.toml` — every key is documented in [Configuration](./config.md); the report always includes the fan-in listing. |
 
 Annotations of type `citation`, `implication`, and `exception` count as implementation. `todo` annotations are tracked separately — a requirement covered only by `todo` annotations is reported as "TODO only" by the `implementation` check, not as implemented.
 

--- a/guide/src/query.md
+++ b/guide/src/query.md
@@ -18,7 +18,7 @@ $ duvet query -c implementation -c test
 | `test` | Do all in-scope implementation annotations have corresponding test annotations? |
 | `coverage` | Do test annotations actually execute their corresponding implementation annotations? |
 | `executed-coverage` | Same as `coverage`, but skips test annotations the supplied coverage data shows as not executed. Useful when iterating on a single test. |
-| `duplicates` | Are there annotations of the same type that redundantly cover the same specification text? |
+| `duplicates` | Do annotations collide on either coincidence axis — several copies of one claim (same section, same quoted text), or several annotations resolving to one source position (fan-in)? Policy lives in `[duplicates.claims]` / `[duplicates.targets]` in `.duvet/config.toml`; the report always includes the fan-in listing. |
 
 Annotations of type `citation`, `implication`, and `exception` count as implementation. `todo` annotations are tracked separately — a requirement covered only by `todo` annotations is reported as "TODO only" by the `implementation` check, not as implemented.
 

--- a/integration/query-coverage-exception-correlation.toml
+++ b/integration/query-coverage-exception-correlation.toml
@@ -1,0 +1,87 @@
+source = { local = true }
+cmd = ["duvet query -c coverage -r cov.xml -f jacoco-xml"]
+report_output = false
+
+# Pins the check composition on the partial-waiver shape: the requirement is
+# "aaa bbb ccc"; an implementation quotes "aaa bbb"; an exception quotes
+# "bbb ccc"; a test quotes the whole requirement. The claim axis is silent —
+# three distinct quotes, no shared claim class. But coverage is positional,
+# so the test's covering set slurps in BOTH the implementation (overlap
+# "aaa bbb") and the exception (overlap "bbb ccc"), and the correlation then
+# demands execution of EVERY coverer under the test's witness. The
+# implementation's target line is a Hit; the exception's target line is a
+# Miss — so the correlation FAILS, naming the exception as the not-executed
+# coverer. An exception cannot silently absorb test evidence: any test that
+# spans exempted text drags the exception into correlation, and a waiver
+# has no execution to offer.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+"""
+
+[[file]]
+path = "src/impl.rs"
+contents = """
+//= spec.md#section-1
+//= type=implementation
+//# aaa bbb
+fn work() {}
+"""
+
+[[file]]
+path = "src/waiver.rs"
+contents = """
+//= spec.md#section-1
+//= type=exception
+//# bbb ccc
+fn not_done() {}
+"""
+
+[[file]]
+path = "src/impl_test.rs"
+contents = """
+//= spec.md#section-1
+//= type=test
+//# aaa bbb ccc
+fn check_work() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa bbb ccc
+"""
+
+# The witness saw the test execute (impl_test.rs:4 Hit) and the
+# implementation execute (impl.rs:4 Hit); the exception's target line is an
+# explicit Miss (waiver.rs:4, ci=0).
+[[file]]
+path = "cov.xml"
+contents = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
+<report name="X">
+    <package name="src">
+        <sourcefile name="impl_test.rs">
+            <line nr="4" mi="0" ci="1" mb="0" cb="0"/>
+        </sourcefile>
+        <sourcefile name="impl.rs">
+            <line nr="4" mi="0" ci="1" mb="0" cb="0"/>
+        </sourcefile>
+        <sourcefile name="waiver.rs">
+            <line nr="4" mi="1" ci="0" mb="0" cb="0"/>
+        </sourcefile>
+    </package>
+</report>
+"""

--- a/integration/query-duplicate-targets-bounds.toml
+++ b/integration/query-duplicate-targets-bounds.toml
@@ -1,5 +1,5 @@
 source = { local = true }
-cmd = ["duvet query --check duplicate-targets --verbose"]
+cmd = ["duvet query --check duplicates --verbose"]
 report_output = false
 
 # Pins spec §3.2: opt-in fan-in bounds. With `count = 2` and `sections = 1`
@@ -38,10 +38,10 @@ contents = """
 pub fn dumped() {}
 
 //= spec.md#section-1
-//# aaa
+//# ddd
 
 //= spec.md#section-1
-//# bbb
+//# eee
 pub fn fine() {}
 """
 
@@ -55,6 +55,10 @@ contents = """
 aaa
 
 bbb
+
+ddd
+
+eee
 
 ## Section 2
 

--- a/integration/query-duplicate-targets-bounds.toml
+++ b/integration/query-duplicate-targets-bounds.toml
@@ -1,0 +1,62 @@
+source = { local = true }
+cmd = ["duvet query --check duplicate-targets --verbose"]
+report_output = false
+
+# Pins spec §3.2: opt-in fan-in bounds. With `count = 2` and `sections = 1`
+# configured, `dumped()` — three implementation claims from two sections on
+# one target — violates both bounds and FAILS. `fine()` with two claims from
+# one section is within both. These are the only rules that fail code for a
+# smell rather than a violated evidence property; the team opted in by
+# writing the numbers.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+
+[duplicates.targets]
+count = 2
+sections = 1
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//# aaa
+
+//= spec.md#section-1
+//# bbb
+
+//= spec.md#section-2
+//# ccc
+pub fn dumped() {}
+
+//= spec.md#section-1
+//# aaa
+
+//= spec.md#section-1
+//# bbb
+pub fn fine() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa
+
+bbb
+
+## Section 2
+
+ccc
+"""

--- a/integration/query-duplicate-targets-bounds.toml
+++ b/integration/query-duplicate-targets-bounds.toml
@@ -8,6 +8,10 @@ report_output = false
 # one section is within both. These are the only rules that fail code for a
 # smell rather than a violated evidence property; the team opted in by
 # writing the numbers.
+#= design/duplicates/spec.md#fan-in-bounds
+#= type=test
+#% When a bound is configured, a target class exceeding it MUST fail
+#% the duplicates check.
 [[file]]
 path = ".duvet/config.toml"
 contents = """

--- a/integration/query-duplicate-targets-listing.toml
+++ b/integration/query-duplicate-targets-listing.toml
@@ -2,7 +2,7 @@ source = { local = true }
 cmd = ["duvet query --check duplicates"]
 report_output = false
 
-# Pins spec §3.1 / P-T1: the duplicate-targets listing contains a target iff
+# Pins spec §3.1 / P-T1: the fan-in listing contains a target iff
 # two or more annotations resolve to it, with exact counts, per-form
 # breakdown, and distinct-section counts, sorted by count descending.
 #

--- a/integration/query-duplicate-targets-listing.toml
+++ b/integration/query-duplicate-targets-listing.toml
@@ -1,0 +1,67 @@
+source = { local = true }
+cmd = ["duvet query --check duplicate-targets"]
+report_output = false
+
+# Pins spec §3.1 / P-T1: the duplicate-targets listing contains a target iff
+# two or more annotations resolve to it, with exact counts, per-form
+# breakdown, and distinct-section counts, sorted by count descending.
+#
+# - `dense()` bears three implementation claims from two sections
+#   (count=3 sections=2)
+# - `pair()` bears two from one section (count=2 sections=1)
+# - `single()` bears one — it MUST NOT appear.
+#
+# No bounds are configured and all forms are `implementation`, so the query
+# PASSES: a listing is not a gate.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//# aaa
+
+//= spec.md#section-1
+//# bbb
+
+//= spec.md#section-2
+//# ccc
+pub fn dense() {}
+
+//= spec.md#section-1
+//# aaa
+
+//= spec.md#section-1
+//# bbb
+pub fn pair() {}
+
+//= spec.md#section-2
+//# ccc
+pub fn single() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa
+
+bbb
+
+## Section 2
+
+ccc
+"""

--- a/integration/query-duplicate-targets-listing.toml
+++ b/integration/query-duplicate-targets-listing.toml
@@ -1,5 +1,5 @@
 source = { local = true }
-cmd = ["duvet query --check duplicate-targets"]
+cmd = ["duvet query --check duplicates"]
 report_output = false
 
 # Pins spec §3.1 / P-T1: the duplicate-targets listing contains a target iff
@@ -11,8 +11,9 @@ report_output = false
 # - `pair()` bears two from one section (count=2 sections=1)
 # - `single()` bears one — it MUST NOT appear.
 #
-# No bounds are configured and all forms are `implementation`, so the query
-# PASSES: a listing is not a gate.
+# Every quote is unique (the claim axis is deliberately clean), no bounds are
+# configured, and all forms are `implementation`, so the check PASSES: a
+# listing is not a gate.
 [[file]]
 path = ".duvet/config.toml"
 contents = """
@@ -39,14 +40,14 @@ contents = """
 pub fn dense() {}
 
 //= spec.md#section-1
-//# aaa
+//# ddd
 
 //= spec.md#section-1
-//# bbb
+//# eee
 pub fn pair() {}
 
 //= spec.md#section-2
-//# ccc
+//# fff
 pub fn single() {}
 """
 
@@ -61,7 +62,13 @@ aaa
 
 bbb
 
+ddd
+
+eee
+
 ## Section 2
 
 ccc
+
+fff
 """

--- a/integration/query-duplicate-targets-listing.toml
+++ b/integration/query-duplicate-targets-listing.toml
@@ -14,6 +14,11 @@ report_output = false
 # Every quote is unique (the claim axis is deliberately clean), no bounds are
 # configured, and all forms are `implementation`, so the check PASSES: a
 # listing is not a gate.
+#= design/duplicates/spec.md#fan-in-listing
+#= type=test
+#% The duplicates check's report MUST include the fan-in listing: it
+#% MUST contain a target if and only if two or more annotations
+#% resolve to it.
 [[file]]
 path = ".duvet/config.toml"
 contents = """
@@ -26,6 +31,11 @@ pattern = "src/**/*.rs"
 source = "spec.md"
 """
 
+#= design/duplicates/spec.md#fan-in-listing
+#= type=test
+#% Each listed target MUST report its exact annotation count, its
+#% per-form breakdown, and its distinct-section count, and the
+#% listing MUST be sorted by annotation count descending.
 [[file]]
 path = "src/lib.rs"
 contents = """
@@ -51,6 +61,10 @@ pub fn pair() {}
 pub fn single() {}
 """
 
+#= design/duplicates/spec.md#type-combinations
+#= type=test
+#% A target class bearing a single claim form
+#% MUST NOT fail this rule.
 [[file]]
 path = "spec.md"
 contents = """

--- a/integration/query-duplicate-targets-mixed-form-allowed.toml
+++ b/integration/query-duplicate-targets-mixed-form-allowed.toml
@@ -1,5 +1,5 @@
 source = { local = true }
-cmd = ["duvet query --check duplicate-targets"]
+cmd = ["duvet query --check duplicates"]
 report_output = false
 
 # The Appendix-A relaxation of spec §3.3 (Decision 8's meta-requirement case):

--- a/integration/query-duplicate-targets-mixed-form-allowed.toml
+++ b/integration/query-duplicate-targets-mixed-form-allowed.toml
@@ -1,0 +1,48 @@
+source = { local = true }
+cmd = ["duvet query --check duplicate-targets"]
+report_output = false
+
+# The Appendix-A relaxation of spec §3.3 (Decision 8's meta-requirement case):
+# the same input as query-duplicate-targets-mixed-form, with the combination
+# added to the target-form family in one reviewed configuration line. PASSES,
+# and per P-T2 adding the allowed set never flips anything else to failing.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+
+[duplicates.targets]
+types = ["test+implementation"]
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=test
+//# aaa
+
+//= spec.md#section-2
+//# bbb
+pub fn both_roles() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa
+
+## Section 2
+
+bbb
+"""

--- a/integration/query-duplicate-targets-mixed-form.toml
+++ b/integration/query-duplicate-targets-mixed-form.toml
@@ -1,0 +1,46 @@
+source = { local = true }
+cmd = ["duvet query --check duplicate-targets"]
+report_output = false
+
+# Pins spec §3.3 / P-T2 (Decisions 8 and 12): a target claimed as test code
+# and implementation code simultaneously FAILS under the default target-form
+# family — disjoint populations in every codebase we care about. The claims
+# differ (no duplicate-claim question); the collision is purely on the target
+# axis.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=test
+//# aaa
+
+//= spec.md#section-2
+//# bbb
+pub fn both_roles() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa
+
+## Section 2
+
+bbb
+"""

--- a/integration/query-duplicate-targets-mixed-form.toml
+++ b/integration/query-duplicate-targets-mixed-form.toml
@@ -1,12 +1,12 @@
 source = { local = true }
-cmd = ["duvet query --check duplicate-targets"]
+cmd = ["duvet query --check duplicates"]
 report_output = false
 
 # Pins spec §3.3 / P-T2 (Decisions 8 and 12): a target claimed as test code
 # and implementation code simultaneously FAILS under the default target-form
 # family — disjoint populations in every codebase we care about. The claims
 # differ (no duplicate-claim question); the collision is purely on the target
-# axis.
+# axis of the one duplicates check.
 [[file]]
 path = ".duvet/config.toml"
 contents = """

--- a/integration/query-duplicate-targets-mixed-form.toml
+++ b/integration/query-duplicate-targets-mixed-form.toml
@@ -7,6 +7,11 @@ report_output = false
 # family — disjoint populations in every codebase we care about. The claims
 # differ (no duplicate-claim question); the collision is purely on the target
 # axis of the one duplicates check.
+#= design/duplicates/spec.md#type-combinations
+#= type=test
+#% A target class bearing two or more distinct claim forms MUST fail
+#% the duplicates check unless its form set is a subset of some
+#% member of the family.
 [[file]]
 path = ".duvet/config.toml"
 contents = """

--- a/integration/query-duplicates-caps.toml
+++ b/integration/query-duplicates-caps.toml
@@ -13,6 +13,12 @@ report_output = false
 # on the same shape), this pins P-D4 bound monotonicity at the fixture level:
 # raising the cap flipped section-1's pair from failing to passing and left
 # section-2's triple failing.
+#= design/duplicates/spec.md#duplicates-verdict
+#= type=test
+#% The duplicates check MUST fail if and only if at least one rule of
+#% [§2.1](#same-claim-same-target)–[§2.4](#exclusivity) or of the
+#% target axis ([§3.2](#fan-in-bounds)–[§3.3](#type-combinations))
+#% fires.
 [[file]]
 path = ".duvet/config.toml"
 contents = """
@@ -28,6 +34,10 @@ source = "spec.md"
 test = 2
 """
 
+#= design/duplicates/spec.md#caps
+#= type=test
+#% A duplicate set whose size exceeds its form's cap MUST fail the
+#% duplicates check.
 [[file]]
 path = "src/lib.rs"
 contents = """
@@ -57,6 +67,12 @@ pub fn copy_two() {}
 pub fn copy_three() {}
 """
 
+#= design/duplicates/spec.md#caps
+#= type=test
+#% A duplicate set within its cap MUST pass this check
+#% ([Decision 5](decisions.md#decision-5)), and when its size exceeds
+#% one it MUST be reported with its size and every member's location,
+#% so multiplicity is always surfaced, never silent.
 [[file]]
 path = "spec.md"
 contents = """

--- a/integration/query-duplicates-caps.toml
+++ b/integration/query-duplicates-caps.toml
@@ -1,0 +1,72 @@
+source = { local = true }
+cmd = ["duvet query --check duplicates --verbose"]
+report_output = false
+
+# Pins spec §2.2 (multiplicity caps) both ways under a raised cap:
+#
+# - section-1: two equal test claims at distinct targets — within `test = 2`,
+#   PASSES, and the allowed duplicate set is surfaced with its members
+#   (multiplicity is never silent).
+# - section-2: three equal test claims — exceeds the cap, FAILS.
+#
+# Together with query-duplicates-exact-pair (which pins the default cap of 1
+# on the same shape), this pins P-D4 bound monotonicity at the fixture level:
+# raising the cap flipped section-1's pair from failing to passing and left
+# section-2's triple failing.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+
+[duplicates.claims]
+test = 2
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=test
+//# aaa bbb ccc
+pub fn proof_evidence() {}
+
+//= spec.md#section-1
+//= type=test
+//# aaa bbb ccc
+pub fn pbt_evidence() {}
+
+//= spec.md#section-2
+//= type=test
+//# ddd eee fff
+pub fn copy_one() {}
+
+//= spec.md#section-2
+//= type=test
+//# ddd eee fff
+pub fn copy_two() {}
+
+//= spec.md#section-2
+//= type=test
+//# ddd eee fff
+pub fn copy_three() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa bbb ccc
+
+## Section 2
+
+ddd eee fff
+"""

--- a/integration/query-duplicates-empty-family.toml
+++ b/integration/query-duplicates-empty-family.toml
@@ -1,0 +1,46 @@
+source = { local = true }
+cmd = ["duvet query --check duplicates"]
+report_output = false
+
+# Pins spec §2.4's empty-family consequence: `types = []` admits no
+# multi-form set, so a `test` and an `implementation` sharing one claim —
+# admitted by the default family as the system itself — FAILS here. The
+# family is the whole rule; there is no free-form precondition carving
+# priced forms out of its range.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+
+[duplicates.claims]
+types = []
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=test
+//# aaa bbb ccc
+pub fn tested_there() {}
+
+//= spec.md#section-1
+//# aaa bbb ccc
+pub fn implemented_here() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa bbb ccc
+"""

--- a/integration/query-duplicates-exclusivity-family.toml
+++ b/integration/query-duplicates-exclusivity-family.toml
@@ -1,0 +1,45 @@
+source = { local = true }
+cmd = ["duvet query --check duplicates"]
+report_output = false
+
+# The restoration path for spec §2.4's tightening (Decision 14): the same
+# input as query-duplicates-exclusivity, with the coexistence admitted by one
+# reviewed configuration line — a rule-level policy declaration, never a
+# per-instance waiver comment. PASSES.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+
+[duplicates.claims]
+types = ["exception+implementation"]
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=exception
+//# aaa bbb ccc
+pub fn waived_here() {}
+
+//= spec.md#section-1
+//# aaa bbb ccc
+pub fn implemented_here() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa bbb ccc
+"""

--- a/integration/query-duplicates-exclusivity-family.toml
+++ b/integration/query-duplicates-exclusivity-family.toml
@@ -6,6 +6,10 @@ report_output = false
 # input as query-duplicates-exclusivity, with the coexistence admitted by one
 # reviewed configuration line — a rule-level policy declaration, never a
 # per-instance waiver comment. PASSES.
+#= design/duplicates/spec.md#policy-source
+#= type=test
+#% Every policy value in this specification MUST be read from
+#% checked-in configuration.
 [[file]]
 path = ".duvet/config.toml"
 contents = """

--- a/integration/query-duplicates-exclusivity.toml
+++ b/integration/query-duplicates-exclusivity.toml
@@ -1,0 +1,46 @@
+source = { local = true }
+cmd = ["duvet query --check duplicates"]
+report_output = false
+
+# Pins spec §2.4 / P-D5 (Decision 4): a free claim form sharing a claim with a
+# priced form FAILS under the default claim-form family, even at distinct
+# targets. An `exception` on a requirement exempts it from the test
+# obligation, so an exception coexisting with an `implementation` claim
+# silently unbills the implementation — the type-shopping exploit the pricing
+# table predicts. This coexistence silently passed the historical check; the
+# tightening is deliberate (Decision 14), restorable per
+# query-duplicates-exclusivity-family.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=exception
+//# aaa bbb ccc
+pub fn waived_here() {}
+
+//= spec.md#section-1
+//# aaa bbb ccc
+pub fn implemented_here() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa bbb ccc
+"""

--- a/integration/query-duplicates-exclusivity.toml
+++ b/integration/query-duplicates-exclusivity.toml
@@ -10,6 +10,12 @@ report_output = false
 # table predicts. This coexistence silently passed the historical check; the
 # tightening is deliberate (Decision 14), restorable per
 # query-duplicates-exclusivity-family.
+#= design/duplicates/spec.md#exclusivity
+#= type=test
+#% A claim class whose non-`spec` members bear two or more distinct
+#% claim forms MUST fail the duplicates check unless the set of
+#% non-`spec` claim forms is admitted by the configured claim-form
+#% family ([§4.2](#schema-claims)).
 [[file]]
 path = ".duvet/config.toml"
 contents = """

--- a/integration/query-duplicates-free-form-unique.toml
+++ b/integration/query-duplicates-free-form-unique.toml
@@ -1,0 +1,45 @@
+source = { local = true }
+cmd = ["duvet query --check duplicates"]
+report_output = false
+
+# Pins spec §2.2 / P-D2 (Decision 3): free-form caps are fixed at 1 with no
+# knob. Two identical `exception` claims at distinct targets FAIL — a
+# declaration of absence has nothing a coverage check could ever
+# disambiguate, so no configuration admits the copy. (The [duplicates.claims]
+# schema has no `exception` key at all; writing one is a configuration
+# error.)
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=exception
+//# aaa bbb ccc
+pub fn first_waiver() {}
+
+//= spec.md#section-1
+//= type=exception
+//# aaa bbb ccc
+pub fn second_waiver() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa bbb ccc
+"""

--- a/integration/query-duplicates-implication-copies.toml
+++ b/integration/query-duplicates-implication-copies.toml
@@ -1,0 +1,43 @@
+source = { local = true }
+cmd = ["duvet query --check duplicates"]
+report_output = false
+
+# Pins the seam between spec §2.2 and §2.4: two identical `implication`
+# claims are a single-form class, so the claim-form family rule (§2.4) does
+# not range over them — they fail on the free cap alone (fixed at 1, no
+# knob). Exactly ONE finding, the cap; no "share one claim" line rides along.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=implication
+//# aaa bbb ccc
+pub fn holds_by_construction() {}
+
+//= spec.md#section-1
+//= type=implication
+//# aaa bbb ccc
+pub fn also_holds_by_construction() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa bbb ccc
+"""

--- a/integration/query-duplicates-implication-copies.toml
+++ b/integration/query-duplicates-implication-copies.toml
@@ -6,6 +6,11 @@ report_output = false
 # claims are a single-form class, so the claim-form family rule (§2.4) does
 # not range over them — they fail on the free cap alone (fixed at 1, no
 # knob). Exactly ONE finding, the cap; no "share one claim" line rides along.
+#= design/duplicates/spec.md#exclusivity
+#= type=test
+#% A claim class whose non-`spec`
+#% members bear a single claim form MUST NOT fail this rule: copies
+#% of one form are the caps' business ([§2.2](#caps)).
 [[file]]
 path = ".duvet/config.toml"
 contents = """

--- a/integration/query-duplicates-partial-overlap-verbose.toml
+++ b/integration/query-duplicates-partial-overlap-verbose.toml
@@ -8,6 +8,10 @@ report_output = false
 # fails it. Content + presentation: the pair appears in the report under
 # `--verbose` (the display tier where the some_overlap population is shown;
 # verbosity never changes the verdict, §4.1 / P-S0).
+#= design/duplicates/spec.md#partial-overlap
+#= type=test
+#% Verdict: a partial overlap MUST NOT fail the duplicates check,
+#% matching the historical check.
 [[file]]
 path = ".duvet/config.toml"
 contents = """
@@ -20,6 +24,10 @@ pattern = "src/**/*.rs"
 source = "spec.md"
 """
 
+#= design/duplicates/spec.md#partial-overlap
+#= type=test
+#% Content: the check MUST identify every partial-overlap pair in
+#% its analysis.
 [[file]]
 path = "src/lib.rs"
 contents = """
@@ -34,6 +42,11 @@ pub fn front_half() {}
 pub fn back_half() {}
 """
 
+#= design/duplicates/spec.md#policy-source
+#= type=test
+#% Command-line options MUST NOT change any verdict: the command line
+#% selects which checks run, points at evidence artifacts, and
+#% controls verbosity — display, never verdict.
 [[file]]
 path = "spec.md"
 contents = """

--- a/integration/query-duplicates-partial-overlap-verbose.toml
+++ b/integration/query-duplicates-partial-overlap-verbose.toml
@@ -1,0 +1,45 @@
+source = { local = true }
+cmd = ["duvet query --check duplicates --verbose"]
+report_output = false
+
+# Pins spec §2.5's three layers in their observable window: two quotes that
+# overlap without full coverage in either direction ("aaa bbb" / "bbb ccc")
+# are outside the model. Verdict: the check PASSES — a partial overlap never
+# fails it. Content + presentation: the pair appears in the report under
+# `--verbose` (the display tier where the some_overlap population is shown;
+# verbosity never changes the verdict, §4.1 / P-S0).
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=test
+//# aaa bbb
+pub fn front_half() {}
+
+//= spec.md#section-1
+//= type=test
+//# bbb ccc
+pub fn back_half() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa bbb ccc
+"""

--- a/integration/query-duplicates-stacked-claim.toml
+++ b/integration/query-duplicates-stacked-claim.toml
@@ -1,0 +1,48 @@
+source = { local = true }
+cmd = ["duvet query --check duplicates"]
+report_output = false
+
+# Pins spec §2.1 / P-D1: two annotations sharing a claim and sharing a
+# resolved target FAIL regardless of claim form and regardless of any cap.
+#
+# A `test` and an `implementation` annotation carry the same quote on the same
+# section, stacked above one function — both resolve to the function line.
+# The raised `test` cap is deliberate noise: it must not rescue the stack
+# (§2.1 is cap-independent), and no same-form cap is exceeded (one member per
+# form), so the only rule that can fire is the stacked-claim rule.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+
+[duplicates.claims]
+test = 2
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=test
+//# aaa bbb ccc
+
+//= spec.md#section-1
+//# aaa bbb ccc
+pub fn stacked() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa bbb ccc
+"""

--- a/integration/query-duplicates-stacked-claim.toml
+++ b/integration/query-duplicates-stacked-claim.toml
@@ -9,7 +9,8 @@ report_output = false
 # section, stacked above one function — both resolve to the function line.
 # The raised `test` cap is deliberate noise: it must not rescue the stack
 # (§2.1 is cap-independent), and no same-form cap is exceeded (one member per
-# form), so the only rule that can fire is the stacked-claim rule.
+# form). The target axis independently flags the same stack as a mixed
+# test+implementation target (§3.3) — both firings appear in the snapshot.
 [[file]]
 path = ".duvet/config.toml"
 contents = """

--- a/integration/query-duplicates-stacked-claim.toml
+++ b/integration/query-duplicates-stacked-claim.toml
@@ -11,6 +11,11 @@ report_output = false
 # (§2.1 is cap-independent), and no same-form cap is exceeded (one member per
 # form). The target axis independently flags the same stack as a mixed
 # test+implementation target (§3.3) — both firings appear in the snapshot.
+#= design/duplicates/spec.md#same-claim-same-target
+#= type=test
+#% Two annotations that share a claim and share a resolved target
+#% MUST fail the duplicates check, regardless of their claim forms
+#% and regardless of any configured cap.
 [[file]]
 path = ".duvet/config.toml"
 contents = """

--- a/integration/query-duplicates-subsumption.toml
+++ b/integration/query-duplicates-subsumption.toml
@@ -1,0 +1,50 @@
+source = { local = true }
+cmd = ["duvet query --check duplicates --verbose"]
+report_output = false
+
+# Pins spec §2.3: an annotation whose claim is fully covered by same-form
+# claims outside its own claim class FAILS regardless of any configured cap.
+#
+# T1 quotes a fragment ("aaa") of what T2 quotes in full ("aaa bbb ccc"), at
+# distinct targets, with `test = 2`. The raised cap admits equal copies only —
+# it must not rescue the fragment. This is the historical union-coverage
+# semantics (see query-duplicates-exact-pair) separated from the cap rule:
+# a raised cap never opens the subsumption door.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+
+[duplicates.claims]
+test = 2
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=test
+//# aaa
+pub fn fragment() {}
+
+//= spec.md#section-1
+//= type=test
+//# aaa bbb ccc
+pub fn full_claim() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa bbb ccc
+"""

--- a/integration/query-duplicates-subsumption.toml
+++ b/integration/query-duplicates-subsumption.toml
@@ -10,6 +10,12 @@ report_output = false
 # it must not rescue the fragment. This is the historical union-coverage
 # semantics (see query-duplicates-exact-pair) separated from the cap rule:
 # a raised cap never opens the subsumption door.
+#= design/duplicates/spec.md#subsumption
+#= type=test
+#% An annotation whose claim is fully covered
+#% ([§1.3](#claim-coverage)) by the claims of same-form annotations
+#% outside its own claim class MUST fail the duplicates check,
+#% regardless of any configured cap.
 [[file]]
 path = ".duvet/config.toml"
 contents = """

--- a/integration/query-duplicates-verdict-determinism.toml
+++ b/integration/query-duplicates-verdict-determinism.toml
@@ -1,0 +1,48 @@
+source = { local = true }
+cmd = ["duvet query --check duplicates", "duvet query --check duplicates --verbose"]
+report_output = false
+
+# Pins spec §4.1 / P-S0 verdict determinism on the verbosity axis: the SAME
+# tree as query-duplicates-exclusivity (an exception and an implementation
+# sharing one claim — FAILS under the default claim-form family), run once
+# at default verbosity and once with --verbose. The snapshot pins BOTH exit
+# codes and BOTH outputs: the verdict is identical (EXIT 1 twice); only the
+# display differs. Verbosity is display, never verdict.
+#
+# No test citation here: the #policy-source CLI sentence is cited once, on
+# query-duplicates-partial-overlap-verbose (the test cap is 1); this fixture
+# widens the evidence to the FAIL direction without re-claiming the quote.
+[[file]]
+path = ".duvet/config.toml"
+contents = """
+'$schema' = "https://awslabs.github.io/duvet/config/v0.4.0.json"
+
+[[source]]
+pattern = "src/**/*.rs"
+
+[[specification]]
+source = "spec.md"
+"""
+
+[[file]]
+path = "src/lib.rs"
+contents = """
+//= spec.md#section-1
+//= type=exception
+//# aaa bbb ccc
+pub fn waived_here() {}
+
+//= spec.md#section-1
+//# aaa bbb ccc
+pub fn implemented_here() {}
+"""
+
+[[file]]
+path = "spec.md"
+contents = """
+# Test Specification
+
+## Section 1
+
+aaa bbb ccc
+"""

--- a/integration/snapshots/query-coverage-exception-correlation_stderr.snap
+++ b/integration/snapshots/query-coverage-exception-correlation_stderr.snap
@@ -1,0 +1,62 @@
+---
+source: xtask/src/tests.rs
+expression: stderr
+---
+$ duvet query -c coverage -r cov.xml -f jacoco-xml
+EXIT: Some(1)
+    Starting duvet in query mode...
+  Extracting requirements
+    Scanning sources
+     Scanned 3 sources 
+     Parsing annotations
+      Parsed 3 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 1 sections 
+    Matching references
+     Matched 3 references 
+  
+Coverage: ✗ FAIL
+
+  Coverage reports checked: 1
+  Executed tests: 1
+  Executed implementations: 1
+  Successful correlations: 0
+  Failed correlations: 1
+  Tests with no implementation: 0
+
+  × Failed correlation
+   ╭─[src/impl_test.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=test
+ 3 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Executed test
+ 4 │     fn check_work() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Failed correlation
+   ╭─[src/impl.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=implementation
+ 3 │ ├─▶ //# aaa bbb
+   · ╰──── Executed implementation
+ 4 │     fn work() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Failed correlation
+   ╭─[src/waiver.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=exception
+ 3 │ ├─▶ //# bbb ccc
+   · ╰──── Not executed implementation
+ 4 │     fn not_done() {}
+   ╰────
+
+
+
+Overall: ✗ FAIL

--- a/integration/snapshots/query-duplicate-targets-bounds_stderr.snap
+++ b/integration/snapshots/query-duplicate-targets-bounds_stderr.snap
@@ -20,6 +20,14 @@ EXIT: Some(1)
 
 Duplicates: ✗ FAIL
 
+Effective policy ([duplicates] in .duvet/config.toml; semantics: design/duplicates/spec.md §4):
+  claims.test = 1 (default)
+  claims.implementation = 1 (default)
+  claims.types = no free form shares a claim (default)
+  targets.count = 2
+  targets.sections = 1
+  targets.types = any combination except test+implementation (default)
+
 Targets bearing more than one annotation (count descending):
   src/lib.rs:9 count=3 sections=2 forms=implementation:3
   ☞ Annotations resolving to src/lib.rs:9

--- a/integration/snapshots/query-duplicate-targets-bounds_stderr.snap
+++ b/integration/snapshots/query-duplicate-targets-bounds_stderr.snap
@@ -2,7 +2,7 @@
 source: xtask/src/tests.rs
 expression: stderr
 ---
-$ duvet query --check duplicate-targets --verbose
+$ duvet query --check duplicates --verbose
 EXIT: Some(1)
     Starting duvet in query mode...
   Extracting requirements
@@ -17,8 +17,8 @@ EXIT: Some(1)
       Mapped 2 sections 
     Matching references
      Matched 5 references 
-  
-Duplicate targets: ✗ FAIL
+
+Duplicates: ✗ FAIL
 
 Targets bearing more than one annotation (count descending):
   src/lib.rs:9 count=3 sections=2 forms=implementation:3
@@ -65,7 +65,7 @@ Advice:
     ╭─[src/lib.rs:11:5]
  10 │     
  11 │ ╭─▶ //= spec.md#section-1
- 12 │ ├─▶ //# aaa
+ 12 │ ├─▶ //# ddd
     · ╰──── Resolves here
  13 │     
     ╰────
@@ -76,7 +76,7 @@ Advice:
     ╭─[src/lib.rs:14:5]
  13 │     
  14 │ ╭─▶ //= spec.md#section-1
- 15 │ ├─▶ //# bbb
+ 15 │ ├─▶ //# eee
     · ╰──── Resolves here
  16 │     pub fn fine() {}
     ╰────
@@ -157,6 +157,62 @@ Advice:
    · ╰──── Fan-in
  9 │     pub fn dumped() {}
    ╰────
+
+  ☞ Unique implementation annotations
+
+Advice: 
+  ☞ Related context for:
+  │  Unique implementation annotations
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ ├─▶ //# aaa
+   · ╰──── Unique
+ 3 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Unique implementation annotations
+   ╭─[src/lib.rs:4:5]
+ 3 │     
+ 4 │ ╭─▶ //= spec.md#section-1
+ 5 │ ├─▶ //# bbb
+   · ╰──── Unique
+ 6 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Unique implementation annotations
+   ╭─[src/lib.rs:7:5]
+ 6 │     
+ 7 │ ╭─▶ //= spec.md#section-2
+ 8 │ ├─▶ //# ccc
+   · ╰──── Unique
+ 9 │     pub fn dumped() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Unique implementation annotations
+    ╭─[src/lib.rs:11:5]
+ 10 │     
+ 11 │ ╭─▶ //= spec.md#section-1
+ 12 │ ├─▶ //# ddd
+    · ╰──── Unique
+ 13 │     
+    ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Unique implementation annotations
+    ╭─[src/lib.rs:14:5]
+ 13 │     
+ 14 │ ╭─▶ //= spec.md#section-1
+ 15 │ ├─▶ //# eee
+    · ╰──── Unique
+ 16 │     pub fn fine() {}
+    ╰────
 
 
 Overall: ✗ FAIL

--- a/integration/snapshots/query-duplicate-targets-bounds_stderr.snap
+++ b/integration/snapshots/query-duplicate-targets-bounds_stderr.snap
@@ -1,0 +1,162 @@
+---
+source: xtask/src/tests.rs
+expression: stderr
+---
+$ duvet query --check duplicate-targets --verbose
+EXIT: Some(1)
+    Starting duvet in query mode...
+  Extracting requirements
+   Extracted requirements from 1 specifications 
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 5 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 2 sections 
+    Matching references
+     Matched 5 references 
+  
+Duplicate targets: ✗ FAIL
+
+Targets bearing more than one annotation (count descending):
+  src/lib.rs:9 count=3 sections=2 forms=implementation:3
+  ☞ Annotations resolving to src/lib.rs:9
+
+Advice: 
+  ☞ Related context for:
+  │  Annotations resolving to src/lib.rs:9
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ ├─▶ //# aaa
+   · ╰──── Resolves here
+ 3 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Annotations resolving to src/lib.rs:9
+   ╭─[src/lib.rs:4:5]
+ 3 │     
+ 4 │ ╭─▶ //= spec.md#section-1
+ 5 │ ├─▶ //# bbb
+   · ╰──── Resolves here
+ 6 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Annotations resolving to src/lib.rs:9
+   ╭─[src/lib.rs:7:5]
+ 6 │     
+ 7 │ ╭─▶ //= spec.md#section-2
+ 8 │ ├─▶ //# ccc
+   · ╰──── Resolves here
+ 9 │     pub fn dumped() {}
+   ╰────
+
+  src/lib.rs:16 count=2 sections=1 forms=implementation:2
+  ☞ Annotations resolving to src/lib.rs:16
+
+Advice: 
+  ☞ Related context for:
+  │  Annotations resolving to src/lib.rs:16
+    ╭─[src/lib.rs:11:5]
+ 10 │     
+ 11 │ ╭─▶ //= spec.md#section-1
+ 12 │ ├─▶ //# aaa
+    · ╰──── Resolves here
+ 13 │     
+    ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Annotations resolving to src/lib.rs:16
+    ╭─[src/lib.rs:14:5]
+ 13 │     
+ 14 │ ╭─▶ //= spec.md#section-1
+ 15 │ ├─▶ //# bbb
+    · ╰──── Resolves here
+ 16 │     pub fn fine() {}
+    ╰────
+
+
+  × Target src/lib.rs:9 bears 3 annotations, exceeding the configured count
+  │ bound
+
+Advice: 
+  ☞ Related context for:
+  │  Target src/lib.rs:9 bears 3 annotations, exceeding the configured count
+  │ bound
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ ├─▶ //# aaa
+   · ╰──── Fan-in
+ 3 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Target src/lib.rs:9 bears 3 annotations, exceeding the configured count
+  │ bound
+   ╭─[src/lib.rs:4:5]
+ 3 │     
+ 4 │ ╭─▶ //= spec.md#section-1
+ 5 │ ├─▶ //# bbb
+   · ╰──── Fan-in
+ 6 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Target src/lib.rs:9 bears 3 annotations, exceeding the configured count
+  │ bound
+   ╭─[src/lib.rs:7:5]
+ 6 │     
+ 7 │ ╭─▶ //= spec.md#section-2
+ 8 │ ├─▶ //# ccc
+   · ╰──── Fan-in
+ 9 │     pub fn dumped() {}
+   ╰────
+
+  × Target src/lib.rs:9 bears annotations from 2 distinct sections, exceeding
+  │ the configured sections bound
+
+Advice: 
+  ☞ Related context for:
+  │  Target src/lib.rs:9 bears annotations from 2 distinct sections, exceeding
+  │ the configured sections bound
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ ├─▶ //# aaa
+   · ╰──── Fan-in
+ 3 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Target src/lib.rs:9 bears annotations from 2 distinct sections, exceeding
+  │ the configured sections bound
+   ╭─[src/lib.rs:4:5]
+ 3 │     
+ 4 │ ╭─▶ //= spec.md#section-1
+ 5 │ ├─▶ //# bbb
+   · ╰──── Fan-in
+ 6 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Target src/lib.rs:9 bears annotations from 2 distinct sections, exceeding
+  │ the configured sections bound
+   ╭─[src/lib.rs:7:5]
+ 6 │     
+ 7 │ ╭─▶ //= spec.md#section-2
+ 8 │ ├─▶ //# ccc
+   · ╰──── Fan-in
+ 9 │     pub fn dumped() {}
+   ╰────
+
+
+Overall: ✗ FAIL

--- a/integration/snapshots/query-duplicate-targets-listing_stdout.snap
+++ b/integration/snapshots/query-duplicate-targets-listing_stdout.snap
@@ -19,6 +19,7 @@ $ duvet query --check duplicates
 Duplicates: ✓ PASS
 
 Targets bearing more than one annotation (count descending):
+  (opt-in bounds: [duplicates.targets] count / sections / types in .duvet/config.toml — design/duplicates/spec.md §3)
   src/lib.rs:9 count=3 sections=2 forms=implementation:3
   src/lib.rs:16 count=2 sections=1 forms=implementation:2
 

--- a/integration/snapshots/query-duplicate-targets-listing_stdout.snap
+++ b/integration/snapshots/query-duplicate-targets-listing_stdout.snap
@@ -2,7 +2,7 @@
 source: xtask/src/tests.rs
 expression: stdout
 ---
-$ duvet query --check duplicate-targets
+$ duvet query --check duplicates
     Starting duvet in query mode...
   Extracting requirements
     Scanning sources
@@ -15,8 +15,8 @@ $ duvet query --check duplicate-targets
       Mapped 2 sections 
     Matching references
      Matched 6 references 
-  
-Duplicate targets: ✓ PASS
+
+Duplicates: ✓ PASS
 
 Targets bearing more than one annotation (count descending):
   src/lib.rs:9 count=3 sections=2 forms=implementation:3

--- a/integration/snapshots/query-duplicate-targets-listing_stdout.snap
+++ b/integration/snapshots/query-duplicate-targets-listing_stdout.snap
@@ -1,0 +1,26 @@
+---
+source: xtask/src/tests.rs
+expression: stdout
+---
+$ duvet query --check duplicate-targets
+    Starting duvet in query mode...
+  Extracting requirements
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 6 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 2 sections 
+    Matching references
+     Matched 6 references 
+  
+Duplicate targets: ✓ PASS
+
+Targets bearing more than one annotation (count descending):
+  src/lib.rs:9 count=3 sections=2 forms=implementation:3
+  src/lib.rs:16 count=2 sections=1 forms=implementation:2
+
+
+Overall: ✓ PASS

--- a/integration/snapshots/query-duplicate-targets-mixed-form-allowed_stdout.snap
+++ b/integration/snapshots/query-duplicate-targets-mixed-form-allowed_stdout.snap
@@ -2,7 +2,7 @@
 source: xtask/src/tests.rs
 expression: stdout
 ---
-$ duvet query --check duplicate-targets
+$ duvet query --check duplicates
     Starting duvet in query mode...
   Extracting requirements
     Scanning sources
@@ -15,8 +15,8 @@ $ duvet query --check duplicate-targets
       Mapped 2 sections 
     Matching references
      Matched 2 references 
-  
-Duplicate targets: ✓ PASS
+
+Duplicates: ✓ PASS
 
 Targets bearing more than one annotation (count descending):
   src/lib.rs:7 count=2 sections=2 forms=test:1,implementation:1

--- a/integration/snapshots/query-duplicate-targets-mixed-form-allowed_stdout.snap
+++ b/integration/snapshots/query-duplicate-targets-mixed-form-allowed_stdout.snap
@@ -1,0 +1,25 @@
+---
+source: xtask/src/tests.rs
+expression: stdout
+---
+$ duvet query --check duplicate-targets
+    Starting duvet in query mode...
+  Extracting requirements
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 2 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 2 sections 
+    Matching references
+     Matched 2 references 
+  
+Duplicate targets: ✓ PASS
+
+Targets bearing more than one annotation (count descending):
+  src/lib.rs:7 count=2 sections=2 forms=test:1,implementation:1
+
+
+Overall: ✓ PASS

--- a/integration/snapshots/query-duplicate-targets-mixed-form_stderr.snap
+++ b/integration/snapshots/query-duplicate-targets-mixed-form_stderr.snap
@@ -2,7 +2,7 @@
 source: xtask/src/tests.rs
 expression: stderr
 ---
-$ duvet query --check duplicate-targets
+$ duvet query --check duplicates
 EXIT: Some(1)
     Starting duvet in query mode...
   Extracting requirements
@@ -16,8 +16,8 @@ EXIT: Some(1)
       Mapped 2 sections 
     Matching references
      Matched 2 references 
-  
-Duplicate targets: ✗ FAIL
+
+Duplicates: ✗ FAIL
 
 Targets bearing more than one annotation (count descending):
   src/lib.rs:7 count=2 sections=2 forms=test:1,implementation:1

--- a/integration/snapshots/query-duplicate-targets-mixed-form_stderr.snap
+++ b/integration/snapshots/query-duplicate-targets-mixed-form_stderr.snap
@@ -20,6 +20,7 @@ EXIT: Some(1)
 Duplicates: ✗ FAIL
 
 Targets bearing more than one annotation (count descending):
+  (opt-in bounds: [duplicates.targets] count / sections / types in .duvet/config.toml — design/duplicates/spec.md §3)
   src/lib.rs:7 count=2 sections=2 forms=test:1,implementation:1
 
   × Target src/lib.rs:7 mixes claim forms test+implementation — the

--- a/integration/snapshots/query-duplicate-targets-mixed-form_stderr.snap
+++ b/integration/snapshots/query-duplicate-targets-mixed-form_stderr.snap
@@ -1,0 +1,53 @@
+---
+source: xtask/src/tests.rs
+expression: stderr
+---
+$ duvet query --check duplicate-targets
+EXIT: Some(1)
+    Starting duvet in query mode...
+  Extracting requirements
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 2 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 2 sections 
+    Matching references
+     Matched 2 references 
+  
+Duplicate targets: ✗ FAIL
+
+Targets bearing more than one annotation (count descending):
+  src/lib.rs:7 count=2 sections=2 forms=test:1,implementation:1
+
+  × Target src/lib.rs:7 mixes claim forms test+implementation — the
+  │ combination is inside no allowed set
+
+Advice: 
+  ☞ Related context for:
+  │  Target src/lib.rs:7 mixes claim forms test+implementation — the
+  │ combination is inside no allowed set
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=test
+ 3 │ ├─▶ //# aaa
+   · ╰──── Mixed forms
+ 4 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Target src/lib.rs:7 mixes claim forms test+implementation — the
+  │ combination is inside no allowed set
+   ╭─[src/lib.rs:5:5]
+ 4 │     
+ 5 │ ╭─▶ //= spec.md#section-2
+ 6 │ ├─▶ //# bbb
+   · ╰──── Mixed forms
+ 7 │     pub fn both_roles() {}
+   ╰────
+
+
+Overall: ✗ FAIL

--- a/integration/snapshots/query-duplicates-caps_stderr.snap
+++ b/integration/snapshots/query-duplicates-caps_stderr.snap
@@ -1,0 +1,144 @@
+---
+source: xtask/src/tests.rs
+expression: stderr
+---
+$ duvet query --check duplicates --verbose
+EXIT: Some(1)
+    Starting duvet in query mode...
+  Extracting requirements
+   Extracted requirements from 1 specifications 
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 5 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 2 sections 
+    Matching references
+     Matched 5 references 
+
+Duplicates: ✗ FAIL
+
+  × Duplicate test annotations: 3 copies exceed the cap of 2
+    ╭─[src/lib.rs:11:5]
+ 10 │     
+ 11 │ ╭─▶ //= spec.md#section-2
+ 12 │ │   //= type=test
+ 13 │ ├─▶ //# ddd eee fff
+    · ╰──── Duplicate
+ 14 │     pub fn copy_one() {}
+    ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Duplicate test annotations: 3 copies exceed the cap of 2
+    ╭─[src/lib.rs:16:5]
+ 15 │     
+ 16 │ ╭─▶ //= spec.md#section-2
+ 17 │ │   //= type=test
+ 18 │ ├─▶ //# ddd eee fff
+    · ╰──── Duplicate
+ 19 │     pub fn copy_two() {}
+    ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Duplicate test annotations: 3 copies exceed the cap of 2
+    ╭─[src/lib.rs:21:5]
+ 20 │     
+ 21 │ ╭─▶ //= spec.md#section-2
+ 22 │ │   //= type=test
+ 23 │ ├─▶ //# ddd eee fff
+    · ╰──── Duplicate
+ 24 │     pub fn copy_three() {}
+    ╰────
+
+  ☞ Allowed duplicate set: 2 test annotations (cap 2)
+
+Advice: 
+  ☞ Related context for:
+  │  Allowed duplicate set: 2 test annotations (cap 2)
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=test
+ 3 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Allowed duplicate
+ 4 │     pub fn proof_evidence() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Allowed duplicate set: 2 test annotations (cap 2)
+   ╭─[src/lib.rs:6:5]
+ 5 │     
+ 6 │ ╭─▶ //= spec.md#section-1
+ 7 │ │   //= type=test
+ 8 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Allowed duplicate
+ 9 │     pub fn pbt_evidence() {}
+   ╰────
+
+  ☞ Unique test annotations
+
+Advice: 
+  ☞ Related context for:
+  │  Unique test annotations
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=test
+ 3 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Unique
+ 4 │     pub fn proof_evidence() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Unique test annotations
+   ╭─[src/lib.rs:6:5]
+ 5 │     
+ 6 │ ╭─▶ //= spec.md#section-1
+ 7 │ │   //= type=test
+ 8 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Unique
+ 9 │     pub fn pbt_evidence() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Unique test annotations
+    ╭─[src/lib.rs:11:5]
+ 10 │     
+ 11 │ ╭─▶ //= spec.md#section-2
+ 12 │ │   //= type=test
+ 13 │ ├─▶ //# ddd eee fff
+    · ╰──── Unique
+ 14 │     pub fn copy_one() {}
+    ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Unique test annotations
+    ╭─[src/lib.rs:16:5]
+ 15 │     
+ 16 │ ╭─▶ //= spec.md#section-2
+ 17 │ │   //= type=test
+ 18 │ ├─▶ //# ddd eee fff
+    · ╰──── Unique
+ 19 │     pub fn copy_two() {}
+    ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Unique test annotations
+    ╭─[src/lib.rs:21:5]
+ 20 │     
+ 21 │ ╭─▶ //= spec.md#section-2
+ 22 │ │   //= type=test
+ 23 │ ├─▶ //# ddd eee fff
+    · ╰──── Unique
+ 24 │     pub fn copy_three() {}
+    ╰────
+
+
+Overall: ✗ FAIL

--- a/integration/snapshots/query-duplicates-caps_stderr.snap
+++ b/integration/snapshots/query-duplicates-caps_stderr.snap
@@ -20,6 +20,14 @@ EXIT: Some(1)
 
 Duplicates: ✗ FAIL
 
+Effective policy ([duplicates] in .duvet/config.toml; semantics: design/duplicates/spec.md §4):
+  claims.test = 2
+  claims.implementation = 1 (default)
+  claims.types = no free form shares a claim (default)
+  targets.count = unlimited (default)
+  targets.sections = unlimited (default)
+  targets.types = any combination except test+implementation (default)
+
   × Duplicate test annotations: 3 copies exceed the cap of 2
     ╭─[src/lib.rs:11:5]
  10 │     

--- a/integration/snapshots/query-duplicates-empty-family_stderr.snap
+++ b/integration/snapshots/query-duplicates-empty-family_stderr.snap
@@ -19,25 +19,26 @@ EXIT: Some(1)
 
 Duplicates: ✗ FAIL
 
-  × Duplicate exception annotations: 2 copies exceed the cap of 1
+  × One claim shared by forms test+implementation — the combination is inside
+  │ no allowed set
    ╭─[src/lib.rs:1:5]
  1 │ ╭─▶ //= spec.md#section-1
- 2 │ │   //= type=exception
+ 2 │ │   //= type=test
  3 │ ├─▶ //# aaa bbb ccc
-   · ╰──── Duplicate
- 4 │     pub fn first_waiver() {}
+   · ╰──── Shared claim
+ 4 │     pub fn tested_there() {}
    ╰────
 
 Advice: 
   ☞ Related context for:
-  │  Duplicate exception annotations: 2 copies exceed the cap of 1
+  │  One claim shared by forms test+implementation — the combination is inside
+  │ no allowed set
    ╭─[src/lib.rs:6:5]
  5 │     
  6 │ ╭─▶ //= spec.md#section-1
- 7 │ │   //= type=exception
- 8 │ ├─▶ //# aaa bbb ccc
-   · ╰──── Duplicate
- 9 │     pub fn second_waiver() {}
+ 7 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Shared claim
+ 8 │     pub fn implemented_here() {}
    ╰────
 
 

--- a/integration/snapshots/query-duplicates-exact-pair_stderr.snap
+++ b/integration/snapshots/query-duplicates-exact-pair_stderr.snap
@@ -20,18 +20,7 @@ EXIT: Some(1)
 
 Duplicates: ✗ FAIL
 
-  × Duplicate test annotations
-   ╭─[src/lib.rs:1:5]
- 1 │ ╭─▶ //= spec.md#section-1
- 2 │ │   //= type=test
- 3 │ ├─▶ //# aaa
-   · ╰──── Duplicate
- 4 │     
-   ╰────
-
-Advice: 
-  ☞ Related context for:
-  │  Duplicate test annotations
+  × Duplicate test annotations: 2 copies exceed the cap of 1
    ╭─[src/lib.rs:5:5]
  4 │     
  5 │ ╭─▶ //= spec.md#section-1
@@ -43,7 +32,7 @@ Advice:
 
 Advice: 
   ☞ Related context for:
-  │  Duplicate test annotations
+  │  Duplicate test annotations: 2 copies exceed the cap of 1
     ╭─[src/lib.rs:9:5]
   8 │     
   9 │ ╭─▶ //= spec.md#section-1
@@ -52,68 +41,54 @@ Advice:
     · ╰──── Duplicate
     ╰────
 
-  × Duplicate test annotations
+  × Subsumed annotation: its claim is fully covered by other annotations
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=test
+ 3 │ ├─▶ //# aaa
+   · ╰──── Subsumed
+ 4 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Subsumed annotation: its claim is fully covered by other annotations
    ╭─[src/lib.rs:5:5]
  4 │     
  5 │ ╭─▶ //= spec.md#section-1
  6 │ │   //= type=test
  7 │ ├─▶ //# aaa bbb ccc
-   · ╰──── Duplicate
+   · ╰──── Covered by
  8 │     
    ╰────
 
 Advice: 
   ☞ Related context for:
-  │  Duplicate test annotations
-   ╭─[src/lib.rs:1:5]
- 1 │ ╭─▶ //= spec.md#section-1
- 2 │ │   //= type=test
- 3 │ ├─▶ //# aaa
-   · ╰──── Duplicate
- 4 │     
-   ╰────
-
-Advice: 
-  ☞ Related context for:
-  │  Duplicate test annotations
+  │  Subsumed annotation: its claim is fully covered by other annotations
     ╭─[src/lib.rs:9:5]
   8 │     
   9 │ ╭─▶ //= spec.md#section-1
  10 │ │   //= type=test
  11 │ ├─▶ //# aaa bbb ccc
-    · ╰──── Duplicate
+    · ╰──── Covered by
     ╰────
 
-  × Duplicate test annotations
-    ╭─[src/lib.rs:9:5]
-  8 │     
-  9 │ ╭─▶ //= spec.md#section-1
- 10 │ │   //= type=test
- 11 │ ├─▶ //# aaa bbb ccc
-    · ╰──── Duplicate
-    ╰────
-
-Advice: 
-  ☞ Related context for:
-  │  Duplicate test annotations
+  ☞ Annotations with some overlap
    ╭─[src/lib.rs:1:5]
  1 │ ╭─▶ //= spec.md#section-1
  2 │ │   //= type=test
  3 │ ├─▶ //# aaa
-   · ╰──── Duplicate
+   · ╰──── Some overlap
  4 │     
    ╰────
 
-Advice: 
-  ☞ Related context for:
-  │  Duplicate test annotations
-   ╭─[src/lib.rs:5:5]
+  ☞ Annotations with some overlap
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=test
+ 3 │ ├─▶ //# aaa
+   · ╰──── Some overlap
  4 │     
- 5 │ ╭─▶ //= spec.md#section-1
- 6 │ │   //= type=test
- 7 │ ├─▶ //# aaa bbb ccc
-   · ╰──── Duplicate
- 8 │     
    ╰────
 
 

--- a/integration/snapshots/query-duplicates-exact-pair_stderr.snap
+++ b/integration/snapshots/query-duplicates-exact-pair_stderr.snap
@@ -20,6 +20,14 @@ EXIT: Some(1)
 
 Duplicates: ✗ FAIL
 
+Effective policy ([duplicates] in .duvet/config.toml; semantics: design/duplicates/spec.md §4):
+  claims.test = 1 (default)
+  claims.implementation = 1 (default)
+  claims.types = no free form shares a claim (default)
+  targets.count = unlimited (default)
+  targets.sections = unlimited (default)
+  targets.types = any combination except test+implementation (default)
+
   × Duplicate test annotations: 2 copies exceed the cap of 1
    ╭─[src/lib.rs:5:5]
  4 │     

--- a/integration/snapshots/query-duplicates-exclusivity-family_stdout.snap
+++ b/integration/snapshots/query-duplicates-exclusivity-family_stdout.snap
@@ -1,0 +1,22 @@
+---
+source: xtask/src/tests.rs
+expression: stdout
+---
+$ duvet query --check duplicates
+    Starting duvet in query mode...
+  Extracting requirements
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 2 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 1 sections 
+    Matching references
+     Matched 2 references 
+
+Duplicates: ✓ PASS
+
+
+Overall: ✓ PASS

--- a/integration/snapshots/query-duplicates-exclusivity_stderr.snap
+++ b/integration/snapshots/query-duplicates-exclusivity_stderr.snap
@@ -19,7 +19,8 @@ EXIT: Some(1)
 
 Duplicates: ✗ FAIL
 
-  × Free claim forms are exclusive: implementation+exception share one claim
+  × One claim shared by forms implementation+exception — the combination is
+  │ inside no allowed set
    ╭─[src/lib.rs:1:5]
  1 │ ╭─▶ //= spec.md#section-1
  2 │ │   //= type=exception
@@ -30,7 +31,8 @@ Duplicates: ✗ FAIL
 
 Advice: 
   ☞ Related context for:
-  │  Free claim forms are exclusive: implementation+exception share one claim
+  │  One claim shared by forms implementation+exception — the combination is
+  │ inside no allowed set
    ╭─[src/lib.rs:6:5]
  5 │     
  6 │ ╭─▶ //= spec.md#section-1

--- a/integration/snapshots/query-duplicates-exclusivity_stderr.snap
+++ b/integration/snapshots/query-duplicates-exclusivity_stderr.snap
@@ -1,0 +1,43 @@
+---
+source: xtask/src/tests.rs
+expression: stderr
+---
+$ duvet query --check duplicates
+EXIT: Some(1)
+    Starting duvet in query mode...
+  Extracting requirements
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 2 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 1 sections 
+    Matching references
+     Matched 2 references 
+
+Duplicates: ✗ FAIL
+
+  × Free claim forms are exclusive: implementation+exception share one claim
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=exception
+ 3 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Shared claim
+ 4 │     pub fn waived_here() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Free claim forms are exclusive: implementation+exception share one claim
+   ╭─[src/lib.rs:6:5]
+ 5 │     
+ 6 │ ╭─▶ //= spec.md#section-1
+ 7 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Shared claim
+ 8 │     pub fn implemented_here() {}
+   ╰────
+
+
+Overall: ✗ FAIL

--- a/integration/snapshots/query-duplicates-free-form-unique_stderr.snap
+++ b/integration/snapshots/query-duplicates-free-form-unique_stderr.snap
@@ -1,0 +1,65 @@
+---
+source: xtask/src/tests.rs
+expression: stderr
+---
+$ duvet query --check duplicates
+EXIT: Some(1)
+    Starting duvet in query mode...
+  Extracting requirements
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 2 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 1 sections 
+    Matching references
+     Matched 2 references 
+
+Duplicates: ✗ FAIL
+
+  × Duplicate exception annotations: 2 copies exceed the cap of 1
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=exception
+ 3 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Duplicate
+ 4 │     pub fn first_waiver() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Duplicate exception annotations: 2 copies exceed the cap of 1
+   ╭─[src/lib.rs:6:5]
+ 5 │     
+ 6 │ ╭─▶ //= spec.md#section-1
+ 7 │ │   //= type=exception
+ 8 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Duplicate
+ 9 │     pub fn second_waiver() {}
+   ╰────
+
+  × Free claim forms are exclusive: exception share one claim
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=exception
+ 3 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Shared claim
+ 4 │     pub fn first_waiver() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Free claim forms are exclusive: exception share one claim
+   ╭─[src/lib.rs:6:5]
+ 5 │     
+ 6 │ ╭─▶ //= spec.md#section-1
+ 7 │ │   //= type=exception
+ 8 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Shared claim
+ 9 │     pub fn second_waiver() {}
+   ╰────
+
+
+Overall: ✗ FAIL

--- a/integration/snapshots/query-duplicates-implication-copies_stderr.snap
+++ b/integration/snapshots/query-duplicates-implication-copies_stderr.snap
@@ -19,25 +19,25 @@ EXIT: Some(1)
 
 Duplicates: ✗ FAIL
 
-  × Duplicate exception annotations: 2 copies exceed the cap of 1
+  × Duplicate implication annotations: 2 copies exceed the cap of 1
    ╭─[src/lib.rs:1:5]
  1 │ ╭─▶ //= spec.md#section-1
- 2 │ │   //= type=exception
+ 2 │ │   //= type=implication
  3 │ ├─▶ //# aaa bbb ccc
    · ╰──── Duplicate
- 4 │     pub fn first_waiver() {}
+ 4 │     pub fn holds_by_construction() {}
    ╰────
 
 Advice: 
   ☞ Related context for:
-  │  Duplicate exception annotations: 2 copies exceed the cap of 1
+  │  Duplicate implication annotations: 2 copies exceed the cap of 1
    ╭─[src/lib.rs:6:5]
  5 │     
  6 │ ╭─▶ //= spec.md#section-1
- 7 │ │   //= type=exception
+ 7 │ │   //= type=implication
  8 │ ├─▶ //# aaa bbb ccc
    · ╰──── Duplicate
- 9 │     pub fn second_waiver() {}
+ 9 │     pub fn also_holds_by_construction() {}
    ╰────
 
 

--- a/integration/snapshots/query-duplicates-partial-overlap-verbose_stdout.snap
+++ b/integration/snapshots/query-duplicates-partial-overlap-verbose_stdout.snap
@@ -1,0 +1,50 @@
+---
+source: xtask/src/tests.rs
+expression: stdout
+---
+$ duvet query --check duplicates --verbose
+    Starting duvet in query mode...
+  Extracting requirements
+   Extracted requirements from 1 specifications 
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 2 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 1 sections 
+    Matching references
+     Matched 2 references 
+
+Duplicates: ✓ PASS
+
+Effective policy ([duplicates] in .duvet/config.toml; semantics: design/duplicates/spec.md §4):
+  claims.test = 1 (default)
+  claims.implementation = 1 (default)
+  claims.types = no free form shares a claim (default)
+  targets.count = unlimited (default)
+  targets.sections = unlimited (default)
+  targets.types = any combination except test+implementation (default)
+
+  ☞ Annotations with some overlap
+   ╭─[src/lib.rs:6:5]
+ 5 │     
+ 6 │ ╭─▶ //= spec.md#section-1
+ 7 │ │   //= type=test
+ 8 │ ├─▶ //# bbb ccc
+   · ╰──── Some overlap
+ 9 │     pub fn back_half() {}
+   ╰────
+
+  ☞ Annotations with some overlap
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=test
+ 3 │ ├─▶ //# aaa bbb
+   · ╰──── Some overlap
+ 4 │     pub fn front_half() {}
+   ╰────
+
+
+Overall: ✓ PASS

--- a/integration/snapshots/query-duplicates-stacked-claim_stderr.snap
+++ b/integration/snapshots/query-duplicates-stacked-claim_stderr.snap
@@ -40,6 +40,7 @@ Advice:
    ╰────
 
 Targets bearing more than one annotation (count descending):
+  (opt-in bounds: [duplicates.targets] count / sections / types in .duvet/config.toml — design/duplicates/spec.md §3)
   src/lib.rs:7 count=2 sections=1 forms=test:1,implementation:1
 
   × Target src/lib.rs:7 mixes claim forms test+implementation — the

--- a/integration/snapshots/query-duplicates-stacked-claim_stderr.snap
+++ b/integration/snapshots/query-duplicates-stacked-claim_stderr.snap
@@ -39,5 +39,35 @@ Advice:
  7 │     pub fn stacked() {}
    ╰────
 
+Targets bearing more than one annotation (count descending):
+  src/lib.rs:7 count=2 sections=1 forms=test:1,implementation:1
+
+  × Target src/lib.rs:7 mixes claim forms test+implementation — the
+  │ combination is inside no allowed set
+
+Advice: 
+  ☞ Related context for:
+  │  Target src/lib.rs:7 mixes claim forms test+implementation — the
+  │ combination is inside no allowed set
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=test
+ 3 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Mixed forms
+ 4 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Target src/lib.rs:7 mixes claim forms test+implementation — the
+  │ combination is inside no allowed set
+   ╭─[src/lib.rs:5:5]
+ 4 │     
+ 5 │ ╭─▶ //= spec.md#section-1
+ 6 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Mixed forms
+ 7 │     pub fn stacked() {}
+   ╰────
+
 
 Overall: ✗ FAIL

--- a/integration/snapshots/query-duplicates-stacked-claim_stderr.snap
+++ b/integration/snapshots/query-duplicates-stacked-claim_stderr.snap
@@ -1,0 +1,43 @@
+---
+source: xtask/src/tests.rs
+expression: stderr
+---
+$ duvet query --check duplicates
+EXIT: Some(1)
+    Starting duvet in query mode...
+  Extracting requirements
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 2 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 1 sections 
+    Matching references
+     Matched 2 references 
+
+Duplicates: ✗ FAIL
+
+  × Same claim stacked on one target (src/lib.rs:7)
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=test
+ 3 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Stacked
+ 4 │     
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Same claim stacked on one target (src/lib.rs:7)
+   ╭─[src/lib.rs:5:5]
+ 4 │     
+ 5 │ ╭─▶ //= spec.md#section-1
+ 6 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Stacked
+ 7 │     pub fn stacked() {}
+   ╰────
+
+
+Overall: ✗ FAIL

--- a/integration/snapshots/query-duplicates-subsumption_stderr.snap
+++ b/integration/snapshots/query-duplicates-subsumption_stderr.snap
@@ -1,0 +1,54 @@
+---
+source: xtask/src/tests.rs
+expression: stderr
+---
+$ duvet query --check duplicates --verbose
+EXIT: Some(1)
+    Starting duvet in query mode...
+  Extracting requirements
+   Extracted requirements from 1 specifications 
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 2 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 1 sections 
+    Matching references
+     Matched 2 references 
+
+Duplicates: ✗ FAIL
+
+  × Subsumed annotation: its claim is fully covered by other annotations
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=test
+ 3 │ ├─▶ //# aaa
+   · ╰──── Subsumed
+ 4 │     pub fn fragment() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  Subsumed annotation: its claim is fully covered by other annotations
+   ╭─[src/lib.rs:6:5]
+ 5 │     
+ 6 │ ╭─▶ //= spec.md#section-1
+ 7 │ │   //= type=test
+ 8 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Covered by
+ 9 │     pub fn full_claim() {}
+   ╰────
+
+  ☞ Annotations with some overlap
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=test
+ 3 │ ├─▶ //# aaa
+   · ╰──── Some overlap
+ 4 │     pub fn fragment() {}
+   ╰────
+
+
+Overall: ✗ FAIL

--- a/integration/snapshots/query-duplicates-subsumption_stderr.snap
+++ b/integration/snapshots/query-duplicates-subsumption_stderr.snap
@@ -20,6 +20,14 @@ EXIT: Some(1)
 
 Duplicates: ✗ FAIL
 
+Effective policy ([duplicates] in .duvet/config.toml; semantics: design/duplicates/spec.md §4):
+  claims.test = 2
+  claims.implementation = 1 (default)
+  claims.types = no free form shares a claim (default)
+  targets.count = unlimited (default)
+  targets.sections = unlimited (default)
+  targets.types = any combination except test+implementation (default)
+
   × Subsumed annotation: its claim is fully covered by other annotations
    ╭─[src/lib.rs:1:5]
  1 │ ╭─▶ //= spec.md#section-1

--- a/integration/snapshots/query-duplicates-verdict-determinism_stderr.snap
+++ b/integration/snapshots/query-duplicates-verdict-determinism_stderr.snap
@@ -1,0 +1,122 @@
+---
+source: xtask/src/tests.rs
+expression: stderr
+---
+$ duvet query --check duplicates
+EXIT: Some(1)
+    Starting duvet in query mode...
+  Extracting requirements
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 2 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 1 sections 
+    Matching references
+     Matched 2 references 
+
+Duplicates: ✗ FAIL
+
+  × One claim shared by forms implementation+exception — the combination is
+  │ inside no allowed set
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=exception
+ 3 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Shared claim
+ 4 │     pub fn waived_here() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  One claim shared by forms implementation+exception — the combination is
+  │ inside no allowed set
+   ╭─[src/lib.rs:6:5]
+ 5 │     
+ 6 │ ╭─▶ //= spec.md#section-1
+ 7 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Shared claim
+ 8 │     pub fn implemented_here() {}
+   ╰────
+
+
+Overall: ✗ FAIL
+ 
+$ duvet query --check duplicates --verbose
+EXIT: Some(1)
+    Starting duvet in query mode...
+  Extracting requirements
+   Extracted requirements from 1 specifications 
+    Scanning sources
+     Scanned 1 sources 
+     Parsing annotations
+      Parsed 2 annotations 
+     Loading specifications
+      Loaded 1 specifications 
+     Mapping sections
+      Mapped 1 sections 
+    Matching references
+     Matched 2 references 
+
+Duplicates: ✗ FAIL
+
+Effective policy ([duplicates] in .duvet/config.toml; semantics: design/duplicates/spec.md §4):
+  claims.test = 1 (default)
+  claims.implementation = 1 (default)
+  claims.types = no free form shares a claim (default)
+  targets.count = unlimited (default)
+  targets.sections = unlimited (default)
+  targets.types = any combination except test+implementation (default)
+
+  × One claim shared by forms implementation+exception — the combination is
+  │ inside no allowed set
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=exception
+ 3 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Shared claim
+ 4 │     pub fn waived_here() {}
+   ╰────
+
+Advice: 
+  ☞ Related context for:
+  │  One claim shared by forms implementation+exception — the combination is
+  │ inside no allowed set
+   ╭─[src/lib.rs:6:5]
+ 5 │     
+ 6 │ ╭─▶ //= spec.md#section-1
+ 7 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Shared claim
+ 8 │     pub fn implemented_here() {}
+   ╰────
+
+  ☞ Unique implementation annotations
+
+Advice: 
+  ☞ Related context for:
+  │  Unique implementation annotations
+   ╭─[src/lib.rs:6:5]
+ 5 │     
+ 6 │ ╭─▶ //= spec.md#section-1
+ 7 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Unique
+ 8 │     pub fn implemented_here() {}
+   ╰────
+
+  ☞ Unique exception annotations
+
+Advice: 
+  ☞ Related context for:
+  │  Unique exception annotations
+   ╭─[src/lib.rs:1:5]
+ 1 │ ╭─▶ //= spec.md#section-1
+ 2 │ │   //= type=exception
+ 3 │ ├─▶ //# aaa bbb ccc
+   · ╰──── Unique
+ 4 │     pub fn waived_here() {}
+   ╰────
+
+
+Overall: ✗ FAIL

--- a/xtask/src/guide.rs
+++ b/xtask/src/guide.rs
@@ -47,7 +47,7 @@ impl Guide {
 
         let command_dir = dir.join("src/command");
         sh.create_dir(&command_dir)?;
-        for command in ["init", "extract", "report"] {
+        for command in ["init", "extract", "report", "query"] {
             let output = cmd!(sh, "duvet {command} --help")
                 .ignore_status()
                 .output()?;


### PR DESCRIPTION
Draft opened to run CI on the review-fix commits stacked on #256 (b50095a). The first commits shown are #256's own; the 8 new commits are:

- fix(init): mark targets.count = 1 as example, not default
- fix(duplicates): make the claim-form family the whole of §2.4
- docs(duplicates): split §2.5 into verdict, content, and presentation
- feat(duplicates): register the spec and complete its traceability chain
- perf(duplicates): precompute claim keys in the subsumption pool filter
- test(duplicates): pin P-S0 on the verbosity axis; note the fixture seams
- docs(duplicates): correct Decision 4's engine-fact to substitution
- test(coverage): pin the exception-in-correlation composition

Every commit was gated locally against the consolidated integration branch (unit suites, fixture suite in assert mode, `duvet query -c implementation,test,duplicates`, `duvet report --ci`). This draft exists to verify CI; intended to land via #256's flow.